### PR TITLE
Get home dir via expanduser

### DIFF
--- a/packages/pyre/primitives/Path.py
+++ b/packages/pyre/primitives/Path.py
@@ -343,7 +343,7 @@ class Path(tuple):
         # if we don't have a user
         if not user:
             # assume the current user
-            dir = pwd.getpwuid(os.getuid()).pw_dir
+            dir = os.path.expanduser("~")
         # otherwise
         else:
             # attempt to


### PR DESCRIPTION
I'm getting a weird error when I try to import pyre in an unprivileged linux user namespace.
```
KeyError: 'getpwuid(): uid not found: 63828'
```
https://github.com/NixOS/nix/issues/554#issuecomment-109366569 seems related. Using `expanduser` instead fixes my problem, if that's an acceptable solution.