### PR TITLE
Set module path relative to current directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif(POLICY CMP0076)
 option(WITH_CUDA "enable support for CUDA" OFF)
 
 # adjust the include path
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/.cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/.cmake)
 # get support
 include(pyre_init)
 include(pyre_journal)


### PR DESCRIPTION
If pyre's CMakeLists.txt is used via add_subdirectory, pyre's .cmake modules
folder won't be in the root source directory, and should be accessed relative
to the current list file being processed.