### PR TITLE
cmake: add WITH_MPI macro to gsl module when MPI_FOUND

### DIFF
--- a/.cmake/pyre_gsl.cmake
+++ b/.cmake/pyre_gsl.cmake
@@ -64,6 +64,8 @@ function(pyre_gslModule)
       target_include_directories(gslmodule PRIVATE ${MPI_CXX_INCLUDE_PATH})
       # and the mpi libraries
       target_link_libraries(gslmodule PRIVATE ${MPI_CXX_LIBRARIES})
+      # add the preprocessor macro
+      add_compile_definitions(WITH_MPI)
     endif()
 
     # install the extension

--- a/.cmake/pyre_gsl.cmake
+++ b/.cmake/pyre_gsl.cmake
@@ -65,7 +65,7 @@ function(pyre_gslModule)
       # and the mpi libraries
       target_link_libraries(gslmodule PRIVATE ${MPI_CXX_LIBRARIES})
       # add the preprocessor macro
-      add_compile_definitions(WITH_MPI)
+      target_compile_definitions(gslmodule PRIVATE WITH_MPI)
     endif()
 
     # install the extension


### PR DESCRIPTION
Add WITH_MPI to compiler options for extension gsl.cc. 