### PR TITLE
Add GCC 13 to CI matrix

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - gcc-13-ci
 jobs:
   # build and test the ref that launched this action
   build:

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -63,7 +63,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update -y
-          sudo apt-get install gcc-13
+          sudo apt-get install gcc-13 g++-13
 
       - name: python ${{matrix.python}} setup
         uses: actions/setup-python@v5

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -57,6 +57,14 @@ jobs:
           echo " -- install our dependencies"
           sudo apt install -y make cmake openssh-server libgsl-dev libopenmpi-dev libhdf5-dev
 
+      # https://github.com/actions/runner-images/issues/9866#issuecomment-2114583692
+      - name: install GCC 13
+        if: matrix.compiler == "gcc-13"
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -y
+          sudo apt-get install gcc-13
+
       - name: python ${{matrix.python}} setup
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -59,7 +59,7 @@ jobs:
 
       # https://github.com/actions/runner-images/issues/9866#issuecomment-2114583692
       - name: install GCC 13
-        if: matrix.compiler == "gcc-13"
+        if: matrix.compiler == 'gcc-13'
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update -y

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -23,7 +23,7 @@ jobs:
         target: [Debug, Release, RelWithDebInfo]
         python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         compiler: [
-          "gcc-11", "gcc-12",
+          "gcc-11", "gcc-12", "gcc-13",
           "clang-13", "clang-14"
         ]
         # define the names of the compilers
@@ -34,6 +34,9 @@ jobs:
           - compiler: gcc-12
             cc: gcc-12
             cxx: g++-12
+          - compiler: gcc-13
+            cc: gcc-13
+            cxx: g++-13
           - compiler: clang-13
             cc: clang-13
             cxx: clang++-13

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - gcc-13-ci
 jobs:
   # build and test the ref that launched this action
   build:


### PR DESCRIPTION
GCC 13 was removed from the Ubuntu 22.04 runner, so we have to install it from apt.

Successfully ran here: https://github.com/pyre/pyre/actions/runs/11490604654