### PR TITLE
rewrite numpy array hook and matrix statistics with c-api

### DIFF
--- a/extensions/gsl/Make.mm
+++ b/extensions/gsl/Make.mm
@@ -34,6 +34,7 @@ PROJ_SRCS = \
     rng.cc \
     vector.cc \
     stats.cc \
+    numpy.cc \
 
 # optional mpi support
 ifneq ($(strip $(MPI_DIR)), )

--- a/extensions/gsl/Make.mm
+++ b/extensions/gsl/Make.mm
@@ -13,6 +13,8 @@ PACKAGE =
 MODULE = gsl
 # get gsl support
 include gsl/default.def
+# get numpy support
+include numpy/default.def
 # build a python extension
 include std-pythonmodule.def
 # my headers live here

--- a/extensions/gsl/gsl.cc
+++ b/extensions/gsl/gsl.cc
@@ -26,6 +26,7 @@
 #include "rng.h" // random numbers
 #include "vector.h" // vectors
 #include "stats.h" // stats
+#include "numpy.h" // numpy hook
 
 // mpi support
 #if defined(WITH_MPI)
@@ -237,9 +238,16 @@ namespace gsl {
         { vector::variance__name__, vector::variance, METH_VARARGS, vector::variance__doc__ },
         { vector::sdev__name__, vector::sdev, METH_VARARGS, vector::sdev__doc__ },
 
+        // numpy
+        { vector::asnumpy__name__, vector::asnumpy, METH_VARARGS, vector::asnumpy__doc__ },
+        { matrix::asnumpy__name__, matrix::asnumpy, METH_VARARGS, matrix::asnumpy__doc__ },
+
         // more statistics
         { stats::correlation__name__, stats::correlation, METH_VARARGS, stats::correlation__doc__},
         { stats::covariance__name__, stats::covariance, METH_VARARGS, stats::covariance__doc__},
+        { stats::matrix_mean__name__, stats::matrix_mean, METH_VARARGS, stats::matrix_mean__doc__},
+        { stats::matrix_mean_sd__name__, stats::matrix_mean_sd, METH_VARARGS, stats::matrix_mean_sd__doc__},
+        { stats::matrix_mean_std__name__, stats::matrix_mean_std, METH_VARARGS, stats::matrix_mean_std__doc__},
 
         // mpi support
 #if defined(WITH_MPI)

--- a/extensions/gsl/gsl.cc
+++ b/extensions/gsl/gsl.cc
@@ -239,8 +239,8 @@ namespace gsl {
         { vector::sdev__name__, vector::sdev, METH_VARARGS, vector::sdev__doc__ },
 
         // numpy
-        { vector::asnumpy__name__, vector::asnumpy, METH_VARARGS, vector::asnumpy__doc__ },
-        { matrix::asnumpy__name__, matrix::asnumpy, METH_VARARGS, matrix::asnumpy__doc__ },
+        { vector::ndarray__name__, vector::ndarray, METH_VARARGS, vector::ndarray__doc__ },
+        { matrix::ndarray__name__, matrix::ndarray, METH_VARARGS, matrix::ndarray__doc__ },
 
         // more statistics
         { stats::correlation__name__, stats::correlation, METH_VARARGS, stats::correlation__doc__},

--- a/extensions/gsl/numpy.cc
+++ b/extensions/gsl/numpy.cc
@@ -1,0 +1,95 @@
+// -*- C++ -*-
+//
+// Lijun Zhu
+// Caltech
+// (c) 1998-2019 all rights reserved
+//
+
+
+#include <portinfo>
+#include <Python.h>
+#include <sstream>
+#include <cstdio>
+
+#include <gsl/gsl_vector.h>
+#include <gsl/gsl_matrix.h>
+
+//#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+#include "numpy.h"
+#include "capsules.h"
+
+
+const char * const gsl::vector::asnumpy__name__ = "vector_asnumpy";
+const char * const gsl::vector::asnumpy__doc__ = "return a numpy array reference of vector";
+
+PyObject *
+gsl::vector::asnumpy(PyObject *, PyObject * args) {
+    // the arguments
+    PyObject * self;
+    // unpack the argument tuple
+    int status = PyArg_ParseTuple(
+                                  args, "O!:vector_dataptr",
+                                  &PyCapsule_Type, &self);
+    // if something went wrong
+    if (!status) return 0;
+    // bail out if the capsule is not valid
+    if (!PyCapsule_IsValid(self, gsl::vector::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, "invalid vector capsule");
+        return 0;
+    }
+
+    // get the vector
+    gsl_vector * v = static_cast<gsl_vector *>(PyCapsule_GetPointer(self, gsl::vector::capsule_t));
+
+    // call numpy c api to create a ndarray reference
+    import_array(); // must be called for using numpy c-api
+    int nd = 1; // ndim
+    npy_intp dims[1] = {(npy_intp)v->size}; // shape
+    int typenum = NPY_DOUBLE;  // dtype
+    PyObject* ndarray = PyArray_SimpleNewFromData(nd, dims, typenum, (void *)v->data);
+    // return the ndarray 
+    return ndarray;
+}
+
+const char * const gsl::matrix::asnumpy__name__ = "matrix_asnumpy";
+const char * const gsl::matrix::asnumpy__doc__ = "return a numpy array reference of matrix";
+
+PyObject *
+gsl::matrix::asnumpy(PyObject *, PyObject * args) {
+    // the arguments
+    PyObject * self;
+    // unpack the argument tuple
+    int status = PyArg_ParseTuple(
+                                  args, "O!:vector_dataptr",
+                                  &PyCapsule_Type, &self);
+    // if something went wrong
+    if (!status) return 0;
+    // bail out if the capsule is not valid
+    if (!PyCapsule_IsValid(self, gsl::matrix::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, "invalid matrix capsule");
+        return 0;
+    }
+
+    // get the matrix
+    gsl_matrix * m = static_cast<gsl_matrix *>(PyCapsule_GetPointer(self, gsl::matrix::capsule_t));
+
+    // check whether memory is contiguous
+    if(m->tda != m->size2) {
+        PyErr_SetString(PyExc_TypeError, "non-contiguous matrix not supported");
+        return 0;
+    }
+
+    // call numpy c api to create a ndarray reference
+    import_array(); // must be called for using numpy c-api
+    int nd = 2; // ndim
+    npy_intp dims[2] = {(npy_intp)m->size1, (npy_intp)m->size2}; // shape
+    int typenum = NPY_DOUBLE;  // dtype
+    PyObject* ndarray = PyArray_SimpleNewFromData(nd, dims, typenum, (void *)m->data);
+    // return the ndarray 
+    return ndarray;
+}
+
+
+// end of file

--- a/extensions/gsl/numpy.cc
+++ b/extensions/gsl/numpy.cc
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //
-// Lijun Zhu
-// Caltech
+// Lijun Zhu (ljzhu@gps.caltech.edu)
+//
 // (c) 1998-2019 all rights reserved
 //
 
@@ -21,11 +21,11 @@
 #include "capsules.h"
 
 
-const char * const gsl::vector::asnumpy__name__ = "vector_asnumpy";
-const char * const gsl::vector::asnumpy__doc__ = "return a numpy array reference of vector";
+const char * const gsl::vector::ndarray__name__ = "vector_ndarray";
+const char * const gsl::vector::ndarray__doc__ = "return a numpy array reference of vector";
 
 PyObject *
-gsl::vector::asnumpy(PyObject *, PyObject * args) {
+gsl::vector::ndarray(PyObject *, PyObject * args) {
     // the arguments
     PyObject * self;
     // unpack the argument tuple
@@ -53,11 +53,11 @@ gsl::vector::asnumpy(PyObject *, PyObject * args) {
     return ndarray;
 }
 
-const char * const gsl::matrix::asnumpy__name__ = "matrix_asnumpy";
-const char * const gsl::matrix::asnumpy__doc__ = "return a numpy array reference of matrix";
+const char * const gsl::matrix::ndarray__name__ = "matrix_ndarray";
+const char * const gsl::matrix::ndarray__doc__ = "return a numpy array reference of matrix";
 
 PyObject *
-gsl::matrix::asnumpy(PyObject *, PyObject * args) {
+gsl::matrix::ndarray(PyObject *, PyObject * args) {
     // the arguments
     PyObject * self;
     // unpack the argument tuple

--- a/extensions/gsl/numpy.h
+++ b/extensions/gsl/numpy.h
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //
-// Lijun Zhu
-// Caltech
+// Lijun Zhu (ljzhu@gps.caltech.edu)
+//
 // (c) 1998-2019 all rights reserved
 //
 
@@ -13,16 +13,16 @@
 namespace gsl {
     namespace vector {
         // vector_asnumpy
-        extern const char * const asnumpy__name__;
-        extern const char * const asnumpy__doc__;
-        PyObject * asnumpy(PyObject *, PyObject *);
+        extern const char * const ndarray__name__;
+        extern const char * const ndarray__doc__;
+        PyObject * ndarray(PyObject *, PyObject *);
     } // of namespace vector
 
     namespace matrix {
-        // matrix_asnumpy
-        extern const char * const asnumpy__name__;
-        extern const char * const asnumpy__doc__;
-        PyObject * asnumpy(PyObject *, PyObject *);
+        // matrix_ndarray
+        extern const char * const ndarray__name__;
+        extern const char * const ndarray__doc__;
+        PyObject * ndarray(PyObject *, PyObject *);
     } // of namespace matrix
 } // of namespace gsl
 

--- a/extensions/gsl/numpy.h
+++ b/extensions/gsl/numpy.h
@@ -1,0 +1,31 @@
+// -*- C++ -*-
+//
+// Lijun Zhu
+// Caltech
+// (c) 1998-2019 all rights reserved
+//
+
+#if !defined(gsl_extension_numpy_h)
+#define gsl_extension_numpy_h
+
+
+// place everything in my private namespace
+namespace gsl {
+    namespace vector {
+        // vector_asnumpy
+        extern const char * const asnumpy__name__;
+        extern const char * const asnumpy__doc__;
+        PyObject * asnumpy(PyObject *, PyObject *);
+    } // of namespace vector
+
+    namespace matrix {
+        // matrix_asnumpy
+        extern const char * const asnumpy__name__;
+        extern const char * const asnumpy__doc__;
+        PyObject * asnumpy(PyObject *, PyObject *);
+    } // of namespace matrix
+} // of namespace gsl
+
+#endif //gsl_extension_numpy_h
+
+// end of file

--- a/extensions/gsl/stats.cc
+++ b/extensions/gsl/stats.cc
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //
-// michael a.g. aïvázis
-// orthologue
+// michael a.g. aïvázis @ orthologue
+// Lijun Zhu @ Caltech
 // (c) 1998-2019 all rights reserved
 //
 
@@ -9,7 +9,9 @@
 #include <portinfo>
 #include <Python.h>
 #include <gsl/gsl_vector.h>
+#include <gsl/gsl_matrix.h>
 #include <gsl/gsl_statistics.h>
+#include <cstdio>
 
 // local includes
 #include "stats.h"
@@ -52,7 +54,6 @@ gsl::stats::correlation(PyObject *, PyObject * args) {
     return PyFloat_FromDouble(result);
 }
 
-// s
 // stats::covariance
 const char * const gsl::stats::covariance__name__ = "stats_covariance";
 const char * const gsl::stats::covariance__doc__ = "the covariance of two datasets";
@@ -87,6 +88,279 @@ gsl::stats::covariance(PyObject *, PyObject * args) {
     result = gsl_stats_covariance(v1->data, 1, v2->data, 1, v1->size);
     // and return the result
     return PyFloat_FromDouble(result);
+}
+
+// stats::mean
+const char * const gsl::stats::matrix_mean__name__ = "stats_matrix_mean";
+const char * const gsl::stats::matrix_mean__doc__ = "the mean value(s) of a matrix";
+
+PyObject *
+gsl::stats::matrix_mean(PyObject *, PyObject * args)
+{
+    // the arguments
+    PyObject * matrixCapsule; // input matrix
+    PyObject *meanCapsule; // output mean vectors
+    int axis;
+    // unpack the argument tuple
+    int status = PyArg_ParseTuple(
+                                  args, "O!kO:stats_matrix_mean",
+                                  &PyCapsule_Type, &matrixCapsule, &axis, &meanCapsule);
+    // if something went wrong
+    if (!status) return 0;
+
+    // bail out if the capsule is not valid
+    // input matrix capsule
+    if (!PyCapsule_IsValid(matrixCapsule, gsl::matrix::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, " invalid matrix capsule");
+        return 0;
+    }
+    // output mean capsules
+    if (!PyCapsule_IsValid(meanCapsule, gsl::vector::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, " invalid vector capsule for mean");
+        return 0;
+    }
+
+    // get the matrix/vector from capsules
+    gsl_matrix * m = static_cast<gsl_matrix *>(PyCapsule_GetPointer(matrixCapsule, gsl::matrix::capsule_t));
+    gsl_vector * meanVec = static_cast<gsl_vector *>(PyCapsule_GetPointer(meanCapsule, gsl::vector::capsule_t));
+
+    // temporary results
+    double mean;
+    // pointer to data
+    double * datap = (double *)m->data;
+
+    size_t rows = m->size1;
+    size_t cols = m->size2;
+    size_t tda = m->tda;
+
+    // for different axis
+    switch(axis) {
+        case(0): // along row
+            for(size_t i=0; i<cols; ++i)
+            {
+                // compute mean for each column
+                mean =  gsl_stats_mean(datap, cols, rows); // (data[], stride, total elements)
+                // set the values to output vectors
+                gsl_vector_set(meanVec, i, mean);
+                // move pointer to next column
+                datap++;
+            }
+            break;
+        case(1): // along column
+            for(size_t i=0; i<rows; ++i)
+            {
+                // compute (mean, sd) for each row
+                mean =  gsl_stats_mean(datap, 1, cols);
+                // set the val
+                gsl_vector_set(meanVec, i, mean);
+                // move pointer to next row
+                datap += tda;
+            }
+            break;
+        default: // all elements
+            if (tda!=cols) {
+                PyErr_SetString(PyExc_TypeError, "Not working for non-contiguous matrix!");
+                return (PyObject *) NULL;
+            }
+            mean = gsl_stats_mean(datap, 1, cols*rows);
+            gsl_vector_set(meanVec, 0, mean);
+    }
+
+    // all done
+    // return None
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+
+// stats::matrix_mean_sd
+// (sample) standard deviation sd = sqrt{ \sum (x_i- mean)^2 /(N-1)}
+const char * const gsl::stats::matrix_mean_sd__name__ = "stats_matrix_mean_sd";
+const char * const gsl::stats::matrix_mean_sd__doc__ = "the mean and (sample) standard deviation of a matrix";
+
+PyObject *
+gsl::stats::matrix_mean_sd(PyObject *, PyObject * args)
+{
+    // the arguments
+    PyObject * matrixCapsule; // input matrix
+    PyObject *meanCapsule, *sdCapsule; // output (mean, sd) vectors
+    int axis;
+    // unpack the argument tuple
+    int status = PyArg_ParseTuple(
+                                  args, "O!kOO:stats_matrix_mean_sd",
+                                  &PyCapsule_Type, &matrixCapsule, &axis, &meanCapsule, &sdCapsule);
+    // if something went wrong
+    if (!status) return 0;
+
+    // bail out if the capsule is not valid
+    // input matrix capsule
+    if (!PyCapsule_IsValid(matrixCapsule, gsl::matrix::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, " invalid matrix capsule");
+        return 0;
+    }
+    // output mean, sd capsules
+    if (!PyCapsule_IsValid(meanCapsule, gsl::vector::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, " invalid vector capsule for mean");
+        return 0;
+    }
+    if (!PyCapsule_IsValid(sdCapsule, gsl::vector::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, "invalid vector capsule for standard deviation");
+        return 0;
+    }
+
+    // get the matrix/vector from capsules
+    gsl_matrix * m = static_cast<gsl_matrix *>(PyCapsule_GetPointer(matrixCapsule, gsl::matrix::capsule_t));
+    gsl_vector * meanVec = static_cast<gsl_vector *>(PyCapsule_GetPointer(meanCapsule, gsl::vector::capsule_t));
+    gsl_vector * sdVec = static_cast<gsl_vector *>(PyCapsule_GetPointer(sdCapsule, gsl::vector::capsule_t));
+
+    // temporary results
+    double mean, sd;
+    // pointer to data
+    double * datap = (double *)m->data;
+
+    size_t rows = m->size1;
+    size_t cols = m->size2;
+    size_t tda = m->tda;
+
+    // for different axis
+    switch(axis) {
+        case(0): // along row
+            for(size_t i=0; i<cols; ++i)
+            {
+                // compute mean for each column
+                mean =  gsl_stats_mean(datap, tda, rows); // (data[], stride, total elements)
+                // compute sd for each column
+                sd = gsl_stats_sd_m(datap, tda, rows, mean);
+                // set the values to output vectors
+                gsl_vector_set(meanVec, i, mean);
+                gsl_vector_set(sdVec, i, sd);
+                // move pointer to next column
+                datap++;
+            }
+            break;
+        case(1): // along column
+            for(size_t i=0; i<rows; ++i)
+            {
+                // compute (mean, sd) for each row
+                mean =  gsl_stats_mean(datap, 1, cols);
+                sd = gsl_stats_sd_m(datap, 1, cols, mean);
+                // set the val
+                gsl_vector_set(meanVec, i, mean);
+                gsl_vector_set(sdVec, i, sd);
+                // move pointer to next row
+                datap += tda;
+            }
+            break;
+        default: // all elements
+            if (tda!=cols) {
+                PyErr_SetString(PyExc_TypeError, "Not working for non-contiguous matrix!");
+                return (PyObject *) NULL;
+            }
+            mean = gsl_stats_mean(datap, 1, cols*rows);
+            sd = gsl_stats_sd_m(datap, 1, cols*rows, mean);
+            gsl_vector_set(meanVec, 0, mean);
+            gsl_vector_set(sdVec, 0, sd);
+    }
+
+    // all done
+    // return None
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+// stats::matrix_mean_std
+// (population) standard deviation sd = sqrt{ \sum (x_i- mean)^2 /N}
+const char * const gsl::stats::matrix_mean_std__name__ = "stats_matrix_mean_std";
+const char * const gsl::stats::matrix_mean_std__doc__ = "the mean and (population) standard deviation of a matrix";
+
+PyObject *
+gsl::stats::matrix_mean_std(PyObject *, PyObject * args)
+{
+    // the arguments
+    PyObject * matrixCapsule; // input matrix
+    PyObject *meanCapsule, *sdCapsule; // output (mean, sd) vectors
+    int axis;
+    // unpack the argument tuple
+    int status = PyArg_ParseTuple(
+                                  args, "O!kOO:stats_matrix_mean_std",
+                                  &PyCapsule_Type, &matrixCapsule, &axis, &meanCapsule, &sdCapsule);
+    // if something went wrong
+    if (!status) return 0;
+
+    // bail out if the capsule is not valid
+    // input matrix capsule
+    if (!PyCapsule_IsValid(matrixCapsule, gsl::matrix::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, " invalid matrix capsule");
+        return 0;
+    }
+    // output mean, sd capsules
+    if (!PyCapsule_IsValid(meanCapsule, gsl::vector::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, " invalid vector capsule for mean");
+        return 0;
+    }
+    if (!PyCapsule_IsValid(sdCapsule, gsl::vector::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, "invalid vector capsule for standard deviation");
+        return 0;
+    }
+
+    // get the matrix/vector from capsules
+    gsl_matrix * m = static_cast<gsl_matrix *>(PyCapsule_GetPointer(matrixCapsule, gsl::matrix::capsule_t));
+    gsl_vector * meanVec = static_cast<gsl_vector *>(PyCapsule_GetPointer(meanCapsule, gsl::vector::capsule_t));
+    gsl_vector * sdVec = static_cast<gsl_vector *>(PyCapsule_GetPointer(sdCapsule, gsl::vector::capsule_t));
+
+    // temporary results
+    double mean, sd;
+    // pointer to data
+    double * datap = (double *)m->data;
+
+    size_t rows = m->size1;
+    size_t cols = m->size2;
+    size_t tda = m->tda;
+
+    // for different axis
+    switch(axis) {
+        case(0): // along row
+            for(size_t i=0; i<cols; ++i)
+            {
+                // compute mean for each column
+                mean =  gsl_stats_mean(datap, tda, rows); // (data[], stride, total elements)
+                // compute sd for each column
+                sd = gsl_stats_sd_with_fixed_mean(datap, tda, rows, mean);
+                // set the values to output vectors
+                gsl_vector_set(meanVec, i, mean);
+                gsl_vector_set(sdVec, i, sd);
+                // move pointer to next column
+                datap++;
+            }
+            break;
+        case(1): // along column
+            for(size_t i=0; i<rows; ++i)
+            {
+                // compute (mean, sd) for each row
+                mean =  gsl_stats_mean(datap, 1, cols);
+                sd = gsl_stats_sd_with_fixed_mean(datap, 1, cols, mean);
+                // set the val
+                gsl_vector_set(meanVec, i, mean);
+                gsl_vector_set(sdVec, i, sd);
+                // move pointer to next row
+                datap += tda;
+            }
+            break;
+        default: // all elements
+            if (tda!=cols) {
+                PyErr_SetString(PyExc_TypeError, "Not working for non-contiguous matrix!");
+                return (PyObject *) NULL;
+            }
+            mean = gsl_stats_mean(datap, 1, cols*rows);
+            sd = gsl_stats_sd_with_fixed_mean(datap, 1, cols*rows, mean);
+            gsl_vector_set(meanVec, 0, mean);
+            gsl_vector_set(sdVec, 0, sd);
+    }
+
+    // all done
+    // return None
+    Py_INCREF(Py_None);
+    return Py_None;
 }
 
 // end of file

--- a/extensions/gsl/stats.cc
+++ b/extensions/gsl/stats.cc
@@ -139,7 +139,7 @@ gsl::stats::matrix_mean(PyObject *, PyObject * args)
             for(size_t i=0; i<cols; ++i)
             {
                 // compute mean for each column
-                mean =  gsl_stats_mean(datap, cols, rows); // (data[], stride, total elements)
+                mean =  gsl_stats_mean(datap, tda, rows); // (data[], stride, total elements)
                 // set the values to output vectors
                 gsl_vector_set(meanVec, i, mean);
                 // move pointer to next column

--- a/extensions/gsl/stats.h
+++ b/extensions/gsl/stats.h
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //
-// michael a.g. aïvázis
-// orthologue
+// michael a.g. aïvázis @ orthologue
+// Lijun Zhu @ Caltech
 // (c) 1998-2019 all rights reserved
 //
 
@@ -17,11 +17,27 @@ namespace gsl {
         extern const char * const correlation__name__;
         extern const char * const correlation__doc__;
         PyObject * correlation(PyObject *, PyObject *);
-        
+
         // gsl_stats_covariance
         extern const char * const covariance__name__;
         extern const char * const covariance__doc__;
         PyObject * covariance(PyObject *, PyObject *);
+
+        // gsl_stats_matrix_mean
+        extern const char * const matrix_mean__name__;
+        extern const char * const matrix_mean__doc__;
+        PyObject * matrix_mean(PyObject *, PyObject *);
+
+        // gsl_stats_matrix_mean_sd
+        extern const char * const matrix_mean_sd__name__;
+        extern const char * const matrix_mean_sd__doc__;
+        PyObject * matrix_mean_sd(PyObject *, PyObject *);
+
+        // gsl_stats_matrix_mean_std
+        extern const char * const matrix_mean_std__name__;
+        extern const char * const matrix_mean_std__doc__;
+        PyObject * matrix_mean_std(PyObject *, PyObject *);
+
 
     } // of namespace stats
 } // of namespace gsl

--- a/packages/gsl/Matrix.py
+++ b/packages/gsl/Matrix.py
@@ -464,6 +464,102 @@ class Matrix:
         # and return
         return λ, x
 
+    # statistics
+    def mean(self, axis=None, out=None):
+        """
+        Compute the mean values of a matrix
+        axis = None, 0, or 1, along which the mean are computed
+        """
+        # check axis
+        if axis is not None and axis !=0 and axis !=1:
+            raise IndexError("axis is out of range")
+        # check whether output vector is already allocated
+        if out is None:
+            # mean, sd over flattened matrix
+            if axis is None:
+                mean = self.vector(shape=1)
+            # mean, sd along row
+            elif axis == 0:
+                mean = self.vector(shape=self.columns)
+            # mean, sd along column
+            elif axis == 1:
+                mean = self.vector(shape=self.rows)
+        else:
+            # use pre-allocated vectors
+            mean = out
+            # assuming correct dimension, skip error checking
+
+        # call gsl function
+        gsl.stats_matrix_mean(self.data, axis, mean.data)
+
+        # return the result
+        return mean
+
+    def mean_sd(self, axis=None, out=None, sample=True):
+        """
+        Compute the mean values of matrix
+        axis: int or None
+             axis along which the means are computed. None for all elements
+        out: tuple of two vectors (mean, sd)
+             vector size is 1 (axis=None),  columns(axis=0), rows(axis=1)
+        sample: True or False
+             when True, the sample standard deviation is computed 1/(N-1)
+             when False, the population standard deviation is computed 1/N
+        """
+        # check axis
+        if axis is not None and axis !=0 and axis !=1:
+            raise IndexError("axis is out of range")
+
+        if out is None:
+            # mean, sd over flattened matrix
+            if axis is None:
+                mean = self.vector(shape=1)
+                sd = self.vector(shape=1)
+            # mean, sd along row
+            elif axis == 0:
+                mean = self.vector(shape=self.columns)
+                sd = self.vector(shape=self.columns)
+            # mean, sd along column
+            elif axis == 1:
+                mean = self.vector(shape=self.rows)
+                sd = self.vector(shape=self.rows)
+        else:
+            # use pre-allocated vectors
+            mean, sd = out
+            # assuming correct dimension, skip error checking
+
+        # call gsl function
+        if sample:
+            gsl.stats_matrix_mean_sd(self.data, axis, mean.data, sd.data)
+        else:
+            gsl.stats_matrix_mean_std(self.data, axis, mean.data, sd.data)
+
+        # return (mean, sd)
+        return mean, sd
+
+    def std(self, axis=None, sample=False):
+        """
+        Compute the standard deviation of a matrix
+        """
+        mean, sd = self.mean_sd(axis=axis, out=None, sample=sample)
+        return sd
+
+
+    # numpy reference
+    def asnumpy(self):
+        """
+        Return a numpy array reference
+        (only for matrix with contiguous data)
+        """
+        # call c-api
+        return gsl.matrix_asnumpy(self.data)
+
+    def tonumpy(self):
+        """
+        Copy matrix to a numpy array
+        """
+        import numpy
+        return numpy.asarray(self.tuple())
 
     # meta methods
     def __init__(self, shape, data=None, **kwds):

--- a/packages/gsl/Matrix.py
+++ b/packages/gsl/Matrix.py
@@ -545,21 +545,17 @@ class Matrix:
         return sd
 
 
-    # numpy reference
-    def asnumpy(self):
+    def ndarray(self, copy=False):
         """
-        Return a numpy array reference
-        (only for matrix with contiguous data)
+        Return a numpy array reference (w/ shared data) if {copy} is False, or a new copy if {copy} is {True}
         """
-        # call c-api
-        return gsl.matrix_asnumpy(self.data)
+        # call c-api extension to create a numpy array reference
+        array = gsl.matrix_ndarray(self.data)
+        # whether the data copy is required
+        if copy:
+            array = array.copy()
+        return array
 
-    def tonumpy(self):
-        """
-        Copy matrix to a numpy array
-        """
-        import numpy
-        return numpy.asarray(self.tuple())
 
     # meta methods
     def __init__(self, shape, data=None, **kwds):

--- a/packages/gsl/Vector.py
+++ b/packages/gsl/Vector.py
@@ -396,6 +396,20 @@ class Vector:
         return gsl.vector_sdev(self.data, float(mean) if mean is not None else None)
 
 
+    def asnumpy(self):
+        """
+        Return a numpy array reference
+        """
+        # call the c api
+        return gsl.vector_asnumpy(self.data)
+
+    def tonumpy(self):
+        """
+        Copy to a numpy array
+        """
+        import numpy
+        return numpy.asarray(self.tuple())
+
     # meta methods
     def __init__(self, shape, data=None, **kwds):
         # chain up

--- a/packages/gsl/Vector.py
+++ b/packages/gsl/Vector.py
@@ -396,19 +396,17 @@ class Vector:
         return gsl.vector_sdev(self.data, float(mean) if mean is not None else None)
 
 
-    def asnumpy(self):
+    def ndarray(self, copy=False):
         """
-        Return a numpy array reference
+        Return a numpy array reference (w/ shared data) if {copy} is False, or a new copy if {copy} is {True}
         """
-        # call the c api
-        return gsl.vector_asnumpy(self.data)
+        # call c-api extension to create a numpy array reference
+        array = gsl.vector_ndarray(self.data)
+        # whether the data copy is required
+        if copy:
+            array = array.copy()
+        return array
 
-    def tonumpy(self):
-        """
-        Copy to a numpy array
-        """
-        import numpy
-        return numpy.asarray(self.tuple())
 
     # meta methods
     def __init__(self, shape, data=None, **kwds):


### PR DESCRIPTION
1) rewrote numpy array reference (asnumpy) for gsl matrix/vector with numpy c api, 
defined in extensions/gsl/numpy.cc 
2) rewrote statistics (mean/sd) with numpy.mean style 
array.mean(axis) where axis = None (flattened), 0 (along row), 1 (along column). 
for standard deviation, an option sample=True(False) is added to differentiate 
sample standard deviation ( normalization factor N-1) and population sd (normalization factor N).  