### PR TITLE
Cleaned up unused variables in CMake configuration files

### DIFF
--- a/.cmake/pyre_benchmarks.cmake
+++ b/.cmake/pyre_benchmarks.cmake
@@ -15,7 +15,7 @@ function(pyre_benchmark_driver benchmarkfile)
   # schedule it to be compiled
   add_executable(${target} ${benchmarkfile})
   # in release mode
-  target_compile_options(${target} PRIVATE $<$<CONFIG:Release>:-O3>)
+  target_compile_options(${target} PRIVATE "-O3")
   # with some macros
   target_compile_definitions(${target} PRIVATE PYRE_CORE)
   # link against my libraries

--- a/.cmake/pyre_init.cmake
+++ b/.cmake/pyre_init.cmake
@@ -78,15 +78,6 @@ function(pyre_destinationInit)
 endfunction(pyre_destinationInit)
 
 
-# describe the root pf tyhe test suite
-function(pyre_testInit)
-  # create a variable to hold the root in the test directory
-  set(PYRE_TESTSUITE_DIR ${CMAKE_SOURCE_DIR}/tests PARENT_SCOPE)
-  set(PYRE_TESTSUITE_TMPDIR ${CMAKE_BINARY_DIR}/tmp PARENT_SCOPE)
-  # all done
-endfunction(pyre_testInit)
-
-
 # ask git for the most recent tag and use it to build the version
 function(pyre_getVersion)
   # git

--- a/.cmake/pyre_tests_journal_ext.cmake
+++ b/.cmake/pyre_tests_journal_ext.cmake
@@ -127,7 +127,7 @@ pyre_test_python_testcase(tests/journal.ext/warning_shared.py)
 # clean up
 add_test(NAME tests.journal.ext.api_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "echo $(pwd); rm api_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.api_file.cleanup PROPERTY
   DEPENDS tests.journal.ext.api_file.py
@@ -135,7 +135,7 @@ set_property(TEST tests.journal.ext.api_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.debug_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm debug_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.debug_file.cleanup PROPERTY
   DEPENDS tests.journal.ext.debug_file.py
@@ -143,7 +143,7 @@ set_property(TEST tests.journal.ext.debug_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.error_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm error_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.error_file.cleanup PROPERTY
   DEPENDS tests.journal.ext.error_file.py
@@ -151,7 +151,7 @@ set_property(TEST tests.journal.ext.error_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.firewall_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm firewall_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.firewall_file.cleanup PROPERTY
   DEPENDS tests.journal.ext.firewall_file.py
@@ -159,7 +159,7 @@ set_property(TEST tests.journal.ext.firewall_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.help_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm help_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.help_file.cleanup PROPERTY
   DEPENDS tests.journal.ext.help_file.py
@@ -167,7 +167,7 @@ set_property(TEST tests.journal.ext.help_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.info_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm info_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.info_file.cleanup PROPERTY
   DEPENDS tests.journal.ext.info_file.py
@@ -175,7 +175,7 @@ set_property(TEST tests.journal.ext.info_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.warning_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm warning_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.warning_file.cleanup PROPERTY
   DEPENDS tests.journal.ext.warning_file.py
@@ -183,7 +183,7 @@ set_property(TEST tests.journal.ext.warning_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.api_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "echo $(pwd); rm api_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.api_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.ext.api_file_mode.py
@@ -191,7 +191,7 @@ set_property(TEST tests.journal.ext.api_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.debug_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm debug_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.debug_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.ext.debug_file_mode.py
@@ -199,7 +199,7 @@ set_property(TEST tests.journal.ext.debug_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.error_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm error_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.error_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.ext.error_file_mode.py
@@ -207,7 +207,7 @@ set_property(TEST tests.journal.ext.error_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.firewall_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm firewall_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.firewall_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.ext.firewall_file_mode.py
@@ -215,7 +215,7 @@ set_property(TEST tests.journal.ext.firewall_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.help_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm help_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.help_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.ext.help_file_mode.py
@@ -223,7 +223,7 @@ set_property(TEST tests.journal.ext.help_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.info_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm info_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.info_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.ext.info_file_mode.py
@@ -231,7 +231,7 @@ set_property(TEST tests.journal.ext.info_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.ext.warning_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm warning_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.ext
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.ext
   )
 set_property(TEST tests.journal.ext.warning_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.ext.warning_file_mode.py

--- a/.cmake/pyre_tests_journal_pkg.cmake
+++ b/.cmake/pyre_tests_journal_pkg.cmake
@@ -127,7 +127,7 @@ pyre_test_python_testcase(tests/journal.pkg/warning_sanity.py)
 # clean up
 add_test(NAME tests.journal.pkg.api_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "echo $(pwd); rm api_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.api_file.cleanup PROPERTY
   DEPENDS tests.journal.pkg.api_file.py
@@ -135,7 +135,7 @@ set_property(TEST tests.journal.pkg.api_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.debug_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm debug_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.debug_file.cleanup PROPERTY
   DEPENDS tests.journal.pkg.debug_file.py
@@ -143,7 +143,7 @@ set_property(TEST tests.journal.pkg.debug_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.error_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm error_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.error_file.cleanup PROPERTY
   DEPENDS tests.journal.pkg.error_file.py
@@ -151,7 +151,7 @@ set_property(TEST tests.journal.pkg.error_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.firewall_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm firewall_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.firewall_file.cleanup PROPERTY
   DEPENDS tests.journal.pkg.firewall_file.py
@@ -159,7 +159,7 @@ set_property(TEST tests.journal.pkg.firewall_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.help_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm help_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.help_file.cleanup PROPERTY
   DEPENDS tests.journal.pkg.help_file.py
@@ -167,7 +167,7 @@ set_property(TEST tests.journal.pkg.help_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.info_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm info_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.info_file.cleanup PROPERTY
   DEPENDS tests.journal.pkg.info_file.py
@@ -175,7 +175,7 @@ set_property(TEST tests.journal.pkg.info_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.warning_file.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm warning_file.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.warning_file.cleanup PROPERTY
   DEPENDS tests.journal.pkg.warning_file.py
@@ -183,7 +183,7 @@ set_property(TEST tests.journal.pkg.warning_file.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.file_sanity.cleanup
   COMMAND ${BASH_PROGRAM} -c "echo $(pwd); rm file_sanity.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.file_sanity.cleanup PROPERTY
   DEPENDS tests.journal.pkg.file_sanity.py
@@ -191,7 +191,7 @@ set_property(TEST tests.journal.pkg.file_sanity.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.file_example.cleanup
   COMMAND ${BASH_PROGRAM} -c "echo $(pwd); rm file_example.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.file_example.cleanup PROPERTY
   DEPENDS tests.journal.pkg.file_example.py
@@ -200,7 +200,7 @@ set_property(TEST tests.journal.pkg.file_example.cleanup PROPERTY
 # clean up
 add_test(NAME tests.journal.pkg.api_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "echo $(pwd); rm api_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.api_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.pkg.api_file_mode.py
@@ -208,7 +208,7 @@ set_property(TEST tests.journal.pkg.api_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.debug_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm debug_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.debug_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.pkg.debug_file_mode.py
@@ -216,7 +216,7 @@ set_property(TEST tests.journal.pkg.debug_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.error_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm error_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.error_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.pkg.error_file_mode.py
@@ -224,7 +224,7 @@ set_property(TEST tests.journal.pkg.error_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.firewall_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm firewall_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.firewall_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.pkg.firewall_file_mode.py
@@ -232,7 +232,7 @@ set_property(TEST tests.journal.pkg.firewall_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.help_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm help_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.help_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.pkg.help_file_mode.py
@@ -240,7 +240,7 @@ set_property(TEST tests.journal.pkg.help_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.info_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm info_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.info_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.pkg.info_file_mode.py
@@ -248,7 +248,7 @@ set_property(TEST tests.journal.pkg.info_file_mode.cleanup PROPERTY
 
 add_test(NAME tests.journal.pkg.warning_file_mode.cleanup
   COMMAND ${BASH_PROGRAM} -c "rm warning_file_mode.log"
-  WORKING_DIRECTORY ${PYRE_TESTSUITE_DIR}/journal.pkg
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/journal.pkg
   )
 set_property(TEST tests.journal.pkg.warning_file_mode.cleanup PROPERTY
   DEPENDS tests.journal.pkg.warning_file_mode.py

--- a/.cmake/pyre_tests_merlin_pkg.cmake
+++ b/.cmake/pyre_tests_merlin_pkg.cmake
@@ -17,7 +17,7 @@ pyre_test_python_testcase(tests/merlin.pkg/components/merlin_packages.py)
 # cleanup
 add_test(NAME tests.merlin.components.clean
   COMMAND ${BASH_PROGRAM} -c "rm .merlin/project.pickle"
-  WORKING_DIRECTORY "${PYRE_TESTSUITE_DIR}/merlin.pkg/components"
+  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests/merlin.pkg/components"
   )
 
 # fixture

--- a/.cmake/pyre_tests_mpi_lib.cmake
+++ b/.cmake/pyre_tests_mpi_lib.cmake
@@ -15,7 +15,7 @@ pyre_test_driver_mpi(tests/mpi.lib/communicator.cc 8)
 
 # startup
 add_test(NAME tests.mpi.lib.localhost.pre
-  COMMAND ${BASH_PROGRAM} -c "cp ${PYRE_TESTSUITE_DIR}/mpi.lib/localhost ."
+  COMMAND ${BASH_PROGRAM} -c "cp ${PROJECT_SOURCE_DIR}/tests/mpi.lib/localhost ."
   )
 # cleanup
 add_test(NAME tests.mpi.lib.localhost.post

--- a/.cmake/pyre_tests_sqlite_pkg.cmake
+++ b/.cmake/pyre_tests_sqlite_pkg.cmake
@@ -14,7 +14,7 @@ pyre_test_python_testcase(tests/sqlite.pkg/sqlite_table.py)
 pyre_test_python_testcase(tests/sqlite.pkg/sqlite_references.py)
 # cleanup
 add_test(NAME tests.sqlite.clean
-  WORKING_DIRECTORY "${PYRE_TESTSUITE_DIR}/sqlite.pkg"
+  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests/sqlite.pkg"
   COMMAND ${BASH_PROGRAM} -c "rm pyre.sql")
 
 # make the fixture

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,10 +195,6 @@ if(PYRE_BUILD_TESTING)
   # and my functions
   include(pyre_tests)
 
-  # initialize the variables that describe the test suite; needed so harnesses can set up the
-  # working directory correctly
-  pyre_testInit()
-
   # pure python
   include(pyre_tests_python)
 


### PR DESCRIPTION
In an effort to restructure the CMake configuration of pyre so as to remove the annoying `CMakeLists.txt` files from the project subdirectories, revision 2dae115 explicitly prepended `tests` in the path passed as argument to the cmake functions that configure the testcases. For example, in file `.cmake/pyre_tests_gsl_pkg.cmake` the line
```
pyre_test_python_testcase(gsl.pkg/sanity.py)
```
was changed in revision 2dae115 into
```
pyre_test_python_testcase(tests/gsl.pkg/sanity.py)
```
The choice of explicitly prepending `tests` was also made envisioning the addition to the build system of support for timed benchmarks (see revision c342075), which will be placed in a subdirectory `benchmarks` of the project root directory and will have the same subdirectory structure of `tests`.

After revision 2dae115, the working directories of the python tests needed also to be adjusted, as `${PYRE_TESTSUITE_DIR}/${dir}` expanded to `${PROJECT_SOURCE_DIR}/tests/tests/<test_path>`, the 
redundant `tests` resulting from the fact that now `${PYRE_TESTSUITE_DIR}` and `${dir}` both factor in the `tests` component of the path. Revisions 1f010cc and c438e7c adjusted the paths by replacing `${PYRE_TESTSUITE_DIR}` with `${PROJECT_SOURCE_DIR}`. 

Because the variable `PYRE_TESTSUITE_DIR` is now used only in a few places, this pull request removes it altogether, by replacing the occurrences of `${PYRE_TESTSUITE_DIR}` with the equivalent`${PROJECT_SOURCE_DIR}/tests`.
In addition, because `PYRE_TESTSUITE_TMPDIR` is also unused, this pull request removes function `pyre_testInit`, whose only purpose was that of setting `PYRE_TESTSUITE_DIR` and `PYRE_TESTSUITE_TMPDIR`.