### PR TITLE
cmake: add WITH_MPI macro to gsl module with target_compile_definitions

### DIFF
--- a/.cmake/pyre_gsl.cmake
+++ b/.cmake/pyre_gsl.cmake
@@ -64,6 +64,8 @@ function(pyre_gslModule)
       target_include_directories(gslmodule PRIVATE ${MPI_CXX_INCLUDE_PATH})
       # and the mpi libraries
       target_link_libraries(gslmodule PRIVATE ${MPI_CXX_LIBRARIES})
+      # add the preprocessor macro
+      target_compile_definitions(gslmodule PRIVATE WITH_MPI)
     endif()
 
     # install the extension


### PR DESCRIPTION
MPI-related methods in gsl.cc require WITH_MPI macro to be compiled. 
Upon Ryan's suggestion, use target_compile_definitions instead. 