### PR TITLE
Add cuda device utils

### DIFF
--- a/lib/pyre/cuda.h
+++ b/lib/pyre/cuda.h
@@ -1,0 +1,14 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+
+// code guard
+#if !defined(pyre_cuda_h)
+#define pyre_cuda_h
+
+// support
+#include "cuda/public.h"
+
+#endif
+
+// end of file

--- a/lib/pyre/cuda/ComputeCapability.cc
+++ b/lib/pyre/cuda/ComputeCapability.cc
@@ -1,0 +1,21 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+
+// my parts
+#include "ComputeCapability.h"
+
+pyre::cuda::ComputeCapability::
+operator std::string() const
+{
+    return std::to_string(major) + "." + std::to_string(minor);
+}
+
+std::ostream &
+pyre::cuda::
+operator<<(std::ostream & os, pyre::cuda::ComputeCapability compute)
+{
+    return os << std::string(compute);
+}
+
+// end of file

--- a/lib/pyre/cuda/ComputeCapability.h
+++ b/lib/pyre/cuda/ComputeCapability.h
@@ -1,0 +1,69 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+
+// code guard
+#if !defined(pyre_cuda_ComputeCapability_h)
+#define pyre_cuda_ComputeCapability_h
+
+#include <iostream>
+#include <string>
+
+// CUDA device compute capability
+//
+// ComputeCapability identifies a CUDA device's architecture generation and
+// feature compatibility.
+struct pyre::cuda::ComputeCapability {
+    // Construct a new ComputeCapability object.
+    constexpr ComputeCapabiltiy(int major, int minor) noexcept;
+
+    explicit operator std::string() const;
+
+    int major; // Major compute version
+    int minor; // Minor compute version
+};
+
+// Serialize ComputeCapability object to stream
+std::ostream &
+pyre::cuda::
+operator<<(std::ostream &, pyre::cuda::ComputeCapability);
+
+// Compare two ComputeCapability objects.
+constexpr bool
+pyre::cuda::
+operator==(pyre::cuda::ComputeCapability,
+           pyre::cuda::ComputeCapability) noexcept;
+
+// Compare two ComputeCapability objects.
+constexpr bool
+pyre::cuda::
+operator!=(pyre::cuda::ComputeCapability,
+           pyre::cuda::ComputeCapability) noexcept;
+
+// Compare two ComputeCapability objects.
+constexpr bool
+pyre::cuda::
+operator<(pyre::cuda::ComputeCapability,
+          pyre::cuda::ComputeCapability) noexcept;
+
+// Compare two ComputeCapability objects.
+constexpr bool
+pyre::cuda::
+operator>(pyre::cuda::ComputeCapability,
+          pyre::cuda::ComputeCapability) noexcept;
+
+// Compare two ComputeCapability objects.
+constexpr bool
+pyre::cuda::
+operator<=(pyre::cuda::ComputeCapability,
+           pyre::cuda::ComputeCapability) noexcept;
+
+// Compare two ComputeCapability objects.
+constexpr bool
+pyre::cuda::
+operator>=(pyre::cuda::ComputeCapability,
+           pyre::cuda::ComputeCapability) noexcept;
+
+#endif
+
+// end of file

--- a/lib/pyre/cuda/ComputeCapability.icc
+++ b/lib/pyre/cuda/ComputeCapability.icc
@@ -1,0 +1,67 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+
+// code guard
+#if !defined(pyre_cuda_ComputeCapability_icc)
+#error This header file contains implementation details of class pyre::cuda::ComputeCapability
+#endif
+
+constexpr
+pyre::cuda::ComputeCapability::
+ComputeCapability(int major, int minor) noexcept :
+    major {major},
+    minor {minor}
+{}
+
+constexpr bool
+pyre::cuda::
+operator==(pyre::cuda::ComputeCapability lhs,
+           pyre::cuda::ComputeCapability rhs) noexcept
+{
+    return lhs.major == rhs.major and lhs.minor == rhs.minor;
+}
+
+constexpr bool
+pyre::cuda::
+operator!=(pyre::cuda::ComputeCapability lhs,
+           pyre::cuda::ComputeCapability rhs) noexcept
+{
+    return not(lhs == rhs);
+}
+
+constexpr bool
+pyre::cuda::
+operator<(pyre::cuda::ComputeCapability lhs,
+          pyre::cuda::ComputeCapability rhs) noexcept
+{
+    return lhs.major < rhs.major or
+           (lhs.major == rhs.major and lhs.minor < rhs.minor);
+}
+
+constexpr bool
+pyre::cuda::
+operator>(pyre::cuda::ComputeCapability lhs,
+          pyre::cuda::ComputeCapability rhs) noexcept
+{
+    return lhs.major > rhs.major or
+           (lhs.major == rhs.major and lhs.minor > rhs.minor);
+}
+
+constexpr bool
+pyre::cuda::
+operator<=(pyre::cuda::ComputeCapability lhs,
+           pyre::cuda::ComputeCapability rhs) noexcept
+{
+    return not(lhs > rhs);
+}
+
+constexpr bool
+pyre::cuda::
+operator>=(pyre::cuda::ComputeCapability lhs,
+           pyre::cuda::ComputeCapability rhs) noexcept
+{
+    return not(lhs < rhs);
+}
+
+// end of file

--- a/lib/pyre/cuda/Device.cu
+++ b/lib/pyre/cuda/Device.cu
@@ -1,0 +1,129 @@
+// -*- CUDA -*-
+// -*- coding: utf-8 -*-
+//
+
+// my parts
+#include "Device.h"
+// local support
+#include "ComputeCapability.h"
+
+#include <pyre/journal.h>
+
+pyre::cuda::Device::
+Device(int id) :
+    _id {id}
+{
+    const int count = getDeviceCount();
+    if (id < 0 or id >= count) {
+        // make an error channel
+        pyre::journal::error_t error("cuda");
+        // show me
+        error
+            << pyre::journal::at(__HERE__)
+            << "invalid cuda device index " << id
+            << pyre::journal::endl;
+
+        // XXX throw an exception?
+    }
+}
+
+static cudaDeviceProp
+pyre::cuda::getDeviceProperties(int id)
+{
+    cudaDeviceProp props;
+    const cudaError_t status = cudaGetDeviceProperties(&props, id);
+    // if anything went wrong
+    if (status != cudaSuccess) {
+        // make an error channel
+        pyre::journal::error_t error("cuda");
+        // show me
+        error
+            << pyre::journal::at(__HERE__)
+            << "while querying properties of device " << id << ": "
+            << cudaGetErrorName(status) << " (" << status << ")"
+            << pyre::journal::endl;
+    }
+    return props;
+}
+
+std::string
+pyre::cuda::Device::
+name() const
+{
+    const auto props = pyre::cuda::getDeviceProperties(id());
+    return props.name;
+}
+
+size_t
+pyre::cuda::Device::
+totalGlobalMem() const
+{
+    const auto props = pyre::cuda::getDeviceProperties(id());
+    return props.totalGlobalMem;
+}
+
+pyre::cuda::ComputeCapability
+pyre::cuda::Device::
+computeCapability() const
+{
+    const auto props = pyre::cuda::getDeviceProperties(id());
+    return {props.major, props.minor};
+}
+
+int
+pyre::cuda::getDeviceCount()
+{
+    int count = -1;
+    const cudaError_t status = cudaGetDeviceCount(&count);
+    // if anything went wrong
+    if (status != cudaSuccess) {
+        // make an error channel
+        pyre::journal::error_t error("cuda");
+        // show me
+        error
+            << pyre::journal::at(__HERE__)
+            << "failed to get cuda device count: "
+            << cudaGetErrorName(status) << " (" << status << ")"
+            << pyre::journal::endl;
+    }
+    return count;
+}
+
+pyre::cuda::Device
+pyre::cuda::getDevice()
+{
+    int d = -1;
+    const cudaError_t status = cudaGetDevice(&d);
+    // if anything went wrong
+    if (status != cudaSuccess) {
+        // make an error channel
+        pyre::journal::error_t error("cuda");
+        // show me
+        error
+            << pyre::journal::at(__HERE__)
+            << "failed to get current cuda device: "
+            << cudaGetErrorName(status) << " (" << status << ")"
+            << pyre::journal::endl;
+    }
+    return d;
+}
+
+void
+pyre::cuda::
+setDevice(pyre::cuda::Device d)
+{
+    const cudaError_t status = cudaSetDevice(d.id());
+    // if anything went wrong
+    if (status != cudaSuccess) {
+        // make an error channel
+        pyre::journal::error_t error("cuda");
+        // show me
+        error
+            << pyre::journal::at(__HERE__)
+            << "failed to set cuda device: "
+            << cudaGetErrorName(status) << " (" << status << ")"
+            << pyre::journal::endl;
+    }
+}
+
+// end of file

--- a/lib/pyre/cuda/Device.h
+++ b/lib/pyre/cuda/Device.h
@@ -1,0 +1,59 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+
+// code guard
+#if !defined(pyre_cuda_Device_h)
+#define pyre_cuda_Device_h
+
+#include <string>
+
+// A CUDA-enabled device
+class pyre::cuda::Device {
+public:
+    // Construct a new Device object.
+    //
+    // Does not change the currently active CUDA device.
+    Device(int id);
+
+    // Return the (0-based) device index.
+    inline int id() const noexcept;
+
+    // Return a string identifying the device.
+    std::string name() const;
+
+    // Get the total global memory capacity in bytes.
+    size_t totalGlobalMem() const;
+
+    // Get the compute capability.
+    pyre::cuda::ComputeCapability computeCapability() const;
+
+private:
+    int _id;
+};
+
+// Compare two Device objects.
+inline bool
+pyre::cuda::
+operator==(pyre::cuda::Device, pyre::cuda::Device) noexcept;
+
+// Compare two Device objects.
+inline bool
+pyre::cuda::
+operator!=(pyre::cuda::Device, pyre::cuda::Device) noexcept;
+
+// Return the number of available CUDA devices.
+int
+pyre::cuda::getDeviceCount();
+
+// Get the current CUDA device for the active host thread.
+pyre::cuda::Device
+pyre::cuda::getDevice();
+
+// Set the CUDA device for the active host thread.
+void
+pyre::cuda::setDevice(pyre::cuda::Device);
+
+#endif
+
+// end of file

--- a/lib/pyre/cuda/Device.icc
+++ b/lib/pyre/cuda/Device.icc
@@ -1,0 +1,31 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+
+// code guard
+#if !defined(pyre_cuda_Device_icc)
+#error This header file contains implementation details of class pyre::cuda::Device
+#endif
+
+int
+pyre::cuda::Device::
+id() const noexcept
+{
+    return _id;
+}
+
+bool
+pyre::cuda::
+operator==(pyre::cuda::Device lhs, pyre::cuda::Device rhs) noexcept
+{
+    return lhs.id() == rhs.id();
+}
+
+bool
+pyre::cuda::
+operator!=(pyre::cuda::Device lhs, pyre::cuda::Device rhs) noexcept
+{
+    return not(lhs == rhs);
+}
+
+// end of file

--- a/lib/pyre/cuda/forward.h
+++ b/lib/pyre/cuda/forward.h
@@ -1,0 +1,20 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+
+// code guard
+#if !defined(pyre_cuda_forward_h)
+#define pyre_cuda_forward_h
+
+// forward declarations
+namespace pyre {
+    namespace cuda {
+        struct ComputeCapability;
+
+        class Device;
+    }
+}
+
+#endif
+
+// end of file

--- a/lib/pyre/cuda/public.h
+++ b/lib/pyre/cuda/public.h
@@ -1,0 +1,27 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+
+// code guard
+#if !defined(pyre_cuda_public_h)
+#define pyre_cuda_public_h
+
+// forward declaration
+#include "forward.h"
+
+// the object model
+#include "ComputeCapability.h"
+#include "Device.h"
+
+// the implementations
+#define pyre_cuda_ComputeCapability_icc
+#include "ComputeCapability.icc"
+#undef pyre_cuda_ComputeCapability_icc
+
+#define pyre_cuda_Device_icc
+#include "Device.icc"
+#undef pyre_cuda_Device_icc
+
+#endif
+
+// end of file


### PR DESCRIPTION
This PR adds support for getting/setting the current cuda device as well as querying certain device properties. 

I kind of struggled a bit to adapt to the existing code style - let me know if there's anything I should go back and reformat.

Apart from that, I'm still trying to understand the build system so this is still very much a work-in-progress. I'll work on adding unit tests and bindings as well, but I figured I'd put this draft up as a baseline to get feedback and discuss the overall design.

The existing "cuda" package seems to be installed as a completely separate package rather than as a submodule of the "pyre" package. I'm not a fan of this approach - I think each module should be placed under a single top-level "pyre" package. This would reduce crowding the PYTHONPATH with lots of globals, would make clear the association between the modules, and would avoid monopolizing generic package names like "cuda" and "journal". 

Therefore, I've added my contributions under a new source directory, `lib/pyre/cuda` and used the namespace `pyre::cuda`. Let me know your thoughts on this. 