### PR TITLE
cmake: promised minor version stability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     pyre-config-version.cmake
     VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion
+    COMPATIBILITY SameMinorVersion
     )
 
 # install config file for find_package


### PR DESCRIPTION
Super small update to cmake package configuration to specify that micro
version bumps are API compatible.

Now we can `find_package(pyre VERSION 1.11.0)` and the upcoming
pyre v1.11.1 will be recognized as compatible.