### PR TITLE
Compile with C++14

### DIFF
--- a/.mm/cuda.def
+++ b/.mm/cuda.def
@@ -11,6 +11,6 @@ PROJECT = cuda
 include live.def
 
 # project settings
-PROJ_CXX_FLAGS += $(COMPILER_CXX_STD17)
+PROJ_CXX_FLAGS += $(COMPILER_CXX_STD14)
 
 # end of file

--- a/.mm/gsl.def
+++ b/.mm/gsl.def
@@ -11,6 +11,6 @@ PROJECT = gsl
 include live.def
 
 # project settings
-PROJ_CXX_FLAGS += $(COMPILER_CXX_STD17)
+PROJ_CXX_FLAGS += $(COMPILER_CXX_STD14)
 
 # end of file

--- a/.mm/journal.def
+++ b/.mm/journal.def
@@ -11,6 +11,6 @@ PROJECT = journal
 include live.def
 
 # project settings
-PROJ_CXX_FLAGS += $(COMPILER_CXX_STD17)
+PROJ_CXX_FLAGS += $(COMPILER_CXX_STD14)
 
 # end of file

--- a/.mm/mpi.def
+++ b/.mm/mpi.def
@@ -16,6 +16,6 @@ PROJECT_MINOR = 9
 include live.def
 
 # project settings
-PROJ_CXX_FLAGS += $(COMPILER_CXX_STD17)
+PROJ_CXX_FLAGS += $(COMPILER_CXX_STD14)
 
 # end of file

--- a/.mm/pyre.def
+++ b/.mm/pyre.def
@@ -16,7 +16,7 @@ PROJECT_MINOR = 9
 include live.def
 
 # project settings
-PROJ_CXX_FLAGS += $(COMPILER_CXX_STD17)
+PROJ_CXX_FLAGS += $(COMPILER_CXX_STD14)
 
 # external dependencies
 include clock/default.def

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -56,7 +56,7 @@ journal.lib.incdir := $(builder.dest.inc)pyre/journal/
 journal.lib.master := journal.h
 journal.lib.extern :=
 journal.lib.c++.defines += PYRE_CORE
-journal.lib.c++.flags += $($(compiler.c++).std.c++17)
+journal.lib.c++.flags += $($(compiler.c++).std.c++14)
 
 # the extension meta-data
 journal.ext.root := extensions/journal/
@@ -66,14 +66,14 @@ journal.ext.wraps := journal.lib
 journal.ext.capsule :=
 journal.ext.extern := journal.lib python
 journal.ext.lib.c++.defines += PYRE_CORE
-journal.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+journal.ext.lib.c++.flags += $($(compiler.c++).std.c++14)
 
 # the pyre library meta-data
 pyre.lib.root := lib/pyre/
 pyre.lib.stem := pyre
 pyre.lib.extern := journal.lib
 pyre.lib.prerequisites += journal.lib
-pyre.lib.c++.flags += $($(compiler.c++).std.c++17)
+pyre.lib.c++.flags += $($(compiler.c++).std.c++14)
 
 # the pyre extensions
 # host info
@@ -83,7 +83,7 @@ host.ext.pkg := pyre.pkg
 host.ext.wraps := pyre.lib
 host.ext.capsule :=
 host.ext.extern := pyre.lib journal.lib python
-host.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+host.ext.lib.c++.flags += $($(compiler.c++).std.c++14)
 host.ext.lib.prerequisites += journal.lib # pyre.lib is added automatically
 # postgres
 postgres.ext.root := extensions/postgres/
@@ -92,7 +92,7 @@ postgres.ext.pkg := pyre.pkg
 postgres.ext.wraps := pyre.lib
 postgres.ext.capsule :=
 postgres.ext.extern := pyre.lib journal.lib libpq python
-postgres.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+postgres.ext.lib.c++.flags += $($(compiler.c++).std.c++14)
 postgres.ext.lib.prerequisites += journal.lib # pyre.lib is added automatically
 # timers
 timers.ext.root := extensions/timers/
@@ -101,7 +101,7 @@ timers.ext.pkg := pyre.pkg
 timers.ext.wraps := pyre.lib
 timers.ext.capsule :=
 timers.ext.extern := pyre.lib journal.lib python
-timers.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+timers.ext.lib.c++.flags += $($(compiler.c++).std.c++14)
 timers.ext.lib.prerequisites += journal.lib # pyre.lib is added automatically
 
 # cuda
@@ -117,7 +117,7 @@ cuda.ext.pkg := cuda.pkg
 cuda.ext.wraps :=
 cuda.ext.capsule :=
 cuda.ext.extern := pyre.lib journal.lib cuda mpi python
-cuda.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+cuda.ext.lib.c++.flags += $($(compiler.c++).std.c++14)
 cuda.ext.lib.prerequisites += journal.lib pyre.lib # gsl.lib is added automatically
 
 # gsl
@@ -133,7 +133,7 @@ gsl.ext.pkg := gsl.pkg
 gsl.ext.wraps :=
 gsl.ext.capsule.destination := pyre/gsl/
 gsl.ext.extern := pyre.lib journal.lib mpi.lib gsl mpi python numpy
-gsl.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+gsl.ext.lib.c++.flags += $($(compiler.c++).std.c++14)
 gsl.ext.lib.prerequisites += journal.lib pyre.lib mpi.ext # gsl.lib is added automatically
 # the tests
 gsl.tst.pkg.stem := gsl
@@ -152,14 +152,14 @@ mpi.lib.extern := journal.lib mpi
 mpi.lib.master := mpi.h
 mpi.lib.incdir := $(builder.dest.inc)pyre/mpi/
 mpi.lib.prerequisites += journal.lib
-mpi.lib.c++.flags += $($(compiler.c++).std.c++17)
+mpi.lib.c++.flags += $($(compiler.c++).std.c++14)
 # the extension
 mpi.ext.root := extensions/mpi/
 mpi.ext.stem := mpi
 mpi.ext.pkg := mpi.pkg
 mpi.ext.wraps := mpi.lib
 mpi.ext.extern := pyre.lib journal.lib mpi python
-mpi.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+mpi.ext.lib.c++.flags += $($(compiler.c++).std.c++14)
 mpi.ext.lib.prerequisites += journal.lib pyre.lib # mpi.lib is added automatically
 # the tests
 mpi.tst.libmpi.stem := mpi


### PR DESCRIPTION
Since pyre doesn't seem to require C++17 features, this allows compilation using Clang 4.

Clang 4 is the version used by Anaconda's macOS compiler tools, so this will simplify package distribution for Macs via conda-forge.