### PR TITLE
Add source_location support

### DIFF
--- a/.cmake/pyre_tests_pyre_lib.cmake
+++ b/.cmake/pyre_tests_pyre_lib.cmake
@@ -12,6 +12,9 @@
 # algebra
 pyre_test_driver(pyre.lib/algebra/bcd.cc)
 
+# error
+pyre_test_driver(pyre.lib/error/source_location.cc)
+
 # geometry
 pyre_test_driver(pyre.lib/geometry/point.cc)
 pyre_test_driver(pyre.lib/geometry/pointcloud.cc)

--- a/lib/pyre/error.h
+++ b/lib/pyre/error.h
@@ -1,0 +1,17 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2021 all rights reserved
+
+// code guard
+#if !defined(pyre_error_h)
+#define pyre_error_h
+
+
+// publish the interface
+#include "error/public.h"
+
+
+#endif
+
+// end of file

--- a/lib/pyre/error/externals.h
+++ b/lib/pyre/error/externals.h
@@ -1,0 +1,35 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2021 all rights reserved
+
+// code guard
+#if !defined(pyre_error_externals_h)
+#define pyre_error_externals_h
+
+
+// prefer STL <source_location> (since C++20)
+#if __has_include(<source_location>)
+#include <source_location>
+
+namespace pyre::error {
+    using source_location_t = std::source_location;
+}
+
+// fallback on Library Fundamentals TS v2 <experimental/source_location>
+#elif __has_include(<experimental/source_location>)
+#include <experimental/source_location>
+
+namespace pyre::error {
+    using source_location_t = std::experimental::source_location;
+}
+
+// no support for source_location
+#else
+#error could not find source_location header
+#endif
+
+
+#endif
+
+// end of file

--- a/lib/pyre/error/public.h
+++ b/lib/pyre/error/public.h
@@ -1,0 +1,17 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2021 all rights reserved
+
+// code guard
+#if !defined(pyre_error_public_h)
+#define pyre_error_public_h
+
+
+// external packages
+#include "externals.h"
+
+
+#endif
+
+// end of file

--- a/lib/pyre/pyre.h
+++ b/lib/pyre/pyre.h
@@ -13,6 +13,7 @@
 #include "timers.h"
 #include "memory.h"
 #include "grid.h"
+#include "error.h"
 
 #endif
 

--- a/tests/pyre.lib/error/source_location.cc
+++ b/tests/pyre.lib/error/source_location.cc
@@ -1,0 +1,55 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2021 all rights reserved
+
+
+#include <cassert>
+#include <string>
+
+#include <pyre/error.h>
+#include <pyre/journal.h>
+
+
+// check source location file name and line number
+int
+main(int argc, char * argv [])
+{
+    // initialize the journal
+    pyre::journal::init(argc, argv);
+    pyre::journal::application("source_location");
+    // make a channel
+    pyre::journal::debug_t channel("pyre.error.source_location");
+
+    // get current source location
+    const auto location = pyre::error::source_location_t::current();
+
+    // show me
+    channel
+        // show me the file name
+        << "location.file_name() = " << location.file_name()
+        << pyre::journal::newline
+        // show me the line number
+        << "location.line() = " << location.line() << pyre::journal::endl(__HERE__);
+
+    // checks if a string ends with the given suffix
+    auto ends_with = [](const std::string & str, const std::string & suffix) {
+        const auto n = str.length();
+        const auto m = suffix.length();
+        if (n < m) {
+            return false;
+        }
+        return str.compare(n - m, m, suffix) == 0;
+    };
+
+    // check file name
+    assert(ends_with(location.file_name(), "source_location.cc"));
+    // check line number
+    assert(location.line() == 25);
+
+    // all done
+    return 0;
+}
+
+
+// end of file


### PR DESCRIPTION
This PR adds a `source_location_t` type alias under the new namespace `pyre::error`. 

`source_location_t` is an alias for `std::source_location`, if available, falling back to `std::experimental::source_location` otherwise. If neither header was found, a compile-time error is raised. The STL version was standardized in C++20, and so far is [supported](https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B20_library_features) by libstdc++ v11. The fallback is supported in [libstdc++ v8](https://gcc.gnu.org/gcc-8/changes.html#libstdcxx) and [libc++ v9](https://clang.llvm.org/cxx_status.html#ts).

I wrote a small unit test and added CMake support (but haven't tried adding it to mm).

Note that the base branch for this PR is "error" rather than "main".