### PR TITLE
Fixes for CMake version 3.12

### DIFF
--- a/.cmake/pyre_journal.cmake
+++ b/.cmake/pyre_journal.cmake
@@ -59,7 +59,7 @@ function(pyre_journalLib)
   # libpyre and libjournal
   install(
     TARGETS journal
-    LIBRARY
+    LIBRARY DESTINATION lib
     )
 
   # all done

--- a/.cmake/pyre_pyre.cmake
+++ b/.cmake/pyre_pyre.cmake
@@ -90,7 +90,7 @@ function(pyre_pyreLib)
   # libpyre and libjournal
   install(
     TARGETS pyre
-    LIBRARY
+    LIBRARY DESTINATION lib
     )
 
   # all done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 
 # cmake setup
-cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 # policies
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)


### PR DESCRIPTION
* CMake `install(TARGETS ...)` requires a `DESTINATION` until CMake 3.14.

* FindPython3 was not added until CMake 3.12.