### PR TITLE
Call explicit constructor for version_t

### DIFF
--- a/lib/pyre/version
+++ b/lib/pyre/version
@@ -11,7 +11,7 @@
 pyre::version_t
 pyre::version() {
     //
-    return { MAJOR, MINOR, "REVISION" };
+    return version_t { MAJOR, MINOR, "REVISION" };
 }
 
 // end of file


### PR DESCRIPTION
Ubuntu 16.04 is stuck on gcc 5 in xenial-updates, but I can still compile pyre with this patch.