### PR TITLE
Added support for fine tuning the performance of h5 accesses

### DIFF
--- a/.mm/pyre.pkg.tests
+++ b/.mm/pyre.pkg.tests
@@ -17,6 +17,7 @@ tests.pyre.pkg.filesystem.zip.clean := sample.zip
 tests.pyre.pkg.schemata.ostreams.clean := output.cfg
 tests.pyre.pkg.primitives.path_resolution.clean := scratch
 tests.pyre.pkg.pyre.clean := __pycache__
+tests.pyre.pkg.h5.api.writer.clean := writer.h5
 
 
 # the {filesystem.local-make} test modifies the current directory, which creates race

--- a/extensions/h5/DAPL.cc
+++ b/extensions/h5/DAPL.cc
@@ -1,0 +1,85 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2023 all rights reserved
+
+
+// externals
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// dataset access property lists
+void
+pyre::h5::py::dapl(py::module & m)
+{
+    // add bindings for hdf5 dataset access property lists
+    auto cls = py::class_<DAPL, PropList>(
+        // in scope
+        m,
+        // class name
+        "DAPL",
+        // docstring
+        "a dataset access property list");
+
+    // static properties
+    cls.def_property_readonly_static(
+        // the name
+        "default",
+        // the implementation
+        [](const py::object &) {
+            // easy enough
+            return &DAPL::DEFAULT;
+        },
+        // docstring
+        "the default dataset access property list");
+
+    // constructor
+    cls.def(
+        // the implementation
+        py::init(),
+        // the docstring
+        "build a dataset access property list");
+
+    // interface
+    // get the chunk size
+    cls.def(
+        // the name
+        "getChunkCache",
+        // the implementation
+        [](const DAPL & self) {
+            // make some room
+            size_t slots;
+            size_t bytes;
+            double w0;
+            // get the values
+            self.getChunkCache(slots, bytes, w0);
+            // pack and ship
+            return py::make_tuple(slots, bytes, w0);
+        },
+        // the docstring
+        "get the chunk cache parameters");
+    // set the chunk size
+    cls.def(
+        // the name
+        "setChunkCache",
+        // the implementation
+        [](const DAPL & self, size_t slots, size_t bytes, double w0) -> void {
+            // set the chunk size and shape
+            self.setChunkCache(slots, bytes, w0);
+            // all done
+            return;
+        },
+        // the signature
+        "slots"_a, "bytes"_a, "w0"_a,
+        // the docstring
+        "set the chunk cache parameters");
+
+
+    // all done
+    return;
+}
+
+
+// end of file

--- a/extensions/h5/DCPL.cc
+++ b/extensions/h5/DCPL.cc
@@ -133,6 +133,38 @@ pyre::h5::py::dcpl(py::module & m)
         // the docstring
         "set the data layout strategy");
 
+    // filters
+    cls.def(
+        // the name
+        "getFilters",
+        // the implementation
+        [](const DCPL & self) {
+            // the filter info
+            using filter_info_t = std::tuple<H5Z_filter_t, string_t, unsigned int, unsigned int>;
+            // make a pile
+            auto filters = std::vector<filter_info_t>();
+
+            // go through the registered filters
+            for (int i = 0; i < self.getNfilters(); ++i) {
+                // make some room
+                unsigned int flags;
+                char name[256];
+                size_t clientDataElements = 0;
+                unsigned int * clientDataValues = nullptr;
+                unsigned int configuration;
+                // get the info
+                auto id = self.getFilter(
+                    i, flags, clientDataElements, clientDataValues, sizeof(name), name,
+                    configuration);
+                // store
+                filters.emplace_back(id, name, flags, configuration);
+            }
+            // all done
+            return filters;
+        },
+        // the docstring
+        "get the number of filters in the dataset pipeline");
+
     // compression
     // deflate
     cls.def(

--- a/extensions/h5/DCPL.cc
+++ b/extensions/h5/DCPL.cc
@@ -1,0 +1,163 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2023 all rights reserved
+
+
+// externals
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// dataset creation property lists
+void
+pyre::h5::py::dcpl(py::module & m)
+{
+    // add bindings for hdf5 dataset creation property lists
+    auto cls = py::class_<DCPL, PropList>(
+        // in scope
+        m,
+        // class name
+        "DCPL",
+        // docstring
+        "a dataset creation property list");
+
+    // static properties
+    cls.def_property_readonly_static(
+        // the name
+        "default",
+        // the implementation
+        [](const py::object &) {
+            // easy enough
+            return &DCPL::DEFAULT;
+        },
+        // docstring
+        "the default dataset creation property list");
+
+    // constructor
+    cls.def(
+        // the implementation
+        py::init(),
+        // the docstring
+        "build a dataset creation property list");
+
+    // interface
+    // get the allocation time
+    cls.def(
+        // the name
+        "getAllocTime",
+        // the implementation
+        &DCPL::getAllocTime,
+        // the docstring
+        "get the allocation time");
+    // set the allocation time
+    cls.def(
+        // the name
+        "setAllocTime",
+        // the implementation
+        &DCPL::setAllocTime,
+        // the signature
+        "timing"_a,
+        // the docstring
+        "set the allocation time");
+
+    // get the chunk size
+    cls.def(
+        // the name
+        "getChunk",
+        // the implementation
+        &DCPL::getChunk,
+        // the docstring
+        "get the chunk size");
+    // set the chunk size
+    cls.def(
+        // the name
+        "setChunk",
+        // the implementation
+        [](const DCPL & self, const shape_t & chunk) -> void {
+            // set the chunk size and shape
+            self.setChunk(chunk.size(), &chunk[0]);
+            // all done
+            return;
+        },
+        // the signature
+        "chunk"_a,
+        // the docstring
+        "set the chunk size");
+
+    // get the fill value writing time
+    cls.def(
+        // the name
+        "getFillTime",
+        // the implementation
+        &DCPL::getFillTime,
+        // the docstring
+        "get the fill value writing time");
+    // set the fill value writing time
+    cls.def(
+        // the name
+        "setFillTime",
+        // the implementation
+        &DCPL::setFillTime,
+        // the signature
+        "timing"_a,
+        // the docstring
+        "set the fill value writing time");
+
+    // get the data layout strategy
+    cls.def(
+        // the name
+        "getLayout",
+        // the implementation
+        &DCPL::getLayout,
+        // the docstring
+        "get the data layout strategy");
+    // set the data layout strategy
+    cls.def(
+        // the name
+        "setLayout",
+        // the implementation
+        &DCPL::setLayout,
+        // the signature
+        "layout"_a,
+        // the docstring
+        "set the data layout strategy");
+
+    // compression
+    // deflate
+    cls.def(
+        // the name
+        "setDeflate",
+        // the implementation
+        &DCPL::setDeflate,
+        // the signature
+        "level"_a,
+        // the docstring
+        "use deflate with the given {level}");
+    // szip
+    cls.def(
+        // the name
+        "setSzip",
+        // the implementation
+        &DCPL::setSzip,
+        // the signature
+        "options"_a, "pixelsPerBlock"_a,
+        // the docstring
+        "use szip compression with the given {options} and {pixelsPerBlock}");
+    // nbit
+    cls.def(
+        // the name
+        "setNbit",
+        // the implementation
+        &DCPL::setNbit,
+        // the docstring
+        "use nbit compression");
+
+
+    // all done
+    return;
+}
+
+
+// end of file

--- a/extensions/h5/DCPL.cc
+++ b/extensions/h5/DCPL.cc
@@ -67,24 +67,33 @@ pyre::h5::py::dcpl(py::module & m)
         // the name
         "getChunk",
         // the implementation
-        &DCPL::getChunk,
+        [](const DCPL & self, int rank) {
+            // make a vector big enough to hold the answer
+            shape_t shape(rank);
+            // get the chunk size
+            self.getChunk(rank, &shape[0]);
+            // and return it
+            return shape;
+        },
+        // the signature
+        "rank"_a,
         // the docstring
-        "get the chunk size");
+        "get the chunk size given the dataset {rank}");
     // set the chunk size
     cls.def(
         // the name
         "setChunk",
         // the implementation
-        [](const DCPL & self, const shape_t & chunk) -> void {
+        [](const DCPL & self, const shape_t & shape) -> void {
             // set the chunk size and shape
-            self.setChunk(chunk.size(), &chunk[0]);
+            self.setChunk(shape.size(), &shape[0]);
             // all done
             return;
         },
         // the signature
-        "chunk"_a,
+        "shape"_a,
         // the docstring
-        "set the chunk size");
+        "set the chunk {shape}");
 
     // get the fill value writing time
     cls.def(

--- a/extensions/h5/DXPL.cc
+++ b/extensions/h5/DXPL.cc
@@ -1,0 +1,58 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2023 all rights reserved
+
+
+// externals
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// dataset memory transfer property lists
+void
+pyre::h5::py::dxpl(py::module & m)
+{
+    // add bindings for hdf5 dataset memory transfer property lists
+    auto cls = py::class_<DXPL, PropList>(
+        // in scope
+        m,
+        // class name
+        "DXPL",
+        // docstring
+        "a dataset memory transfer property list");
+
+    // static properties
+    cls.def_property_readonly_static(
+        // the name
+        "default",
+        // the implementation
+        [](const py::object &) {
+            // easy enough
+            return &DXPL::DEFAULT;
+        },
+        // docstring
+        "the default dataset memory transfer property list");
+
+    // constructors
+    cls.def(
+        // the implementation
+        py::init(),
+        // the docstring
+        "build a dataset memory transfer property list");
+
+    cls.def(
+        // the implementation
+        py::init<const char *>(),
+        // the signature
+        "expression"_a,
+        // the docstring
+        "build a dataset memory transfer property list");
+
+    // all done
+    return;
+}
+
+
+// end of file

--- a/extensions/h5/DataSet.cc
+++ b/extensions/h5/DataSet.cc
@@ -167,6 +167,24 @@ pyre::h5::py::dataset(py::module & m)
         // the docstring
         "get detailed information about my type");
 
+    // access property list
+    cls.def_property_readonly(
+        // the name
+        "dapl",
+        // the implementation
+        &DataSet::getAccessPlist,
+        // the docstring
+        "get my access property list");
+
+    // creation property list
+    cls.def_property_readonly(
+        // the name
+        "dcpl",
+        // the implementation
+        &DataSet::getCreatePlist,
+        // the docstring
+        "get my creation property list");
+
     // the on-disk size
     cls.def_property_readonly(
         // the name

--- a/extensions/h5/DataSet.cc
+++ b/extensions/h5/DataSet.cc
@@ -9,6 +9,58 @@
 // namespace setup
 #include "forward.h"
 
+// helpers
+namespace pyre::h5::py {
+
+    // bindings for reading dataset contents into {pyre::memory} buffers
+    template <class memT>
+    auto bindReadBuffer(py::class_<DataSet> & cls) -> void
+    {
+        // add a {write} overload for the given grid type
+        cls.def(
+            // the name
+            "read",
+            // the implementation
+            &read<memT>,
+            // the signature
+            "data"_a, "memtype"_a, "origin"_a, "shape"_a,
+            // the docstring
+            "fill {data} with the tile @{origin}+{shape}");
+    }
+
+    // bindings for writing out the contents of {pyre::memory} buffers
+    template <class memT>
+    auto bindWriteBuffer(py::class_<DataSet> & cls) -> void
+    {
+        // add a {write} overload for the given grid type
+        cls.def(
+            // the name
+            "write",
+            // the implementation
+            &write<memT>,
+            // the signature
+            "data"_a, "memtype"_a, "origin"_a, "shape"_a,
+            // the docstring
+            "fill {data} with the tile @{origin}+{shape}");
+    }
+
+    // bindings for writing out the contents of grids
+    template <class gridT>
+    auto bindWriteGrid(py::class_<DataSet> & cls) -> void
+    {
+        // add a {write} overload for the given grid type
+        cls.def(
+            // the name
+            "write",
+            // the implementation
+            &writeGrid<gridT>,
+            // the signature
+            "data"_a, "memtype"_a, "origin"_a, "shape"_a,
+            // the docstring
+            "fill {data} with the tile @{origin}+{shape}");
+    }
+} // namespace pyre::h5::py
+
 // datasets
 void
 pyre::h5::py::dataset(py::module & m)
@@ -518,207 +570,48 @@ pyre::h5::py::dataset(py::module & m)
         // the docstring
         "close the dataset");
 
-    // read a block of data from the dataset
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_int8_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
+    // reading
+    // into memory buffers
+    bindReadBuffer<heap_int8_t>(cls);
+    bindReadBuffer<heap_int16_t>(cls);
+    bindReadBuffer<heap_int32_t>(cls);
+    bindReadBuffer<heap_int64_t>(cls);
+    bindReadBuffer<heap_uint8_t>(cls);
+    bindReadBuffer<heap_uint16_t>(cls);
+    bindReadBuffer<heap_uint32_t>(cls);
+    bindReadBuffer<heap_uint64_t>(cls);
+    bindReadBuffer<heap_float_t>(cls);
+    bindReadBuffer<heap_double_t>(cls);
+    bindReadBuffer<heap_complexfloat_t>(cls);
+    bindReadBuffer<heap_complexdouble_t>(cls);
 
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_int16_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_int32_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_int64_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_uint8_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_uint16_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_uint32_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_uint64_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_float_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_double_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_complexfloat_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "read",
-        // the implementation
-        &read<heap_complexdouble_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    // write a block of data to the dataset
-    cls.def(
-        // the name
-        "write",
-        // the implementation
-        &write<heap_int8_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "write",
-        // the implementation
-        &write<heap_int16_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "write",
-        // the implementation
-        &write<heap_int32_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "write",
-        // the implementation
-        &write<heap_int64_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "write",
-        // the implementation
-        &write<heap_float_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "write",
-        // the implementation
-        &write<heap_double_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "write",
-        // the implementation
-        &write<heap_complexfloat_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
-
-    cls.def(
-        // the name
-        "write",
-        // the implementation
-        &write<heap_complexdouble_t>,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
+    // writing
+    // from memory buffers
+    bindWriteBuffer<heap_int8_t>(cls);
+    bindWriteBuffer<heap_int16_t>(cls);
+    bindWriteBuffer<heap_int32_t>(cls);
+    bindWriteBuffer<heap_int64_t>(cls);
+    bindWriteBuffer<heap_uint8_t>(cls);
+    bindWriteBuffer<heap_uint16_t>(cls);
+    bindWriteBuffer<heap_uint32_t>(cls);
+    bindWriteBuffer<heap_uint64_t>(cls);
+    bindWriteBuffer<heap_float_t>(cls);
+    bindWriteBuffer<heap_double_t>(cls);
+    bindWriteBuffer<heap_complexfloat_t>(cls);
+    bindWriteBuffer<heap_complexdouble_t>(cls);
+    // from 2d grids
+    bindWriteGrid<int8_heapgrid_2d_t>(cls);
+    bindWriteGrid<int16_heapgrid_2d_t>(cls);
+    bindWriteGrid<int32_heapgrid_2d_t>(cls);
+    bindWriteGrid<int64_heapgrid_2d_t>(cls);
+    bindWriteGrid<uint8_heapgrid_2d_t>(cls);
+    bindWriteGrid<uint16_heapgrid_2d_t>(cls);
+    bindWriteGrid<uint32_heapgrid_2d_t>(cls);
+    bindWriteGrid<uint64_heapgrid_2d_t>(cls);
+    bindWriteGrid<float_heapgrid_2d_t>(cls);
+    bindWriteGrid<double_heapgrid_2d_t>(cls);
+    bindWriteGrid<complexfloat_heapgrid_2d_t>(cls);
+    bindWriteGrid<complexdouble_heapgrid_2d_t>(cls);
 
     // all done
     return;

--- a/extensions/h5/FAPL.cc
+++ b/extensions/h5/FAPL.cc
@@ -15,7 +15,7 @@ void
 pyre::h5::py::fapl(py::module & m)
 {
     // add bindings for hdf5 file objects
-    auto cls = py::class_<FileAccessPropertyList>(
+    auto cls = py::class_<FAPL>(
         // in scope
         m,
         // class name
@@ -35,7 +35,7 @@ pyre::h5::py::fapl(py::module & m)
         // the name
         "getMetaBlockSize",
         // the implementation
-        &FileAccessPropertyList::getMetaBlockSize,
+        &FAPL::getMetaBlockSize,
         // the docstring
         "retrieve the metadata block size");
 
@@ -44,7 +44,7 @@ pyre::h5::py::fapl(py::module & m)
         // the name
         "setMetaBlockSize",
         // the implementation
-        &FileAccessPropertyList::setMetaBlockSize,
+        &FAPL::setMetaBlockSize,
         // the signature
         "size"_a,
         // the docstring
@@ -55,7 +55,7 @@ pyre::h5::py::fapl(py::module & m)
         // the name
         "close",
         // the implementation
-        &FileAccessPropertyList::close,
+        &FAPL::close,
         // the docstring
         "discard the property list");
 
@@ -65,8 +65,8 @@ pyre::h5::py::fapl(py::module & m)
         // the name
         "ros3",
         // the implementation
-        [](FileAccessPropertyList & plist, bool authenticate, string_t region, string_t id,
-           string_t key, string_t token) -> FileAccessPropertyList & {
+        [](FAPL & plist, bool authenticate, string_t region, string_t id,
+           string_t key, string_t token) -> FAPL & {
             // make room for the driver parameters
             H5FD_ros3_fapl_t p;
             // populate

--- a/extensions/h5/FAPL.cc
+++ b/extensions/h5/FAPL.cc
@@ -51,7 +51,7 @@ pyre::h5::py::fapl(py::module & m)
         // the docstring
         "retrieve the metadata block size");
 
-    // set the page buffer settings
+    // get the metadata block size
     cls.def(
         // the name
         "setMetaBlockSize",
@@ -61,6 +61,39 @@ pyre::h5::py::fapl(py::module & m)
         "size"_a,
         // the docstring
         "set the metadata cache parameters");
+
+    // get the page buffer characteristics
+    cls.def(
+        // the name
+        "getPageBufferSize",
+        // the implementation
+        [](const FAPL & self) {
+            // make some room
+            size_t buffer = 4 * 1024;
+            unsigned int meta = 0;
+            unsigned int raw = 0;
+            // get the info
+            H5Pget_page_buffer_size(self.getId(), &buffer, &meta, &raw);
+            // pack and ship
+            return py::make_tuple(buffer, meta, raw);
+        },
+        // the docstring
+        "retrieve the page buffer characteristics");
+
+    // set the page buffer characteristics
+    cls.def(
+        // the name
+        "setPageBufferSize",
+        // the implementation
+        [](const FAPL & self, size_t buffer, unsigned int meta, unsigned int raw) {
+            // set the values and return
+            return H5Pset_page_buffer_size(self.getId(), buffer, meta, raw);
+        },
+        // the signature
+        "page"_a, "meta"_a = 0, "raw"_a = 0,
+        // the docstring
+        "retrieve the page buffer characteristics");
+
 
 #if defined(H5_HAVE_ROS3_VFD)
     // populate the property list with ros3 parameters

--- a/extensions/h5/FAPL.cc
+++ b/extensions/h5/FAPL.cc
@@ -23,6 +23,18 @@ pyre::h5::py::fapl(py::module & m)
         // docstring
         "a file access property list");
 
+    // static properties
+    cls.def_property_readonly_static(
+        // the name
+        "default",
+        // the implementation
+        [](const py::object &) {
+            // easy enough
+            return &FAPL::DEFAULT;
+        },
+        // docstring
+        "the default file access property list");
+
     // constructor
     cls.def(
         // the implementation

--- a/extensions/h5/FAPL.cc
+++ b/extensions/h5/FAPL.cc
@@ -10,12 +10,12 @@
 #include "forward.h"
 
 
-// file objects
+// file access property lists
 void
 pyre::h5::py::fapl(py::module & m)
 {
-    // add bindings for hdf5 file objects
-    auto cls = py::class_<FAPL>(
+    // add bindings for hdf5 file access property lists
+    auto cls = py::class_<FAPL, PropList>(
         // in scope
         m,
         // class name
@@ -50,23 +50,14 @@ pyre::h5::py::fapl(py::module & m)
         // the docstring
         "set the metadata cache parameters");
 
-    // close the list
-    cls.def(
-        // the name
-        "close",
-        // the implementation
-        &FAPL::close,
-        // the docstring
-        "discard the property list");
-
 #if defined(H5_HAVE_ROS3_VFD)
     // populate the property list with ros3 parameters
     cls.def(
         // the name
         "ros3",
         // the implementation
-        [](FAPL & plist, bool authenticate, string_t region, string_t id,
-           string_t key, string_t token) -> FAPL & {
+        [](FAPL & self, bool authenticate, string_t region, string_t id, string_t key,
+           string_t token) -> FAPL & {
             // make room for the driver parameters
             H5FD_ros3_fapl_t p;
             // populate
@@ -82,7 +73,7 @@ pyre::h5::py::fapl(py::module & m)
             // send to the {ros3} driver; this process includes runtime validation, so there is
             // no need for extra checks that the struct we populated is understood by whatever
             // runtime we have dynamically linked against
-            auto status = H5Pset_fapl_ros3(plist.getId(), &p);
+            auto status = H5Pset_fapl_ros3(self.getId(), &p);
             // if the transfer failed
             if (status < 0) {
                 // make a channel
@@ -96,7 +87,7 @@ pyre::h5::py::fapl(py::module & m)
                     << pyre::journal::endl(__HERE__);
             }
             // all done
-            return plist;
+            return self;
         },
         // the signature
         "authenticate"_a = true, "region"_a = "", "id"_a = "", "key"_a = "", "token"_a = "",

--- a/extensions/h5/FCPL.cc
+++ b/extensions/h5/FCPL.cc
@@ -52,6 +52,40 @@ pyre::h5::py::fcpl(py::module & m)
         // the docstring
         "set the file space page {size}");
 
+    // get the file space strategy
+    cls.def(
+        // the name
+        "getFilespaceStrategy",
+        // the implementation
+        [](FCPL & self) {
+            // make some room
+            H5F_fspace_strategy_t strategy;
+            hbool_t persist;
+            hsize_t threshold;
+            // read the strategy
+            self.getFileSpaceStrategy(strategy, persist, threshold);
+            // pack them and return them
+            return py::make_tuple(strategy, persist, threshold);
+        },
+        // the docstring
+        "get the current file space strategy");
+
+    // set the file space strategy
+    cls.def(
+        // the name
+        "setFilespaceStrategy",
+        // the implementation
+        [](FCPL & self, H5F_fspace_strategy_t strategy, hbool_t persist, hsize_t threshold) {
+            // set the strategy
+            self.setFileSpaceStrategy(strategy, persist, threshold);
+            // all done
+            return;
+        },
+        // the signature
+        "strategy"_a, "persist"_a, "threshold"_a,
+        // the docstring
+        "set the file space strategy");
+
     // all done
     return;
 }

--- a/extensions/h5/FCPL.cc
+++ b/extensions/h5/FCPL.cc
@@ -1,0 +1,60 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2023 all rights reserved
+
+
+// externals
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// file creation property lists
+void
+pyre::h5::py::fcpl(py::module & m)
+{
+    // add bindings for hdf5 file creation property lists
+    auto cls = py::class_<FCPL, PropList>(
+        // in scope
+        m,
+        // class name
+        "FCPL",
+        // docstring
+        "a file creation property list");
+
+    // constructor
+    cls.def(
+        // the implementation
+        py::init(),
+        // the docstring
+        "build a file creation property list");
+
+    // interface
+    // get the page size
+    cls.def(
+        // the name
+        "getPageSize",
+        // the implementation
+        &FCPL::getFileSpacePagesize,
+        // the signature
+        // the docstring
+        "retrieve the file space page size");
+
+    // set the page size
+    cls.def(
+        // the name
+        "setPageSize",
+        // the implementation
+        &FCPL::setFileSpacePagesize,
+        // the signature
+        "size"_a,
+        // the docstring
+        "set the file space page {size}");
+
+    // all done
+    return;
+}
+
+
+// end of file

--- a/extensions/h5/FCPL.cc
+++ b/extensions/h5/FCPL.cc
@@ -23,6 +23,18 @@ pyre::h5::py::fcpl(py::module & m)
         // docstring
         "a file creation property list");
 
+    // static properties
+    cls.def_property_readonly_static(
+        // the name
+        "default",
+        // the implementation
+        [](const py::object &) {
+            // easy enough
+            return &FCPL::DEFAULT;
+        },
+        // docstring
+        "the default file creation property list");
+
     // constructor
     cls.def(
         // the implementation

--- a/extensions/h5/File.cc
+++ b/extensions/h5/File.cc
@@ -77,23 +77,23 @@ pyre::h5::py::file(py::module & m)
     // constructor for accessing a file with a custom access property list
     cls.def(
         // the implementation
-        py::init([](string_t uri, const FileAccessPropertyList & p, string_t mode) {
+        py::init([](string_t uri, const FAPL & p, string_t mode) {
             // decode mode
             if (mode == "r") {
                 // read-only, file must exist
-                return File(uri, H5F_ACC_RDONLY, FileCreatePropertyList::DEFAULT, p);
+                return File(uri, H5F_ACC_RDONLY, FCPL::DEFAULT, p);
             }
             if (mode == "r+") {
                 // read/write, file must exist
-                return File(uri, H5F_ACC_RDWR, FileCreatePropertyList::DEFAULT, p);
+                return File(uri, H5F_ACC_RDWR, FCPL::DEFAULT, p);
             }
             if (mode == "w") {
                 // create file, truncate if it exists
-                return File(uri, H5F_ACC_TRUNC, FileCreatePropertyList::DEFAULT, p);
+                return File(uri, H5F_ACC_TRUNC, FCPL::DEFAULT, p);
             }
             if (mode == "w-" || mode == "x") {
                 // create file, fail if it exists
-                return File(uri, H5F_ACC_EXCL, FileCreatePropertyList::DEFAULT, p);
+                return File(uri, H5F_ACC_EXCL, FCPL::DEFAULT, p);
             }
 
             // h5py has one more valid {mode}

--- a/extensions/h5/File.cc
+++ b/extensions/h5/File.cc
@@ -26,7 +26,7 @@ pyre::h5::py::file(py::module & m)
     // constructor for accessing a local file
     cls.def(
         // the implementation
-        py::init([](std::string uri, std::string mode) {
+        py::init([](string_t uri, string_t mode) {
             // decode mode
             if (mode == "r") {
                 // read-only, file must exist
@@ -77,7 +77,7 @@ pyre::h5::py::file(py::module & m)
     // constructor for accessing a file with a custom access property list
     cls.def(
         // the implementation
-        py::init([](std::string uri, const FileAccessPropertyList & p, std::string mode) {
+        py::init([](string_t uri, const FileAccessPropertyList & p, string_t mode) {
             // decode mode
             if (mode == "r") {
                 // read-only, file must exist

--- a/extensions/h5/File.cc
+++ b/extensions/h5/File.cc
@@ -86,6 +86,24 @@ pyre::h5::py::file(py::module & m)
         // the docstring
         "get my h5 object category");
 
+    // creation property list
+    cls.def_property_readonly(
+        // the name
+        "fcpl",
+        // the implementation
+        &File::getCreatePlist,
+        // the docstring
+        "get my creation property list");
+
+    // access property list
+    cls.def_property_readonly(
+        // the name
+        "fapl",
+        // the implementation
+        &File::getAccessPlist,
+        // the docstring
+        "get my access property list");
+
     // close the file
     cls.def(
         // the name

--- a/extensions/h5/File.cc
+++ b/extensions/h5/File.cc
@@ -23,26 +23,26 @@ pyre::h5::py::file(py::module & m)
         // docstring
         "an HDF5 file");
 
-    // constructor for accessing a local file
+    // constructor
     cls.def(
         // the implementation
-        py::init([](string_t uri, string_t mode) {
+        py::init([](string_t uri, string_t mode, const FCPL & fcpl, const FAPL & fapl) {
             // decode mode
             if (mode == "r") {
                 // read-only, file must exist
-                return File(uri, H5F_ACC_RDONLY);
+                return File(uri, H5F_ACC_RDONLY, fcpl, fapl);
             }
             if (mode == "r+") {
                 // read/write, file must exist
-                return File(uri, H5F_ACC_RDWR);
+                return File(uri, H5F_ACC_RDWR, fcpl, fapl);
             }
             if (mode == "w") {
                 // create file, truncate if it exists
-                return File(uri, H5F_ACC_TRUNC);
+                return File(uri, H5F_ACC_TRUNC, fcpl, fapl);
             }
             if (mode == "w-" || mode == "x") {
                 // create file, fail if it exists
-                return File(uri, H5F_ACC_EXCL);
+                return File(uri, H5F_ACC_EXCL, fcpl, fapl);
             }
 
             // h5py has one more valid {mode}
@@ -70,58 +70,7 @@ pyre::h5::py::file(py::module & m)
             return File();
         }),
         // the signature
-        "uri"_a, "mode"_a = "r",
-        // the docstring
-        "open an HDF5 file given its {uri}");
-
-    // constructor for accessing a file with a custom access property list
-    cls.def(
-        // the implementation
-        py::init([](string_t uri, const FAPL & p, string_t mode) {
-            // decode mode
-            if (mode == "r") {
-                // read-only, file must exist
-                return File(uri, H5F_ACC_RDONLY, FCPL::DEFAULT, p);
-            }
-            if (mode == "r+") {
-                // read/write, file must exist
-                return File(uri, H5F_ACC_RDWR, FCPL::DEFAULT, p);
-            }
-            if (mode == "w") {
-                // create file, truncate if it exists
-                return File(uri, H5F_ACC_TRUNC, FCPL::DEFAULT, p);
-            }
-            if (mode == "w-" || mode == "x") {
-                // create file, fail if it exists
-                return File(uri, H5F_ACC_EXCL, FCPL::DEFAULT, p);
-            }
-
-            // h5py has one more valid {mode}
-            // a: create if it doesn't exist, read/write regardless
-            // supporting this requires attempting to open the file in RDWR mode
-            // and trying again in EXCL if it fails
-            // i need to learn a bit more about error trapping before attempting this
-
-            // if we get this far, we have a problem
-            auto channel = pyre::journal::error_t("pyre.h5.file");
-            // so complain
-            channel
-                // say why
-                << "invalid mode '" << mode << "'"
-                << pyre::journal::newline
-                // show me the filename
-                << "while opening '" << uri << "'"
-                << pyre::journal::newline
-                // show me what's supported
-                << "currently supported modes: r, r+, w, w-"
-                // and flush
-                << pyre::journal::endl(__HERE__);
-
-            // just in case this error is not fatal, make a stub
-            return File();
-        }),
-        // the signature
-        "uri"_a, "fapl"_a, "mode"_a = "r",
+        "uri"_a, "mode"_a = "r", "fcpl"_a = FCPL::DEFAULT, "fapl"_a = FAPL::DEFAULT,
         // the docstring
         "open an HDF5 file given its {uri} and a custom access property list");
 

--- a/extensions/h5/FileAccessPropertyList.cc
+++ b/extensions/h5/FileAccessPropertyList.cc
@@ -30,6 +30,26 @@ pyre::h5::py::fapl(py::module & m)
         // the docstring
         "create a file access property list");
 
+    // get the metadata block size
+    cls.def(
+        // the name
+        "getMetaBlockSize",
+        // the implementation
+        &FileAccessPropertyList::getMetaBlockSize,
+        // the docstring
+        "retrieve the metadata block size");
+
+    // set the page buffer settings
+    cls.def(
+        // the name
+        "setMetaBlockSize",
+        // the implementation
+        &FileAccessPropertyList::setMetaBlockSize,
+        // the signature
+        "size"_a,
+        // the docstring
+        "set the metadata cache parameters");
+
     // close the list
     cls.def(
         // the name

--- a/extensions/h5/Group.cc
+++ b/extensions/h5/Group.cc
@@ -105,20 +105,14 @@ pyre::h5::py::group(py::module & m)
         // the name
         "members",
         // the implementation
-        [](const Group & self) {
-            // we build (name, type) pairs
-            using info_t = string_t;
-            // in a container
-            using members_t = std::vector<info_t>;
-            // make one
-            auto members = members_t();
-            // go through them
+        [](const Group & self) -> names_t {
+            // make a pile
+            auto members = names_t();
+            // look up how many members i have and go through them
             for (auto index = 0; index < self.getNumObjs(); ++index) {
-                // get the name of the member at {index}y3j
+                // to get the name of the member at {index}
                 auto name = self.getObjnameByIdx(index);
-                // figure out its type
-                auto type = self.childObjType(name);
-                // and add the pair to the pile
+                // and add it to the pile
                 members.emplace_back(name);
             }
             // all done

--- a/extensions/h5/Group.cc
+++ b/extensions/h5/Group.cc
@@ -100,6 +100,20 @@ pyre::h5::py::group(py::module & m)
         // the docstring
         "close this group");
 
+    // check whether a name corresponds to a group member
+    cls.def(
+        // the name
+        "has",
+        // the implementation
+        [](const Group & self, const string_t & name) -> bool {
+            // check and return the result
+            return self.nameExists(name);
+        },
+        // the signature
+        "name"_a,
+        // the docstring
+        "check whether {name} is a group member");
+
     // extract information about my members
     cls.def(
         // the name
@@ -208,6 +222,19 @@ pyre::h5::py::group(py::module & m)
         },
         // the docstring
         "the number of group members");
+
+    cls.def(
+        // the name
+        "__contains__",
+        // the implementation
+        [](const Group & self, const string_t & name) -> bool {
+            // check and return the result
+            return self.nameExists(name);
+        },
+        // the signature
+        "name"_a,
+        // the docstring
+        "check whether {name} is a known member of this group");
 
     cls.def(
         // the name

--- a/extensions/h5/Group.cc
+++ b/extensions/h5/Group.cc
@@ -202,12 +202,12 @@ pyre::h5::py::group(py::module & m)
         "create",
         // the implementation
         [](const Group & self, const string_t & path, const DataType & type,
-           const DataSpace & space) -> DataSet {
+           const DataSpace & space, const DCPL & dcpl, const DAPL & dapl) -> DataSet {
             // make the dataset and return it
-            return self.createDataSet(path, type, space);
+            return self.createDataSet(path, type, space, dcpl, dapl);
         },
         // the signature
-        "path"_a, "type"_a, "space"_a,
+        "path"_a, "type"_a, "space"_a, "dcpl"_a = DCPL::DEFAULT, "dapl"_a = DAPL::DEFAULT,
         // the docstring
         "create a new dataset at the given {name} given its {type} and data {space}");
 

--- a/extensions/h5/LAPL.cc
+++ b/extensions/h5/LAPL.cc
@@ -1,0 +1,70 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2023 all rights reserved
+
+
+// externals
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// link access property lists
+void
+pyre::h5::py::lapl(py::module & m)
+{
+    // add bindings for link access property lists
+    auto cls = py::class_<LAPL, PropList>(
+        // in scope
+        m,
+        // class name
+        "LAPL",
+        // docstring
+        "a link access property list");
+
+    // static properties
+    cls.def_property_readonly_static(
+        // the name
+        "default",
+        // the implementation
+        [](const py::object &) {
+            // easy enough
+            return &LAPL::DEFAULT;
+        },
+        // docstring
+        "the default link access property list");
+
+    // constructor
+    cls.def(
+        // the implementation
+        py::init(),
+        // the docstring
+        "build a link access property list");
+
+    // interface
+    // set the number of allowed link traversals
+    cls.def(
+        // the name
+        "getNumLinks",
+        // the implementation
+        &LAPL::getNumLinks,
+        // the docstring
+        "get the number of allowed link traversals");
+    // set the number of allowed link traversals
+    cls.def(
+        // the name
+        "setNumLinks",
+        // the implementation
+        &LAPL::setNumLinks,
+        // the signature
+        "links"_a,
+        // the docstring
+        "set the number of allowed link traversals");
+
+    // all done
+    return;
+}
+
+
+// end of file

--- a/extensions/h5/LCPL.cc
+++ b/extensions/h5/LCPL.cc
@@ -77,7 +77,7 @@ pyre::h5::py::lcpl(py::module & m)
         // the implementation
         &LCPL::setCharEncoding,
         // the signature
-        "create"_a,
+        "encoding"_a,
         // the docstring
         "set the string character encoding");
 

--- a/extensions/h5/LCPL.cc
+++ b/extensions/h5/LCPL.cc
@@ -1,0 +1,89 @@
+// -*- c++ -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2023 all rights reserved
+
+
+// externals
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// link creation property lists
+void
+pyre::h5::py::lcpl(py::module & m)
+{
+    // add bindings for link creation property lists
+    auto cls = py::class_<LCPL, PropList>(
+        // in scope
+        m,
+        // class name
+        "LCPL",
+        // docstring
+        "a link creation property list");
+
+    // static properties
+    cls.def_property_readonly_static(
+        // the name
+        "default",
+        // the implementation
+        [](const py::object &) {
+            // easy enough
+            return &LCPL::DEFAULT;
+        },
+        // docstring
+        "the default link creation property list");
+
+    // constructor
+    cls.def(
+        // the implementation
+        py::init(),
+        // the docstring
+        "build a link creation property list");
+
+    // interface
+    // set the intermediate group creation strategy
+    cls.def(
+        // the name
+        "getCreateIntermediateGroup",
+        // the implementation
+        &LCPL::getCreateIntermediateGroup,
+        // the docstring
+        "get the intermediate group creation strategy");
+    // set the intermediate group creation strategy
+    cls.def(
+        // the name
+        "setCreateIntermediateGroup",
+        // the implementation
+        &LCPL::setCreateIntermediateGroup,
+        // the signature
+        "create"_a,
+        // the docstring
+        "set the intermediate group creation strategy");
+
+    // set the string character encoding
+    cls.def(
+        // the name
+        "getCharEncoding",
+        // the implementation
+        &LCPL::getCharEncoding,
+        // the docstring
+        "get the string character encoding");
+    // set the string character encoding
+    cls.def(
+        // the name
+        "setCharEncoding",
+        // the implementation
+        &LCPL::setCharEncoding,
+        // the signature
+        "create"_a,
+        // the docstring
+        "set the string character encoding");
+
+    // all done
+    return;
+}
+
+
+// end of file

--- a/extensions/h5/PropList.cc
+++ b/extensions/h5/PropList.cc
@@ -1,0 +1,95 @@
+// externals
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// property lists
+void
+pyre::h5::py::pl(py::module & m)
+{
+    // add bindings for hdf5 property lists
+    auto cls = py::class_<PropList>(
+        // in scope
+        m,
+        // class name
+        "PL",
+        // docstring
+        "a basic property list");
+
+    // constructor
+    cls.def(
+        // the implementation
+        py::init(),
+        // the docstring
+        "create a property list");
+
+    // properties
+    cls.def_property_readonly(
+        // the name
+        "hid",
+        // the implementation
+        &PropList::getId,
+        // the docstring
+        "get my h5 handle id");
+
+    // metamethods
+    cls.def(
+        // the name
+        "__len__",
+        // the implementation
+        &PropList::getNumProps,
+        // the docstring
+        "the number of properties in this list");
+
+    cls.def(
+        // the name
+        "__in__",
+        // the implementation
+        py::overload_cast<const string_t &>(&PropList::propExist, py::const_),
+        // the signature
+        "name"_a,
+        // the docstring
+        "check whether {name} is a known property in this list");
+
+    cls.def(
+        // the name
+        "__getitem__",
+        // the implementation
+        py::overload_cast<const string_t &>(&PropList::getProperty, py::const_),
+        // the signature
+        "name"_a,
+        // the docstring
+        "get the property associated with {name}");
+
+    cls.def(
+        // the name
+        "__setitem__",
+        // the implementation
+        py::overload_cast<const string_t &, const string_t &>(&PropList::setProperty, py::const_),
+        // the signature
+        "name"_a, "value"_a,
+        // the docstring
+        "set the property {name} to {value}");
+
+    cls.def(
+        // the name
+        "__delitem__",
+        // the implementation
+        py::overload_cast<const string_t &>(&PropList::removeProp, py::const_),
+        // the signature
+        "name"_a,
+        // the docstring
+        "delete the property associated with {name}");
+
+    // close the list
+    cls.def(
+        // the name
+        "close",
+        // the implementation
+        &PropList::close,
+        // the docstring
+        "discard the property list");
+}
+
+// end of file

--- a/extensions/h5/PropList.cc
+++ b/extensions/h5/PropList.cc
@@ -44,7 +44,7 @@ pyre::h5::py::pl(py::module & m)
 
     cls.def(
         // the name
-        "__in__",
+        "__contains__",
         // the implementation
         py::overload_cast<const string_t &>(&PropList::propExist, py::const_),
         // the signature

--- a/extensions/h5/PropList.cc
+++ b/extensions/h5/PropList.cc
@@ -82,6 +82,18 @@ pyre::h5::py::pl(py::module & m)
         // the docstring
         "delete the property associated with {name}");
 
+    // interface
+    // get the size of a property
+    cls.def(
+        // the name
+        "getPropertySize",
+        // the implementation
+        py::overload_cast<const string_t &>(&PropList::getPropSize, py::const_),
+        // the signature
+        "name"_a,
+        // the docstring
+        "retrieve the size of the named property");
+
     // close the list
     cls.def(
         // the name

--- a/extensions/h5/__init__.cc
+++ b/extensions/h5/__init__.cc
@@ -25,6 +25,7 @@ PYBIND11_MODULE(h5, m)
     // enums
     pyre::h5::py::enums(m);
     // property lists
+    pyre::h5::py::pl(m);
     pyre::h5::py::fapl(m);
 
     // subpackages

--- a/extensions/h5/__init__.cc
+++ b/extensions/h5/__init__.cc
@@ -31,6 +31,7 @@ PYBIND11_MODULE(h5, m)
     pyre::h5::py::dxpl(m);
     pyre::h5::py::fapl(m);
     pyre::h5::py::fcpl(m);
+    pyre::h5::py::lcpl(m);
 
     // subpackages
     pyre::h5::py::datatypes::__init__(m);

--- a/extensions/h5/__init__.cc
+++ b/extensions/h5/__init__.cc
@@ -26,6 +26,7 @@ PYBIND11_MODULE(h5, m)
     pyre::h5::py::enums(m);
     // property lists
     pyre::h5::py::pl(m);
+    pyre::h5::py::fcpl(m);
     pyre::h5::py::fapl(m);
 
     // subpackages

--- a/extensions/h5/__init__.cc
+++ b/extensions/h5/__init__.cc
@@ -31,6 +31,7 @@ PYBIND11_MODULE(h5, m)
     pyre::h5::py::dxpl(m);
     pyre::h5::py::fapl(m);
     pyre::h5::py::fcpl(m);
+    pyre::h5::py::lapl(m);
     pyre::h5::py::lcpl(m);
 
     // subpackages

--- a/extensions/h5/__init__.cc
+++ b/extensions/h5/__init__.cc
@@ -28,6 +28,7 @@ PYBIND11_MODULE(h5, m)
     pyre::h5::py::pl(m);
     pyre::h5::py::dapl(m);
     pyre::h5::py::dcpl(m);
+    pyre::h5::py::dxpl(m);
     pyre::h5::py::fapl(m);
     pyre::h5::py::fcpl(m);
 

--- a/extensions/h5/__init__.cc
+++ b/extensions/h5/__init__.cc
@@ -26,9 +26,10 @@ PYBIND11_MODULE(h5, m)
     pyre::h5::py::enums(m);
     // property lists
     pyre::h5::py::pl(m);
+    pyre::h5::py::dapl(m);
     pyre::h5::py::dcpl(m);
-    pyre::h5::py::fcpl(m);
     pyre::h5::py::fapl(m);
+    pyre::h5::py::fcpl(m);
 
     // subpackages
     pyre::h5::py::datatypes::__init__(m);

--- a/extensions/h5/__init__.cc
+++ b/extensions/h5/__init__.cc
@@ -26,6 +26,7 @@ PYBIND11_MODULE(h5, m)
     pyre::h5::py::enums(m);
     // property lists
     pyre::h5::py::pl(m);
+    pyre::h5::py::dcpl(m);
     pyre::h5::py::fcpl(m);
     pyre::h5::py::fapl(m);
 

--- a/extensions/h5/api.cc
+++ b/extensions/h5/api.cc
@@ -22,7 +22,7 @@ pyre::h5::py::api(py::module & m)
         []() -> void {
             // turn off the native diagnostics; we commit to catching all exceptions and
             // generating our own messages
-            H5::Exception::dontPrint();
+            // H5::Exception::dontPrint();
             // all done
             return;
         },

--- a/extensions/h5/datatypes/native.cc
+++ b/extensions/h5/datatypes/native.cc
@@ -87,7 +87,7 @@ pyre::h5::py::datatypes::native(py::module & m)
     // save it
     native.attr("half") = nh;
     // allocate the complex type
-    auto ch = H5::CompType(2 + nh.getSize());
+    auto ch = H5::CompType(2 * nh.getSize());
     // insert the real and imaginary parts
     ch.insertMember("r", 0, nh);
     ch.insertMember("i", nh.getSize(), nh);

--- a/extensions/h5/enums.cc
+++ b/extensions/h5/enums.cc
@@ -14,6 +14,15 @@
 void
 pyre::h5::py::enums(py::module & m)
 {
+    // dataset space allocation timing
+    py::enum_<H5D_alloc_time_t>(m, "AllocTime", "the timing for allocating dataset space")
+        // add the values
+        .value("error", H5D_ALLOC_TIME_ERROR)
+        .value("default", H5D_ALLOC_TIME_DEFAULT)
+        .value("early", H5D_ALLOC_TIME_EARLY)
+        .value("late", H5D_ALLOC_TIME_LATE)
+        .value("incr", H5D_ALLOC_TIME_INCR);
+
     // dataset fill timing
     py::enum_<H5D_fill_time_t>(m, "FillTime", "the timing for writing the dataset fill value")
         // add the values
@@ -29,6 +38,15 @@ pyre::h5::py::enums(py::module & m)
         .value("undefined", H5D_FILL_VALUE_UNDEFINED)
         .value("default", H5D_FILL_VALUE_DEFAULT)
         .value("user_defined", H5D_FILL_VALUE_USER_DEFINED);
+
+    // dataset layout strategy
+    py::enum_<H5D_layout_t>(m, "Layout", "dataset layout strategies")
+        .value("error", H5D_LAYOUT_ERROR)
+        .value("compact", H5D_COMPACT)
+        .value("contiguous", H5D_CONTIGUOUS)
+        .value("chunked", H5D_CHUNKED)
+        .value("virtual", H5D_VIRTUAL)
+        .value("layouts", H5D_NLAYOUTS);
 
     // file space handling strategies
     py::enum_<H5F_fspace_strategy_t>(m, "FilespaceStrategy", "the file space strategies")

--- a/extensions/h5/enums.cc
+++ b/extensions/h5/enums.cc
@@ -14,6 +14,28 @@
 void
 pyre::h5::py::enums(py::module & m)
 {
+    // dataset fill timing
+    py::enum<H5D_fill_time_t>(m, "FillTime", "the timing for writing the dataset fill value")
+        .value("error", H5D_FILL_TIME_ERROR)
+        .value("alloc", H5D_FILL_TIME_ALLOC)
+        .value("never", H5D_FILL_TIME_NEVER)
+        .value("if_set", H5D_FILL_TIME_IFSET);
+
+    // dataset fill value
+    py::enum<H5D_fill_value_t>(m, "FillValue", "fill value strategies")
+        .value("error", H5D_FILL_VALUE_ERROR)
+        .value("undefined", H5D_FILL_VALUE_UNDEFINED)
+        .value("default", H5D_FILL_VALUE_DEFAULT)
+        .value("user_defined", H5D_FILL_VALUE_USER_DEFINED);
+
+    // file space handling strategies
+    py::enum_<H5F_fspace_strategy_t>(m, "FilespaceStrategy", "the file space strategies")
+        .value("fsm_aggr", H5F_FSPACE_STRATEGY_FSM_AGGR)
+        .value("page", H5F_FSPACE_STRATEGY_PAGE)
+        .value("aggr", H5F_FSPACE_STRATEGY_AGGR)
+        .value("none", H5F_FSPACE_STRATEGY_NONE)
+        .value("types", H5F_FSPACE_STRATEGY_NTYPES);
+
     // identifier types
     py::enum_<H5I_type_t>(m, "IdentifierType", "the types of h5 identifiers")
         // add the values
@@ -57,23 +79,6 @@ pyre::h5::py::enums(py::module & m)
 #endif
         .value("types", H5O_TYPE_NTYPES);
 
-    // dataset types
-    py::enum_<H5T_class_t>(m, "DataSetType", "the types of h5 datasets")
-        // add the values
-        .value("error", H5T_NO_CLASS)
-        .value("int", H5T_INTEGER)
-        .value("float", H5T_FLOAT)
-        .value("timestamp", H5T_TIME)
-        .value("str", H5T_STRING)
-        .value("bits", H5T_BITFIELD)
-        .value("opaque", H5T_OPAQUE)
-        .value("compound", H5T_COMPOUND)
-        .value("ref", H5T_REFERENCE)
-        .value("enum", H5T_ENUM)
-        .value("vlen", H5T_VLEN)
-        .value("array", H5T_ARRAY)
-        .value("classes", H5T_NCLASSES);
-
     // dataspace types
     py::enum_<H5S_class_t>(m, "DataSpaceType", "the types of h5 dataspaces")
         // add the values
@@ -95,38 +100,22 @@ pyre::h5::py::enums(py::module & m)
         .value("prepend", H5S_SELECT_PREPEND)
         .value("invalid", H5S_SELECT_INVALID);
 
-    // byte packing order
-    py::enum_<H5T_order_t>(m, "ByteOrder", "the byte packing strategies")
+    // dataset types
+    py::enum_<H5T_class_t>(m, "DataSetType", "the types of h5 datasets")
         // add the values
-        .value("error", H5T_ORDER_ERROR)
-        .value("littleEndian", H5T_ORDER_LE)
-        .value("bigEndian", H5T_ORDER_BE)
-        .value("vax", H5T_ORDER_VAX)
-        .value("mixed", H5T_ORDER_MIXED)
-        .value("none", H5T_ORDER_NONE);
-
-    // integer sign schemes
-    py::enum_<H5T_sign_t>(m, "Sign", "the sign schemes")
-        .value("error", H5T_SGN_ERROR)
-        .value("unsigned", H5T_SGN_NONE) // unsigned types
-        .value("complement", H5T_SGN_2)  // two's complement
-        .value("null", H5T_NSGN);
-
-    // datatype bit padding types
-    py::enum_<H5T_pad_t>(m, "PaddingType", "the bit padding strategies")
-        // add the values
-        .value("error", H5T_PAD_ERROR)
-        .value("zero", H5T_PAD_ZERO)
-        .value("one", H5T_PAD_ONE)
-        .value("background", H5T_PAD_BACKGROUND);
-
-    // floating point mantissa normalization strategies
-    py::enum_<H5T_norm_t>(m, "NormalizationType", "the mantissa normalization strategies")
-        // add the values
-        .value("error", H5T_NORM_ERROR)
-        .value("implied", H5T_NORM_IMPLIED)
-        .value("set", H5T_NORM_MSBSET)
-        .value("none", H5T_NORM_NONE);
+        .value("error", H5T_NO_CLASS)
+        .value("int", H5T_INTEGER)
+        .value("float", H5T_FLOAT)
+        .value("timestamp", H5T_TIME)
+        .value("str", H5T_STRING)
+        .value("bits", H5T_BITFIELD)
+        .value("opaque", H5T_OPAQUE)
+        .value("compound", H5T_COMPOUND)
+        .value("ref", H5T_REFERENCE)
+        .value("enum", H5T_ENUM)
+        .value("vlen", H5T_VLEN)
+        .value("array", H5T_ARRAY)
+        .value("classes", H5T_NCLASSES);
 
     // string character sets
     py::enum_<H5T_cset_t>(m, "CharacterSet", "the string character sets")
@@ -148,6 +137,39 @@ pyre::h5::py::enums(py::module & m)
         .value("reserved_14", H5T_CSET_RESERVED_14)
         .value("reserved_15", H5T_CSET_RESERVED_15);
 
+    // floating point mantissa normalization strategies
+    py::enum_<H5T_norm_t>(m, "NormalizationType", "the mantissa normalization strategies")
+        // add the values
+        .value("error", H5T_NORM_ERROR)
+        .value("implied", H5T_NORM_IMPLIED)
+        .value("set", H5T_NORM_MSBSET)
+        .value("none", H5T_NORM_NONE);
+
+    // byte packing order
+    py::enum_<H5T_order_t>(m, "ByteOrder", "the byte packing strategies")
+        // add the values
+        .value("error", H5T_ORDER_ERROR)
+        .value("littleEndian", H5T_ORDER_LE)
+        .value("bigEndian", H5T_ORDER_BE)
+        .value("vax", H5T_ORDER_VAX)
+        .value("mixed", H5T_ORDER_MIXED)
+        .value("none", H5T_ORDER_NONE);
+
+    // datatype bit padding types
+    py::enum_<H5T_pad_t>(m, "PaddingType", "the bit padding strategies")
+        // add the values
+        .value("error", H5T_PAD_ERROR)
+        .value("zero", H5T_PAD_ZERO)
+        .value("one", H5T_PAD_ONE)
+        .value("background", H5T_PAD_BACKGROUND);
+
+    // integer sign schemes
+    py::enum_<H5T_sign_t>(m, "Sign", "the sign schemes")
+        .value("error", H5T_SGN_ERROR)
+        .value("unsigned", H5T_SGN_NONE) // unsigned types
+        .value("complement", H5T_SGN_2)  // two's complement
+        .value("null", H5T_NSGN);
+
     // string padding shemes
     py::enum_<H5T_str_t>(m, "StringPadding", "the string padding schemes")
         .value("error", H5T_STR_ERROR)
@@ -167,14 +189,6 @@ pyre::h5::py::enums(py::module & m)
         .value("reserved_13", H5T_STR_RESERVED_13)
         .value("reserved_14", H5T_STR_RESERVED_14)
         .value("reserved_15", H5T_STR_RESERVED_15);
-
-    // file space handling strategies
-    py::enum_<H5F_fspace_strategy_t>(m, "FilespaceStrategy", "the file space strategies")
-        .value("fsm_aggr", H5F_FSPACE_STRATEGY_FSM_AGGR)
-        .value("page", H5F_FSPACE_STRATEGY_PAGE)
-        .value("aggr", H5F_FSPACE_STRATEGY_AGGR)
-        .value("none", H5F_FSPACE_STRATEGY_NONE)
-        .value("types", H5F_FSPACE_STRATEGY_NTYPES);
 
 
     // all done

--- a/extensions/h5/enums.cc
+++ b/extensions/h5/enums.cc
@@ -15,14 +15,16 @@ void
 pyre::h5::py::enums(py::module & m)
 {
     // dataset fill timing
-    py::enum<H5D_fill_time_t>(m, "FillTime", "the timing for writing the dataset fill value")
+    py::enum_<H5D_fill_time_t>(m, "FillTime", "the timing for writing the dataset fill value")
+        // add the values
         .value("error", H5D_FILL_TIME_ERROR)
         .value("alloc", H5D_FILL_TIME_ALLOC)
         .value("never", H5D_FILL_TIME_NEVER)
         .value("if_set", H5D_FILL_TIME_IFSET);
 
     // dataset fill value
-    py::enum<H5D_fill_value_t>(m, "FillValue", "fill value strategies")
+    py::enum_<H5D_fill_value_t>(m, "FillValue", "fill value strategies")
+        // add the values
         .value("error", H5D_FILL_VALUE_ERROR)
         .value("undefined", H5D_FILL_VALUE_UNDEFINED)
         .value("default", H5D_FILL_VALUE_DEFAULT)

--- a/extensions/h5/enums.cc
+++ b/extensions/h5/enums.cc
@@ -168,6 +168,14 @@ pyre::h5::py::enums(py::module & m)
         .value("reserved_14", H5T_STR_RESERVED_14)
         .value("reserved_15", H5T_STR_RESERVED_15);
 
+    // file space handling strategies
+    py::enum_<H5F_fspace_strategy_t>(m, "FilespaceStrategy", "the file space strategies")
+        .value("fsm_aggr", H5F_FSPACE_STRATEGY_FSM_AGGR)
+        .value("page", H5F_FSPACE_STRATEGY_PAGE)
+        .value("aggr", H5F_FSPACE_STRATEGY_AGGR)
+        .value("none", H5F_FSPACE_STRATEGY_NONE)
+        .value("types", H5F_FSPACE_STRATEGY_NTYPES);
+
 
     // all done
     return;

--- a/extensions/h5/enums.cc
+++ b/extensions/h5/enums.cc
@@ -190,7 +190,7 @@ pyre::h5::py::enums(py::module & m)
         .value("complement", H5T_SGN_2)  // two's complement
         .value("null", H5T_NSGN);
 
-    // string padding shemes
+    // string padding schemes
     py::enum_<H5T_str_t>(m, "StringPadding", "the string padding schemes")
         .value("error", H5T_STR_ERROR)
         .value("null_terminated", H5T_STR_NULLTERM)
@@ -209,7 +209,6 @@ pyre::h5::py::enums(py::module & m)
         .value("reserved_13", H5T_STR_RESERVED_13)
         .value("reserved_14", H5T_STR_RESERVED_14)
         .value("reserved_15", H5T_STR_RESERVED_15);
-
 
     // all done
     return;

--- a/extensions/h5/external.h
+++ b/extensions/h5/external.h
@@ -69,6 +69,7 @@ namespace pyre::h5::py {
     using DXPL = H5::DSetMemXferPropList;
     using FAPL = H5::FileAccPropList;
     using FCPL = H5::FileCreatPropList;
+    using LAPL = H5::LinkAccPropList;
     using LCPL = H5::LinkCreatPropList;
     // dataspaces derive from {Identifier}
     using DataSpace = H5::DataSpace;

--- a/extensions/h5/external.h
+++ b/extensions/h5/external.h
@@ -45,6 +45,7 @@ namespace pyre::h5::py {
 
     // aliases for common STL classes
     using string_t = std::string;
+    using names_t = std::vector<string_t>;
     using ints_t = std::vector<long>;
     using doubles_t = std::vector<double>;
     using strings_t = std::vector<string_t>;

--- a/extensions/h5/external.h
+++ b/extensions/h5/external.h
@@ -17,6 +17,7 @@
 #include <pyre/h5.h>
 #include <pyre/journal.h>
 #include <pyre/memory.h>
+#include <pyre/grid.h>
 // pybind11
 #include <pybind11/pybind11.h>
 #include <pybind11/complex.h>
@@ -101,6 +102,31 @@ namespace pyre::h5::py {
     using heap_double_t = pyre::memory::heap_t<double>;
     using heap_complexfloat_t = pyre::memory::heap_t<std::complex<float>>;
     using heap_complexdouble_t = pyre::memory::heap_t<std::complex<double>>;
+
+    using int8_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<int8_t>>;
+    using int16_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<int16_t>>;
+    using int32_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<int32_t>>;
+    using int64_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<int64_t>>;
+    using uint8_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<uint8_t>>;
+    using uint16_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<uint16_t>>;
+    using uint32_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<uint32_t>>;
+    using uint64_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<uint64_t>>;
+    using float_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<float>>;
+    using double_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<double>>;
+    using complexfloat_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<std::complex<float>>>;
+    using complexdouble_heapgrid_2d_t =
+        pyre::grid::grid_t<pyre::grid::canonical_t<2>, pyre::memory::heap_t<std::complex<double>>>;
 
 } // namespace pyre::h5::py
 

--- a/extensions/h5/external.h
+++ b/extensions/h5/external.h
@@ -66,6 +66,7 @@ namespace pyre::h5::py {
     using PropList = H5::PropList;
     using DAPL = H5::DSetAccPropList;
     using DCPL = H5::DSetCreatPropList;
+    using DXPL = H5::DSetMemXferPropList;
     using FAPL = H5::FileAccPropList;
     using FCPL = H5::FileCreatPropList;
     // dataspaces derive from {Identifier}

--- a/extensions/h5/external.h
+++ b/extensions/h5/external.h
@@ -64,6 +64,7 @@ namespace pyre::h5::py {
     using Identifier = H5::IdComponent; // pure virtual
     // property lists derive from {Identifier}
     using PropList = H5::PropList;
+    using DAPL = H5::DSetAccPropList;
     using DCPL = H5::DSetCreatPropList;
     using FAPL = H5::FileAccPropList;
     using FCPL = H5::FileCreatPropList;

--- a/extensions/h5/external.h
+++ b/extensions/h5/external.h
@@ -69,6 +69,7 @@ namespace pyre::h5::py {
     using DXPL = H5::DSetMemXferPropList;
     using FAPL = H5::FileAccPropList;
     using FCPL = H5::FileCreatPropList;
+    using LCPL = H5::LinkCreatPropList;
     // dataspaces derive from {Identifier}
     using DataSpace = H5::DataSpace;
     // locations derive from {Identifier}

--- a/extensions/h5/external.h
+++ b/extensions/h5/external.h
@@ -64,6 +64,7 @@ namespace pyre::h5::py {
     using Identifier = H5::IdComponent; // pure virtual
     // property lists derive from {Identifier}
     using PropList = H5::PropList;
+    using DCPL = H5::DSetCreatPropList;
     using FAPL = H5::FileAccPropList;
     using FCPL = H5::FileCreatPropList;
     // dataspaces derive from {Identifier}

--- a/extensions/h5/external.h
+++ b/extensions/h5/external.h
@@ -63,8 +63,8 @@ namespace pyre::h5::py {
     using Identifier = H5::IdComponent; // pure virtual
     // property lists derive from {Identifier}
     using PropList = H5::PropList;
-    using FileAccessPropertyList = H5::FileAccPropList;
-    using FileCreatePropertyList = H5::FileCreatPropList;
+    using FAPL = H5::FileAccPropList;
+    using FCPL = H5::FileCreatPropList;
     // dataspaces derive from {Identifier}
     using DataSpace = H5::DataSpace;
     // locations derive from {Identifier}

--- a/extensions/h5/forward.h
+++ b/extensions/h5/forward.h
@@ -18,6 +18,7 @@ namespace pyre::h5::py {
     void enums(py::module &);
     // property lists
     void pl(py::module &);
+    void dcpl(py::module &);
     void fcpl(py::module &);
     void fapl(py::module &);
     // datasets

--- a/extensions/h5/forward.h
+++ b/extensions/h5/forward.h
@@ -14,12 +14,17 @@ namespace pyre::h5::py {
     void api(py::module &);
 
     // wrappers for the C++ HDF5 api
+    // support
     void enums(py::module &);
+    // property lists
+    void pl(py::module &);
+    void fapl(py::module &);
+    // datasets
     void dataspace(py::module &);
     void dataset(py::module &);
-    void fapl(py::module &);
-    void file(py::module &);
+    // structural
     void group(py::module &);
+    void file(py::module &);
 } // namespace pyre::h5::py
 
 

--- a/extensions/h5/forward.h
+++ b/extensions/h5/forward.h
@@ -20,6 +20,7 @@ namespace pyre::h5::py {
     void pl(py::module &);
     void dapl(py::module &);
     void dcpl(py::module &);
+    void dxpl(py::module &);
     void fapl(py::module &);
     void fcpl(py::module &);
     // datasets

--- a/extensions/h5/forward.h
+++ b/extensions/h5/forward.h
@@ -18,6 +18,7 @@ namespace pyre::h5::py {
     void enums(py::module &);
     // property lists
     void pl(py::module &);
+    void fcpl(py::module &);
     void fapl(py::module &);
     // datasets
     void dataspace(py::module &);

--- a/extensions/h5/forward.h
+++ b/extensions/h5/forward.h
@@ -23,6 +23,7 @@ namespace pyre::h5::py {
     void dxpl(py::module &);
     void fapl(py::module &);
     void fcpl(py::module &);
+    void lapl(py::module &);
     void lcpl(py::module &);
     // datasets
     void dataspace(py::module &);

--- a/extensions/h5/forward.h
+++ b/extensions/h5/forward.h
@@ -23,6 +23,7 @@ namespace pyre::h5::py {
     void dxpl(py::module &);
     void fapl(py::module &);
     void fcpl(py::module &);
+    void lcpl(py::module &);
     // datasets
     void dataspace(py::module &);
     void dataset(py::module &);

--- a/extensions/h5/forward.h
+++ b/extensions/h5/forward.h
@@ -18,9 +18,10 @@ namespace pyre::h5::py {
     void enums(py::module &);
     // property lists
     void pl(py::module &);
+    void dapl(py::module &);
     void dcpl(py::module &);
-    void fcpl(py::module &);
     void fapl(py::module &);
+    void fcpl(py::module &);
     // datasets
     void dataspace(py::module &);
     void dataset(py::module &);

--- a/extensions/pyre/grid/grids.icc
+++ b/extensions/pyre/grid/grids.icc
@@ -54,7 +54,6 @@ pyre::py::grid::makecls(py::module & m)
     using packing_t = pyre::grid::canonical_t<dim>;
     using grid_t = pyre::grid::grid_t<packing_t, storage_t>;
 
-
     // encode the dimension
     auto d = std::to_string(dim) + "D";
     // assemble the name

--- a/lib/pyre/h5/api.h
+++ b/lib/pyre/h5/api.h
@@ -52,6 +52,12 @@ namespace pyre::h5 {
         const dataset_t & self, memT & data, const datatype_t & memtype, const shape_t & origin,
         const shape_t shape) -> void;
 
+    // support for writing from existing {pyre::grid} instances
+    template <class gridT>
+    auto writeGrid(
+        const dataset_t & self, gridT & data, const datatype_t & memtype, const shape_t & origin,
+        const shape_t shape) -> void;
+
 } // namespace pyre::h5
 
 

--- a/lib/pyre/h5/datasets.h
+++ b/lib/pyre/h5/datasets.h
@@ -143,10 +143,8 @@ pyre::h5::write(
     const dataset_t & self, memT & data, const datatype_t & memtype, const shape_t & origin,
     const shape_t shape) -> void
 {
-    // get the size of the buffer
-    hsize_t memsize = data.cells();
-    // the in-memory layout is one-dimensional
-    auto memspace = dataspace_t(1, &memsize);
+    // pretend the memory buffer is the same shape as the incoming tile
+    auto memspace = dataspace_t(shape.size(), &shape[0]);
     // make a block count
     shape_t count;
     // resize it to the same rank as the requested {shape} and fill it with ones

--- a/lib/pyre/h5/datasets.h
+++ b/lib/pyre/h5/datasets.h
@@ -135,7 +135,7 @@ pyre::h5::read(
     self.read(data.data(), memtype, memspace, filespace);
     // all done
     return;
-};
+}
 
 template <class memT>
 auto
@@ -160,7 +160,21 @@ pyre::h5::write(
     self.write(data.data(), memtype, memspace, filespace);
     // all done
     return;
-};
+}
+
+template <class gridT>
+auto
+pyre::h5::writeGrid(
+    const dataset_t & self, gridT & data, const datatype_t & memtype, const shape_t & origin,
+    const shape_t shape) -> void
+{
+    // get my storage
+    auto & storage = *data.data();
+    // access the underlying store and delegate
+    write(self, storage, memtype, origin, shape);
+    // all done
+    return;
+}
 
 
 #endif

--- a/lib/pyre/memory/Cell.icc
+++ b/lib/pyre/memory/Cell.icc
@@ -10,7 +10,7 @@
 #else
 
 
-// compute the footprint of the given number of cells
+// access privileges
 template <typename T, bool isConst>
 constexpr auto
 pyre::memory::Cell<T, isConst>::readonly() -> bool

--- a/packages/pyre/h5/api/Dataset.py
+++ b/packages/pyre/h5/api/Dataset.py
@@ -41,7 +41,7 @@ class Dataset(Object):
         Store my value
         """
         # process the incoming value and store it
-        self._value = self._pyre_layout.process(value)
+        self._value = self._pyre_layout.process(value=value, dataset=self)
         # all done
         return
 
@@ -186,15 +186,14 @@ class Dataset(Object):
         if spec is None:
             # there isn't much more i can do
             return None
-        # get my h5 handle
-        hid = self._pyre_id
         # if i don't have a connection to a file
-        if hid is None:
-            # process and return my default value; don't cache it so we can try again
-            # next time the value is requested
-            return spec.process(spec.default)
-        # if all is good, ask my spec to extract my value from the h5 store and process it
-        value = spec._pyre_pull(dataset=self)
+        if self._pyre_id is None:
+            # process my default value
+            value = spec.process(value=spec.default, dataset=self)
+        # if all is good
+        else:
+            # ask my spec to extract my value from the h5 store and process it
+            value = spec._pyre_pull(dataset=self)
         # update the cache
         self._value = value
         # and hand it off

--- a/packages/pyre/h5/api/Dataset.py
+++ b/packages/pyre/h5/api/Dataset.py
@@ -102,6 +102,30 @@ class Dataset(Object):
         # easy enough
         return self._pyre_id.type
 
+    @property
+    def dapl(self):
+        """
+        The dataset access property list
+        """
+        # easy enough
+        return self._pyre_id.dapl
+
+    @property
+    def dcpl(self):
+        """
+        The dataset creation property list
+        """
+        # easy enough
+        return self._pyre_id.dcpl
+
+    @property
+    def chunk(self):
+        """
+        The dataset chunk size
+        """
+        # easy enough
+        return self._pyre_id.dcpl.getChunk(rank=len(self.shape))
+
     # metamethods
     def __init__(self, **kwds):
         # chain up

--- a/packages/pyre/h5/api/Dataset.py
+++ b/packages/pyre/h5/api/Dataset.py
@@ -126,6 +126,14 @@ class Dataset(Object):
         # easy enough
         return self._pyre_id.dcpl.getChunk(rank=len(self.shape))
 
+    @property
+    def filters(self):
+        """
+        The dataset chunk size
+        """
+        # easy enough
+        return self._pyre_id.dcpl.getFilters()
+
     # metamethods
     def __init__(self, **kwds):
         # chain up

--- a/packages/pyre/h5/api/File.py
+++ b/packages/pyre/h5/api/File.py
@@ -102,7 +102,7 @@ class File(Group):
         # if there was no {profile} specification
         profile = "default" if profile is None else profile
         # ask for the credentials
-        id, secret = aws.credentials(profile="default")
+        id, secret, token = aws.credentials(profile="default")
         # if both are non-trivial
         if id and secret:
             # turn authentication on
@@ -116,6 +116,7 @@ class File(Group):
             region=region,
             id=id,
             key=secret,
+            token=token,
             authenticate=authenticate,
         )
         #

--- a/packages/pyre/h5/api/File.py
+++ b/packages/pyre/h5/api/File.py
@@ -102,7 +102,7 @@ class File(Group):
         # if there was no {profile} specification
         profile = "default" if profile is None else profile
         # ask for the credentials
-        id, secret, token = aws.credentials(profile="default")
+        id, secret, token = aws.credentials(profile=profile)
         # if both are non-trivial
         if id and secret:
             # turn authentication on

--- a/packages/pyre/h5/api/File.py
+++ b/packages/pyre/h5/api/File.py
@@ -56,7 +56,10 @@ class File(Group):
     # framework hooks
     # attach to local files
     def _pyre_local(
-        self, uri: pyre.primitives.pathlike, mode: str = "r", **kwds
+        self,
+        uri: pyre.primitives.pathlike,
+        mode: str = "r",
+        **kwds,
     ) -> "File":
         """
         Access the local h5 file at {uri}
@@ -79,6 +82,7 @@ class File(Group):
         key: str,
         region: str = "",
         profile: str = "default",
+        fapl: libh5.FAPL = libh5.FAPL.default,
     ) -> "File":
         """
         Access the remote dataset {key} in the given S3 {bucket} using the {ROS3} driver
@@ -103,9 +107,7 @@ class File(Group):
         else:
             # turn it off and let the ros3 driver figure it out
             authenticate = False
-        # make a file access parameter list
-        fapl = libh5.FAPL()
-        # attach the required {ros3} driver information
+        # attach the required {ros3} driver information to the fapl
         fapl.ros3(
             region=region,
             id=id,

--- a/packages/pyre/h5/api/Group.py
+++ b/packages/pyre/h5/api/Group.py
@@ -54,6 +54,16 @@ class Group(Object):
         return member
 
     def __setattr__(self, name: str, value: typing.Any) -> None:
+        # if the {name} is already registered
+        if hasattr(self, name):
+            # get the object
+            member = super().__getattribute__(name)
+            # if it is a dataset
+            if isinstance(member, Dataset):
+                # set its value
+                member.value = value
+                # and do no more
+                return
         # if {value} is an hdf5 object
         if isinstance(value, Object):
             # record it

--- a/packages/pyre/h5/api/Group.py
+++ b/packages/pyre/h5/api/Group.py
@@ -71,6 +71,12 @@ class Group(Object):
         # and make a normal assignment
         return super().__setattr__(name, value)
 
+    def __delattr__(self, name: str) -> None:
+        # forget {name}
+        self._pyre_contents.discard(name)
+        # and chain up to remove the attribute
+        return super().__delattr__(name)
+
     # member access
     def __getitem__(self, path):
         """

--- a/packages/pyre/h5/api/Reader.py
+++ b/packages/pyre/h5/api/Reader.py
@@ -56,17 +56,27 @@ class Reader:
         return inspector._pyre_inspect(h5id=anchor, path=path, query=query)
 
     # metamethods
-    def __init__(self, uri: pyre.primitives.uri, mode: str = "r", **kwds):
+    def __init__(
+        self,
+        uri: pyre.primitives.uri,
+        mode: str = "r",
+        fapl: libh5.FAPL = libh5.FAPL.default,
+        **kwds,
+    ):
         # chain up
         super().__init__(**kwds)
         # build the file object
-        self._file = self.open(uri=uri, mode=mode)
+        self._file = self._pyre_open(uri=uri, mode=mode, fapl=fapl)
         # all done
         return
 
     # implementation details
-    def open(
-        self, uri: typing.Union[pyre.primitives.uri, str], mode: str = "r", **kwds
+    def _pyre_open(
+        self,
+        uri: typing.Union[pyre.primitives.uri, str],
+        mode: str = "r",
+        fapl: libh5.FAPL = libh5.FAPL.default,
+        **kwds,
     ) -> typing.Optional[File]:
         """
         Open an h5 file object
@@ -78,7 +88,7 @@ class Reader:
         # if the {scheme} points to a local path
         if scheme == "file":
             # make a local {file} object whose path is the {address} of the {uri} and return it
-            return File()._pyre_local(uri=uri.address, mode=mode, **kwds)
+            return File()._pyre_local(uri=uri.address, mode=mode, fapl=fapl, **kwds)
         # if the {scheme} points to an {s3} bucket
         if scheme == "s3":
             # check whether the installed {h5} library supports {ros3}
@@ -102,7 +112,11 @@ class Reader:
             _, bucket, *key = pyre.primitives.path(uri.address)
             # open the remote file and return it
             return File()._pyre_ros3(
-                region=region, profile=profile, bucket=bucket, key="/".join(key)
+                fapl=fapl,
+                region=region,
+                profile=profile,
+                bucket=bucket,
+                key="/".join(key),
             )
 
         # if we get this far, the {uri} was malformed; make a channel

--- a/packages/pyre/h5/api/Reader.py
+++ b/packages/pyre/h5/api/Reader.py
@@ -10,6 +10,7 @@ import pyre
 
 # support
 from .. import libh5
+from .File import File
 from .Explorer import Explorer
 
 # typing
@@ -18,7 +19,6 @@ from .. import schema
 from .Object import Object
 from .Dataset import Dataset
 from .Group import Group
-from .File import File
 from .Inspector import Inspector
 
 # type aliases
@@ -60,7 +60,7 @@ class Reader:
         self,
         uri: pyre.primitives.uri,
         mode: str = "r",
-        fapl: libh5.FAPL = libh5.FAPL.default,
+        fapl: typing.Optional[libh5.FAPL] = None,
         **kwds,
     ):
         # chain up
@@ -75,7 +75,7 @@ class Reader:
         self,
         uri: typing.Union[pyre.primitives.uri, str],
         mode: str = "r",
-        fapl: libh5.FAPL = libh5.FAPL.default,
+        fapl: typing.Optional[libh5.FAPL] = None,
         **kwds,
     ) -> typing.Optional[File]:
         """

--- a/packages/pyre/h5/api/Writer.py
+++ b/packages/pyre/h5/api/Writer.py
@@ -68,7 +68,7 @@ class Writer:
         self,
         uri: pyre.primitives.uri,
         mode: str = "w",
-        fcpl: libh5.FCPL = libh5.FCPL.default,
+        fcpl: typing.Optional[libh5.FCPL] = None,
         **kwds,
     ):
         # chain up

--- a/packages/pyre/h5/api/Writer.py
+++ b/packages/pyre/h5/api/Writer.py
@@ -85,12 +85,12 @@ class Writer:
         """
         # form the {dataset} name as known by its parent
         name = dataset._pyre_location.name
-        # attempt to
-        try:
+        # if {name} is already present in {dst}
+        if name in dst:
             # look up the {dataset} in the output file
             hid = dst.get(path=name)
         # if it doesn't exist
-        except RuntimeError:
+        else:
             # we have to make it; ask the {dataset} for its type and shape
             datatype, dataspace = dataset._pyre_describe()
             # with these two, we can create it
@@ -106,12 +106,12 @@ class Writer:
         """
         # form the name of the target group in the output
         name = group._pyre_location.name
-        # attempt to
-        try:
-            # look up a pre-existing group
+        # if {name} is already a member of {dst}
+        if name in dst:
+            # look it up
             hid = dst.get(path=name)
         # if it doesn't exist
-        except RuntimeError:
+        else:
             # make it
             hid = dst.create(path=name)
         # now, go through the group contents

--- a/packages/pyre/h5/api/Writer.py
+++ b/packages/pyre/h5/api/Writer.py
@@ -92,7 +92,7 @@ class Writer:
         # if it doesn't exist
         else:
             # we have to make it; ask the {dataset} for its type and shape
-            datatype, dataspace = dataset._pyre_describe()
+            datatype, dataspace, *_ = dataset._pyre_describe()
             # with these two, we can create it
             hid = dst.create(path=name, type=datatype, space=dataspace)
         # we have structure; make content

--- a/packages/pyre/h5/api/Writer.py
+++ b/packages/pyre/h5/api/Writer.py
@@ -50,7 +50,7 @@ class Writer:
         if data is None:
             # i must have structure, so build it
             assembler = Assembler()
-            # by visiting the structure we are traversin
+            # by visiting the structure we are traversing
             data = assembler.visit(descriptor=query)
         # i need structure to traverse
         if query is None:
@@ -64,11 +64,17 @@ class Writer:
         return
 
     # metamethods
-    def __init__(self, uri: pyre.primitives.uri, mode: str = "w", **kwds):
+    def __init__(
+        self,
+        uri: pyre.primitives.uri,
+        mode: str = "w",
+        fcpl: libh5.FCPL = libh5.FCPL.default,
+        **kwds,
+    ):
         # chain up
         super().__init__(**kwds)
         # build the file object
-        self._file = self._pyre_open(uri=uri, mode=mode)
+        self._file = self._pyre_open(uri=uri, mode=mode, fcpl=fcpl)
         # all done
         return
 

--- a/packages/pyre/h5/api/Writer.py
+++ b/packages/pyre/h5/api/Writer.py
@@ -92,9 +92,22 @@ class Writer:
         # if it doesn't exist
         else:
             # we have to make it; ask the {dataset} for its type and shape
-            datatype, dataspace, *_ = dataset._pyre_describe()
-            # with these two, we can create it
-            hid = dst.create(path=name, type=datatype, space=dataspace)
+            datatype, dataspace, chunk, *_ = dataset._pyre_describe()
+            # creation configuration
+            dcpl = libh5.DCPL()
+            # and access configuration
+            dapl = libh5.DAPL()
+            # if the chunking strategy is non-trivial
+            if chunk:
+                # show me
+                print(f"{dataset}: {chunk=}")
+                # configure the dataset creation
+                dcpl.setChunk(chunk)
+                # MGA: what to do with the dapl chunk cache values?
+            # create the dataset
+            hid = dst.create(
+                path=name, type=datatype, space=dataspace, dcpl=dcpl, dapl=dapl
+            )
         # we have structure; make content
         dataset._pyre_write(dst=hid)
         # all done

--- a/packages/pyre/h5/memtypes/MemoryType.py
+++ b/packages/pyre/h5/memtypes/MemoryType.py
@@ -44,6 +44,36 @@ class MemoryType:
         # allocate the buffer and return it
         return allocator(cells=cells)
 
+    def grid(self, shape):
+        """
+        Allocate a grid on the heap of the given {shape}
+        """
+        # get my type tag
+        tag = self.tag
+        # get the rank
+        rank = len(shape)
+        # build the name of the shape
+        sname = f"Shape{rank}D"
+        # the name of the packing
+        cname = f"Canonical{rank}D"
+        # the name of the storage
+        mname = f"{tag}Heap"
+        # and the name of the grid
+        gname = f"{tag}HeapGrid{rank}D"
+
+        # grab the binding
+        libpyre = pyre.libpyre
+        # build the shape
+        shape = getattr(libpyre.grid, sname)(shape=shape)
+        # use it to make the packing
+        packing = getattr(libpyre.grid, cname)(shape=shape)
+        # allocate storage
+        storage = getattr(libpyre.memory, mname)(cells=shape.cells)
+        # assemble the grid
+        grid = getattr(libpyre.grid, gname)(packing=packing, storage=storage)
+        # and return it
+        return grid
+
     # metamethods
     def __str__(self):
         # use my {ctype} as my marker

--- a/packages/pyre/h5/schema/Dataset.py
+++ b/packages/pyre/h5/schema/Dataset.py
@@ -81,7 +81,7 @@ class Dataset(Descriptor):
         # as a result, their type does not depend on the value of the dataset
         type = self.disktype
         # hand off the pair
-        return type, scalar
+        return type, scalar, None
 
     # visiting
     def _pyre_identify(self, authority, **kwds):

--- a/packages/pyre/h5/schema/Schema.py
+++ b/packages/pyre/h5/schema/Schema.py
@@ -4,15 +4,11 @@
 # (c) 1998-2023 all rights reserved
 
 
-# externals
-import itertools
-
 # superclass
 from pyre.patterns.AttributeClassifier import AttributeClassifier
 
 # parts
 from .Descriptor import Descriptor
-from .Dataset import Dataset
 from .Inventory import Inventory
 
 # typing

--- a/packages/pyre/h5/typed/Array.py
+++ b/packages/pyre/h5/typed/Array.py
@@ -46,6 +46,15 @@ class Array:
         # all done
         return value
 
+    # metamethods
+    def __init__(self, chunk=None, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # record the chunking strategy
+        self.chunk = chunk
+        # all done
+        return
+
     # value synchronization
     def _pyre_pull(self, dataset):
         """
@@ -100,10 +109,12 @@ class Array:
         """
         # the type is in my schema
         type = self.disktype
-        # get the shape from the {dataset} value
+        # get the actual shape from the {dataset} value
         space = libh5.DataSpace(shape=dataset.value.shape)
+        # i may have a chunking strategy
+        chunk = self.chunk
         # hand off the pair
-        return type, space
+        return type, space, chunk
 
 
 # end of file

--- a/packages/pyre/h5/typed/Array.py
+++ b/packages/pyre/h5/typed/Array.py
@@ -17,37 +17,33 @@ class Array:
     Implementation details of the {array} dataset mixin
     """
 
-    # type info
-    # metamethods
-    def __init__(self, shape=None, **kwds):
-        # chain up the mixin hierarchy
-        super().__init__(shape=shape, **kwds)
-        # if my {shape} is trivial
-        if shape is None:
-            # the default raster object has a trivial shape
-            defaultShape = []
-        # otherwise
-        else:
-            # expand the shape, replacing unknown extents with zeros
-            defaultShape = [0 if s is Ellipsis else s for s in shape]
-        # build the default raster and attach it
-        self._default = Raster(
-            dataset=None,
-            shape=defaultShape,
-            memtype=self.memtype,
-            disktype=self.disktype,
-        )
-        # all done
-        return
-
     # interface
-    def coerce(self, value, **kwds):
+    def coerce(self, value, dataset, **kwds):
         """
         Convert {value} into an array
         """
         # this is sufficiently high up in the conversion process to suffice; the only thing higher
         # is {process}, and its implementation in {schema} just delegates to {coerce} immediately;
-        # so, leave alone, for now
+        # if value is trivial
+        if value is self._default:
+            # get my shape
+            shape = self.shape
+            # if it is trivial
+            if shape is None:
+                # replace it with an empty list
+                shape = []
+            # otherwise
+            else:
+                # expand it, replacing unknown extents with zeros
+                shape = [0 if s is Ellipsis else s for s in shape]
+            # and use it to build a default raster with my memory and on-disk reps
+            value = Raster(
+                dataset=dataset,
+                shape=shape,
+                memtype=self.memtype,
+                disktype=self.disktype,
+            )
+        # all done
         return value
 
     # value synchronization

--- a/packages/pyre/h5/typed/Bool.py
+++ b/packages/pyre/h5/typed/Bool.py
@@ -18,7 +18,7 @@ class Bool:
     # metamethods
     def __init__(self, **kwds):
         # chain up
-        super().__init__(disktype=disktypes.c_s1, memtype=memtypes.int8, **kwds)
+        super().__init__(disktype=disktypes.strType, memtype=memtypes.int8, **kwds)
         # all done
         return
 
@@ -37,11 +37,23 @@ class Bool:
         Push my cache value to disk
         """
         # grab the value and convert to a string
-        value = str(src.value)
+        value = self.string(src.value)
         # and write it out
         dst.str(value)
         # all done
         return
+
+    # information about my on-disk layout
+    def _pyre_describe(self, dataset):
+        """
+        Construct representations for my on-disk datatype and dataspace
+        """
+        # bools are string scalars
+        shape = libh5.DataSpace()
+        # with a length wide enough to hold the two possible values
+        type = self.disktype(cells=5)
+        # hand off the pair
+        return type, shape
 
 
 # end of file

--- a/packages/pyre/h5/typed/Bool.py
+++ b/packages/pyre/h5/typed/Bool.py
@@ -53,7 +53,7 @@ class Bool:
         # with a length wide enough to hold the two possible values
         type = self.disktype(cells=5)
         # hand off the pair
-        return type, shape
+        return type, shape, None
 
 
 # end of file

--- a/packages/pyre/h5/typed/Container.py
+++ b/packages/pyre/h5/typed/Container.py
@@ -16,11 +16,10 @@ class Container:
 
     # metamethods
     def __init__(self, schema, shape=None, **kwds):
-        # extract my {memtype} and {disktype} from my {schema}
-        memtype = schema.memtype
-        disktype = schema.disktype
-        # chain up
-        super().__init__(schema=schema, memtype=memtype, disktype=disktype, **kwds)
+        # extract my {memtype} and {disktype} from my {schema} and chain up
+        super().__init__(
+            schema=schema, memtype=schema.memtype, disktype=schema.disktype, **kwds
+        )
         # save the shape
         self.shape = shape
         # all done

--- a/packages/pyre/h5/typed/Raster.py
+++ b/packages/pyre/h5/typed/Raster.py
@@ -57,6 +57,24 @@ class Raster:
         # and return it
         return shape
 
+    @shape.setter
+    def shape(self, shape):
+        """
+        Set my shape
+        """
+        # get my on-disk rep
+        hid = self.dataset
+        # if it is non-trivial
+        if hid is not None:
+            # disallow setting the shape
+            raise RuntimeError(
+                "can't set the shape of a raster when attached to a dataset"
+            )
+        # otherwise, record the new value
+        self._shape = shape
+        # all done
+        return
+
     @property
     def disktype(self):
         """

--- a/packages/pyre/h5/typed/Raster.py
+++ b/packages/pyre/h5/typed/Raster.py
@@ -107,6 +107,38 @@ class Raster:
         # easy enough
         return self._dataset._pyre_id.type
 
+    @property
+    def dapl(self):
+        """
+        The dataset access property list
+        """
+        # easy enough
+        return self._dataset._pyre_id.dapl
+
+    @property
+    def dcpl(self):
+        """
+        The dataset creation property list
+        """
+        # easy enough
+        return self._dataset._pyre_id.dcpl
+
+    @property
+    def chunk(self):
+        """
+        The dataset chunk size
+        """
+        # easy enough
+        return self.dcpl.getChunk(rank=len(self.shape))
+
+    @property
+    def filters(self):
+        """
+        The dataset chunk size
+        """
+        # easy enough
+        return self.dcpl.getFilters()
+
     # interface
     def read(self, shape=None, origin=None):
         """

--- a/packages/pyre/h5/typed/String.py
+++ b/packages/pyre/h5/typed/String.py
@@ -53,7 +53,7 @@ class String:
         # but the type knows the length of the value
         type = self.disktype(cells=max(1, len(self.string(dataset.value))))
         # hand off the pair
-        return type, shape
+        return type, shape, None
 
 
 # end of file

--- a/packages/pyre/h5/typed/Strings.py
+++ b/packages/pyre/h5/typed/Strings.py
@@ -18,9 +18,6 @@ class Strings(Dataset.list):
     Implementation details of the dataset mixin that supports a {list} of {str}
     """
 
-    # constants
-    typename = "strings"  # the name of my type
-
     # metamethods
     def __init__(self, schema=None, **kwds):
         # if the user didn't pick

--- a/packages/pyre/h5/typed/Strings.py
+++ b/packages/pyre/h5/typed/Strings.py
@@ -93,7 +93,7 @@ class Strings(Dataset.list):
         # and the space
         space = libh5.DataSpace(shape=shape)
         # hand the pair off
-        return type, space
+        return type, space, None
 
 
 # end of file

--- a/packages/pyre/h5/typed/Strings.py
+++ b/packages/pyre/h5/typed/Strings.py
@@ -85,7 +85,7 @@ class Strings(Dataset.list):
         """
         Construct representations for my on-disk datatype and dataspace
         """
-        # get the dataset value; it should be a list of string
+        # get the dataset value; it should be a list of strings
         value = dataset.value
         # the type width is the max of the lengths
         width = max([1] + list(map(len, value)))

--- a/packages/pyre/shells/AWS.py
+++ b/packages/pyre/shells/AWS.py
@@ -28,10 +28,12 @@ class AWS(pyre.component):
         profiles = self._profiles
         # get the id
         id = profiles[profile].get("aws_access_key_id", "")
-        # and the secret
+        # the secret
         secret = profiles[profile].get("aws_secret_access_key", "")
-        # and pass them on
-        return id, secret
+        # and the session token
+        token = profiles[profile].get("aws_session_token", "")
+        # pass them on
+        return id, secret, token
 
     def profile(self, name: str = "default"):
         """
@@ -92,6 +94,12 @@ class AWS(pyre.component):
         if key is not None:
             # override the value in the default profile
             credentials["default"]["aws_secret_access_key"] = key
+        # check whether there is a session token in the environment
+        key = os.environ.get("AWS_SESSION_TOKEN", None)
+        # if there
+        if key is not None:
+            # override the value in the default profile
+            credentials["default"]["aws_session_token"] = key
 
         # NYI: there may be profile configurations in ~/.aws.config
 

--- a/tests/pyre.pkg/h5/api/writer.py
+++ b/tests/pyre.pkg/h5/api/writer.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2023 all rights reserved
+
+
+"""
+Check that we can decorate groups with schema
+"""
+
+
+# the driver
+def test():
+    # support
+    import pyre
+    import journal
+
+    # make a channel
+    channel = journal.debug("pyre.h5.api.writer")
+
+    # declare the metadata group layout
+    class Meta(pyre.h5.schema.group):
+        """
+        A group of datasets in some HDF5 file
+        """
+
+        # something simple
+        id = pyre.h5.schema.int()
+        id.__doc__ = "a simple dataset"
+
+        # a string
+        type = pyre.h5.schema.str()
+        type.default = "SAMPLE"
+        type.__doc__ = "the data product type"
+
+        # something a bit more complicated
+        pile = pyre.h5.schema.strings()
+        pile.default = "HH", "VV"
+        pile.__doc__ = "a dataset that's a container"
+
+    # and the main group layout
+    class Root(pyre.h5.schema.group):
+        """
+        The top level group
+        """
+
+        # add the metadata
+        meta = Meta()
+
+    # instantiate the product spec
+    spec = Root(name="root")
+    # show me
+    spec._pyre_view(channel=channel)
+    # realize it
+    data = pyre.h5.api.assembler().visit(descriptor=spec)
+    # adjust it
+    data.meta.id = 7
+    data.meta.type = "SOME PRODUCT DATA TYPE"
+    data.meta.pile = "HH", "HV", "VH", "VV"
+    # show me
+    data._pyre_view(channel=channel)
+
+    # pick a filename
+    uri = "writer.h5"
+    # write the file
+    pyre.h5.write(uri=uri, data=data)
+    # read it back in
+    recovered = pyre.h5.read(uri=uri)
+
+    # check
+    assert recovered.meta.id == data.meta.id
+    assert recovered.meta.type == data.meta.type
+    assert recovered.meta.pile == data.meta.pile
+
+    # all done
+    return data
+
+
+# main
+if __name__ == "__main__":
+    # drive
+    test()
+
+
+# end of file


### PR DESCRIPTION
Added bindings for the creation and access property lists of the various high level API objects, with a focus on fine tuning the performance of h5 accesses. The effect is most dramatic for the ROS3 virtual file driver, where a few extra lines of code to control buffer and cache sizes when data products are constructed and accessed, the performance improvement is multiple orders of magnitude.