### PR TITLE
Adding assignment operator for grid views; fixing gsl pdf constructors in unit tests

### DIFF
--- a/lib/pyre/grid/View.h
+++ b/lib/pyre/grid/View.h
@@ -27,6 +27,7 @@ public:
     // meta-methods
 public:
     inline View(grid_type & grid, const slice_type & slice);
+    inline const View & operator=(const View & view) const;
 
     // interface
 public:
@@ -42,7 +43,7 @@ public:
     // iteration support
     inline auto begin() const;
     inline auto end() const;
-
+    
     // implementation details
 private:
     grid_type & _grid;

--- a/lib/pyre/grid/View.icc
+++ b/lib/pyre/grid/View.icc
@@ -21,6 +21,16 @@ View(grid_type & grid, const slice_type & slice) :
 {}
 
 
+// Assign values from one view to another
+template <typename gridT>
+const pyre::grid::View<gridT> &
+pyre::grid::View<gridT>::
+operator=(const pyre::grid::View<gridT> & view) const {
+    std::copy(view.begin(), view.end(), begin());
+    return *this;
+}
+
+
 // interface
 template <typename gridT>
 const auto &
@@ -74,6 +84,5 @@ end() const {
     // easy enough...
     return iterator_type(_grid, _slice.end());
 }
-
 
 // end of file

--- a/tests/gsl/matrix_clone.py
+++ b/tests/gsl/matrix_clone.py
@@ -18,7 +18,7 @@ def test():
     # make a matrix
     m = gsl.matrix(shape=(100,50))
     # set it to random values
-    m.random(pdf=gsl.pdf.gaussian(sigma=2, rng=gsl.rng()))
+    m.random(pdf=gsl.pdf.gaussian(mean=0.0, sigma=2, rng=gsl.rng()))
     # clone it
     n = m.clone()
     # and check it

--- a/tests/gsl/matrix_random.py
+++ b/tests/gsl/matrix_random.py
@@ -18,7 +18,7 @@ def test():
     # make a matrix
     m = gsl.matrix(shape=(100,50))
     # set it to random values
-    m.random(pdf=gsl.pdf.gaussian(sigma=2, rng=gsl.rng()))
+    m.random(pdf=gsl.pdf.gaussian(mean=0.0, sigma=2, rng=gsl.rng()))
     # all done
     return m
 

--- a/tests/gsl/matrix_slices.py
+++ b/tests/gsl/matrix_slices.py
@@ -18,7 +18,7 @@ def test():
     # make a matrix
     m = gsl.matrix(shape=(100,50))
     # fill it with random values
-    m.random(pdf=gsl.pdf.gaussian(sigma=2, rng=gsl.rng()))
+    m.random(pdf=gsl.pdf.gaussian(mean=0.0, sigma=2, rng=gsl.rng()))
 
     # rows
     i = 3

--- a/tests/gsl/pdf_gaussian.py
+++ b/tests/gsl/pdf_gaussian.py
@@ -23,7 +23,7 @@ def test():
     # build a random number generator
     rng = gsl.rng()
     # build a gaussian distribution
-    gaussian = gsl.pdf.gaussian(sigma=σ, rng=rng)
+    gaussian = gsl.pdf.gaussian(mean=0.0, sigma=σ, rng=rng)
 
     # sample it
     sample = gaussian.sample()

--- a/tests/libpyre/grid/Make.mm
+++ b/tests/libpyre/grid/Make.mm
@@ -39,6 +39,7 @@ GRID_TESTS = \
     grid-mosaic \
     grid-scan \
     grid-transform \
+    grid-view-assignment \
 
 all: test clean
 

--- a/tests/libpyre/grid/grid-view-assignment.cc
+++ b/tests/libpyre/grid/grid-view-assignment.cc
@@ -1,0 +1,106 @@
+// -*- C++ -*-
+//
+// michael a.g. aïvázis, bryan riel
+// orthologue
+// (c) 1998-2018 all rights reserved
+//
+
+// configuration
+#include <portinfo>
+// externals
+#include <iostream>
+#include <pyre/journal.h>
+#include <pyre/memory.h>
+#include <pyre/grid.h>
+
+// main
+int main() {
+    // journal control
+    pyre::journal::debug_t debug("pyre.memory.direct");
+    // debug.activate();
+
+    // space
+    typedef double cell_t;
+    // layout
+    typedef std::array<int, 2> rep_t;
+    typedef pyre::grid::index_t<rep_t> index_t;
+    typedef pyre::grid::layout_t<index_t> layout_t;
+    // storage
+    typedef pyre::memory::view_t<cell_t> view_t;
+    // grid
+    typedef pyre::grid::grid_t<cell_t, layout_t, view_t> grid_t;
+
+    // make a channel
+    pyre::journal::debug_t channel("pyre.grid");
+
+    // make a common ordering
+    layout_t::packing_type packing {1u, 0u};
+    // make a shape for reference grid
+    layout_t::shape_type ref_shape {6, 4};
+    // make a layout
+    layout_t ref_layout {ref_shape, packing};
+
+    // allocate some memory for reference grid
+    cell_t * buffer = new cell_t[ref_layout.size()];
+    // initialize the memory with predictable values
+    for (layout_t::size_type i = 0; i < ref_layout.size(); ++i) {
+        buffer[i] = i;
+    }
+    // make reference grid
+    grid_t ref_grid {ref_layout, buffer};
+
+    // make a shape for a new grid
+    layout_t::shape_type new_shape {2, 4};
+    // make a layout
+    layout_t new_layout {new_shape, packing};
+
+    // allocate memory for new grid
+    cell_t * new_buffer = new cell_t[new_layout.size()];
+    // initialize the memory with zeros
+    std::fill(new_buffer, new_buffer + new_layout.size(), 0.0);
+    // make new grid
+    grid_t new_grid {new_layout, new_buffer};
+
+    // create slice indices for reference grid
+    const index_t ref_low = {2, 0};
+    const index_t ref_high = {4, 4};
+    const layout_t::slice_type ref_slice = {ref_low, ref_high, packing};
+
+    // create slice indices for new grid for setting values (slice whole grid for testing)
+    const index_t low = {0, 0};
+    const index_t high = {2, 4};
+    const layout_t::slice_type slice = {low, high, packing};
+
+    // assign values from reference view to new view
+    new_grid.view(slice) = ref_grid.view(ref_slice);
+
+    // loop over the grid
+    const double bias = ref_low[0] * ref_shape[1];
+    for (auto idx : new_grid.layout()) {
+        // get the value stored at this location
+        auto value = new_grid[idx];
+        // the expect values is the current offset as a double plus a bias from view
+        grid_t::cell_type expected = new_grid.layout().offset(idx) + bias;
+        // if they are not the same
+        if (value != expected) {
+            // make a channel
+            pyre::journal::error_t error("pyre.grid");
+            // show me
+            error
+                << pyre::journal::at(__HERE__)
+                << "new_grid[" << idx << "]: " << value << " != " << expected
+                << pyre::journal::endl;
+            // and bail
+            return 1;
+        }
+    }
+
+    // clean up
+    delete [] buffer;
+    delete [] new_buffer;
+    // all done
+    return 0;
+}
+
+
+// end of file


### PR DESCRIPTION
For pyre::grid::View, I've added an assignment operator from another pyre::grid::View instance:
```
inline const View & operator=(const View & view) const;
```
This addition allows for setting grid elements pointed to by a view to values from another view, e.g.
```
new_grid.view(slice) = ref_grid.view(ref_slice);
```
I've added a corresponding unit test called `pyre/tests/libpyre/grid/grid-view-assignment.cc` that performs a view assignment and checks the new values are as expected.

This PR also fixes some gsl unit tests that use a gsl.gaussian pdf where the `mean` argument was not being set in the constructor.

Note that I attempted to squash these commits into one commit for clarity, but it appears I didn't do that successfully.