### PR TITLE
Add clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+Language: Cpp
+Standard: c++17
+
+AccessModifierOffset: -4
+AllowAllConstructorInitializersOnNextLine: false
+AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakTemplateDeclarations: Yes
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+CompactNamespaces: false
+Cpp11BracedListStyle: false
+IndentWidth: 4
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+PointerAlignment: Middle
+SpaceAfterTemplateKeyword: true
+SpaceBeforeCpp11BracedList: true
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: true
+    AfterFunction: true
+    SplitEmptyFunction: false

--- a/breakfuncs.sh
+++ b/breakfuncs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# match one or more ::-separated identifiers which may be templates,
+# but must start at column zero,
+# followed by an identifier which ends with an open-parenthesis
+# insert a break between these groups, after the final ::
+sed 's/^\(\([A-Za-z][A-Za-z0-9_ <>,]*::\)\+\)\([A-Za-z0-9_]*\)(/\1\n\3(/g' $*


### PR DESCRIPTION
Inspired by @gmgunter's [comment regarding code style](https://github.com/pyre/pyre/pull/58#issuecomment-668150943), I wrote up a quick clang-format for pyre based on the existing style (as I understand it). There are a few shortcomings, but overall I'm incredibly impressed with the return-on-investment of a config that only took me a few minutes to write.

Unfortunately there's no clang-format to always break after namespace specifiers in function definitions, but it was fairly straightforward to write a sed script to patch these after the fact. My intended usage here is
```sh
clang-format -i lib/**.{h,icc,cc}
./breakfuncs.sh -i lib/**.{h,icc,cc}
```
This sometimes trips up (e.g. when clang-format inserts newlines into a long function declaration, which would not have needed them after breakfuncs.sh) but otherwise appears to enforce the de facto style.