### PR TITLE
Tensor

### DIFF
--- a/.cmake/pyre_tests_pyre_lib.cmake
+++ b/.cmake/pyre_tests_pyre_lib.cmake
@@ -394,6 +394,9 @@ pyre_add_definitions(tests/pyre.lib/tensor/tensor_iterators.cc ${definitions})
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_literals.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_literals.cc ${definitions})
 
+pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_matrix_assignment.cc)
+pyre_add_definitions(tests/pyre.lib/tensor/tensor_matrix_assignment.cc ${definitions})
+
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_matrix_equal.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_matrix_equal.cc ${definitions})
 

--- a/.cmake/pyre_tests_pyre_lib.cmake
+++ b/.cmake/pyre_tests_pyre_lib.cmake
@@ -355,6 +355,9 @@ set(definitions "HAVE_COMPACT_PACKINGS")
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_concepts.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_concepts.cc ${definitions})
 
+pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_contractions.cc)
+pyre_add_definitions(tests/pyre.lib/tensor/tensor_contractions.cc ${definitions})
+
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_canonical_arithmetics.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_canonical_arithmetics.cc ${definitions})
 

--- a/.cmake/pyre_tests_pyre_lib.cmake
+++ b/.cmake/pyre_tests_pyre_lib.cmake
@@ -370,6 +370,9 @@ pyre_add_definitions(tests/pyre.lib/tensor/tensor_cayley_hamilton_theorem.cc ${d
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_compact_arithmetics.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_compact_arithmetics.cc ${definitions})
 
+pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_dot.cc)
+pyre_add_definitions(tests/pyre.lib/tensor/tensor_dot.cc ${definitions})
+
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_dyadic.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_dyadic.cc ${definitions})
 

--- a/.cmake/pyre_tests_pyre_lib.cmake
+++ b/.cmake/pyre_tests_pyre_lib.cmake
@@ -406,6 +406,9 @@ pyre_add_definitions(tests/pyre.lib/tensor/tensor_matrix_product.cc ${definition
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_matrix_vector_product.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_matrix_vector_product.cc ${definitions})
 
+pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_fourth_order_contraction.cc)
+pyre_add_definitions(tests/pyre.lib/tensor/tensor_fourth_order_contraction.cc ${definitions})
+
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_print.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_print.cc ${definitions})
 

--- a/.mm/pyre.lib.tests
+++ b/.mm/pyre.lib.tests
@@ -59,6 +59,7 @@ pyre.lib.tests.drivers.exclude += \
     tensor/tensor_iterators.cc \
     tensor/tensor_linear_system.cc \
     tensor/tensor_literals.cc \
+    tensor/tensor_matrix_assignment.cc \
     tensor/tensor_matrix_equal.cc \
     tensor/tensor_matrix_norm.cc \
     tensor/tensor_matrix_vector_product.cc \

--- a/.mm/pyre.lib.tests
+++ b/.mm/pyre.lib.tests
@@ -51,6 +51,7 @@ pyre.lib.tests.drivers.exclude += \
     tensor/tensor_concepts.cc \
     tensor/tensor_contractions.cc \
     tensor/tensor_diagonal_inverse.cc \
+    tensor/tensor_dot.cc \
     tensor/tensor_dyadic.cc \
     tensor/tensor_eigenvalues.cc \
     tensor/tensor_eigenvalues_transformation.cc \

--- a/.mm/pyre.lib.tests
+++ b/.mm/pyre.lib.tests
@@ -49,10 +49,12 @@ pyre.lib.tests.drivers.exclude += \
     tensor/tensor_cayley_hamilton_theorem.cc \
     tensor/tensor_compact_arithmetics.cc \
     tensor/tensor_concepts.cc \
+    tensor/tensor_contractions.cc \
     tensor/tensor_diagonal_inverse.cc \
     tensor/tensor_dyadic.cc \
     tensor/tensor_eigenvalues.cc \
     tensor/tensor_eigenvalues_transformation.cc \
+    tensor/tensor_fourth_order_contraction.cc \
     tensor/tensor_identities.cc \
     tensor/tensor_iterators.cc \
     tensor/tensor_linear_system.cc \

--- a/benchmarks/pyre.lib/tensor/matrix_determinant.cc
+++ b/benchmarks/pyre.lib/tensor/matrix_determinant.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/matrix_norm.cc
+++ b/benchmarks/pyre.lib/tensor/matrix_norm.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/matrix_plus_matrix.cc
+++ b/benchmarks/pyre.lib/tensor/matrix_plus_matrix.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/matrix_times_matrix.cc
+++ b/benchmarks/pyre.lib/tensor/matrix_times_matrix.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/matrix_times_scalar.cc
+++ b/benchmarks/pyre.lib/tensor/matrix_times_scalar.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/matrix_times_vector.cc
+++ b/benchmarks/pyre.lib/tensor/matrix_times_vector.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/matrix_trace.cc
+++ b/benchmarks/pyre.lib/tensor/matrix_trace.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/vector_norm.cc
+++ b/benchmarks/pyre.lib/tensor/vector_norm.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/vector_plus_vector.cc
+++ b/benchmarks/pyre.lib/tensor/vector_plus_vector.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/vector_scalar_product.cc
+++ b/benchmarks/pyre.lib/tensor/vector_scalar_product.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/benchmarks/pyre.lib/tensor/vector_times_scalar.cc
+++ b/benchmarks/pyre.lib/tensor/vector_times_scalar.cc
@@ -7,7 +7,6 @@
 
 // get array
 #include <array>
-#include <iostream>
 
 // get support
 #include <pyre/timers.h>

--- a/lib/pyre/math.h
+++ b/lib/pyre/math.h
@@ -1,0 +1,21 @@
+// -*- c++ -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+
+// code guard
+#if !defined(pyre_math_h)
+#define pyre_math_h
+
+// DESIGN NOTES
+// A patch for {constexpr} transcendental functions until the llvm implementation of the standard
+// library catches up with the new C++26 standard (the gnu standard library already provides
+// support for them)
+
+// publish the interface
+#include "math/public.h"
+
+
+#endif
+
+// end of file

--- a/lib/pyre/math/externals.h
+++ b/lib/pyre/math/externals.h
@@ -1,0 +1,18 @@
+// -*- c++ -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+
+
+// code guard
+#if !defined(pyre_math_externals_h)
+#define pyre_math_externals_h
+
+
+// externals
+#include <cmath>
+
+
+#endif
+
+// end of file

--- a/lib/pyre/math/public.h
+++ b/lib/pyre/math/public.h
@@ -1,0 +1,20 @@
+// -*- c++ -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+
+
+// code guard
+#if !defined(pyre_math_public_h)
+#define pyre_math_public_h
+
+
+// external packages
+#include "externals.h"
+
+// the {constexpr} implementation of transcendental functions (until c++26)
+#include "transcendental.h"
+
+#endif
+
+// end of file

--- a/lib/pyre/math/transcendental.h
+++ b/lib/pyre/math/transcendental.h
@@ -11,203 +11,44 @@
 #define pyre_math_transcendental_h
 
 
+// TOFIX: switch to auto ->
+
 namespace pyre::math {
 
-    // helper function to compute factorial
-    constexpr double factorial(int n)
-    {
-        return (n <= 1) ? 1 : n * factorial(n - 1);
-    }
-
-    // helper function to compute power
-    constexpr double pow_helper(double base, int exp)
-    {
-        return (exp == 0) ? 1 :
-               (exp > 0)  ? base * pow_helper(base, exp - 1) :
-                            1 / pow_helper(base, -exp);
-    }
+    // function to compute factorial of an integer
+    constexpr double factorial(int n);
 
     // {constexpr} pow for integer exponents
-    constexpr double pow(double base, int exp)
-    {
-        if (std::is_constant_evaluated()) {
-            return pow_helper(base, exp);
-        } else {
-            return std::pow(base, exp);
-        }
-    }
-
-    // helper function to compute the series sum
-    constexpr double exp_series(double x, int terms = 15)
-    {
-        return (terms == 0) ? 1 : pow(x, terms) / factorial(terms) + exp_series(x, terms - 1);
-    }
+    constexpr double pow(double base, int exp);
 
     // {constexpr} exp function
-    constexpr double exp(double x)
-    {
-        if (std::is_constant_evaluated()) {
-            return exp_series(x);
-        } else {
-            return std::exp(x);
-        }
-    }
-
-    // helper function to compute log using Newton's method
-    constexpr double log_newton(double x, double guess = 1.0, int iterations = 15)
-    {
-        return (iterations == 0) ?
-                   guess :
-                   log_newton(x, guess - (exp(guess) - x) / exp(guess), iterations - 1);
-    }
+    constexpr double exp(double x);
 
     // {constexpr} log function
-    constexpr double log_helper(double x)
-    {
-        return (x < 0)  ? std::numeric_limits<double>::quiet_NaN() :
-               (x == 0) ? -std::numeric_limits<double>::infinity() :
-               (x == 1) ? 0.0 :
-                          log_newton(x);
-    }
-
-    // {constexpr} log function
-    constexpr double log(double x)
-    {
-        if (std::is_constant_evaluated()) {
-            return log_helper(x);
-        } else {
-            return std::log(x);
-        }
-    }
-
-    // helper function to compute sqrt using Newton's method
-    constexpr double sqrt_newton(double x, double guess = 1.0, int iterations = 15)
-    {
-        return (iterations == 0) ? guess :
-                                   sqrt_newton(x, 0.5 * (guess + x / guess), iterations - 1);
-    }
+    constexpr double log(double x);
 
     // {constexpr} sqrt function
-    constexpr double sqrt_helper(double x)
-    {
-        return (x < 0) ? std::numeric_limits<double>::quiet_NaN() : (x == 0) ? 0.0 : sqrt_newton(x);
-    }
-
-    // {constexpr} sqrt function
-    constexpr double sqrt(double x)
-    {
-        if (std::is_constant_evaluated()) {
-            return sqrt_helper(x);
-        } else {
-            return std::sqrt(x);
-        }
-    }
-
-    // Taylor series expansion for sine
-    constexpr double sin_taylor(double x, int terms = 15)
-    {
-        double result = 0.0;
-        double power = x;
-        for (int i = 0; i < terms; ++i) {
-            int sign = (i % 2 == 0) ? 1 : -1;
-            result += sign * power / factorial(2 * i + 1);
-            power *= x * x;
-        }
-        return result;
-    }
+    constexpr double sqrt(double x);
 
     // {constexpr} sin function
-    constexpr double sin(double x)
-    {
-        if (std::is_constant_evaluated()) {
-            return sin_taylor(x);
-        } else {
-            return std::sin(x);
-        }
-    }
-
-    // Taylor series expansion for cosine
-    constexpr double cos_taylor(double x, int terms = 15)
-    {
-        double result = 0.0;
-        double power = 1.0;
-        for (int i = 0; i < terms; ++i) {
-            int sign = (i % 2 == 0) ? 1 : -1;
-            result += sign * power / factorial(2 * i);
-            power *= x * x;
-        }
-        return result;
-    }
+    constexpr double sin(double x);
 
     // {constexpr} cos function
-    constexpr double cos(double x)
-    {
-        if (std::is_constant_evaluated()) {
-            return cos_taylor(x);
-        } else {
-            return std::cos(x);
-        }
-    }
-
-    // Taylor series expansion for tangent
-    constexpr double atan_poly(double x, int terms = 15)
-    {
-        if (x > 1.0) {
-            return M_PI / 2 - atan(1 / x);
-        } else if (x < -1.0) {
-            return -M_PI / 2 - atan(1 / x);
-        } else {
-            double result = 0.0;
-            double term = x;
-            int sign = 1;
-            for (int i = 1; i <= terms; ++i) {
-                result += sign * term / (2 * i - 1);
-                term *= x * x;
-                sign = -sign;
-            }
-            return result;
-        }
-    }
+    constexpr double cos(double x);
 
     // {constexpr} atan function
-    constexpr double atan(double x)
-    {
-        if (std::is_constant_evaluated()) {
-            return atan_poly(x);
-        } else {
-            return std::atan(x);
-        }
-    }
-
-    // Taylor series expansion for arctangent
-    constexpr double atan2_poly(double y, double x)
-    {
-        if (x > 0) {
-            return atan(y / x);
-        } else if (x < 0 && y >= 0) {
-            return atan(y / x) + M_PI;
-        } else if (x < 0 && y < 0) {
-            return atan(y / x) - M_PI;
-        } else if (x == 0 && y > 0) {
-            return M_PI / 2;
-        } else if (x == 0 && y < 0) {
-            return -M_PI / 2;
-        }
-        // undefined case when x == 0 and y == 0
-        return 0.0;
-    }
+    constexpr double atan(double x);
 
     // {constexpr} atan2 function
-    constexpr double atan2(double y, double x)
-    {
-        if (std::is_constant_evaluated()) {
-            return atan2_poly(y, x);
-        } else {
-            return std::atan2(y, x);
-        }
-    }
+    constexpr double atan2(double y, double x);
 
 } // namespace pyre::math
+
+
+// get the inline definitions
+#define pyre_tensor_transcendental_icc
+#include "transcendental.icc"
+#undef pyre_tensor_transcendental_icc
 
 
 #endif

--- a/lib/pyre/math/transcendental.h
+++ b/lib/pyre/math/transcendental.h
@@ -11,36 +11,34 @@
 #define pyre_math_transcendental_h
 
 
-// TOFIX: switch to auto ->
-
 namespace pyre::math {
 
     // function to compute factorial of an integer
-    constexpr double factorial(int n);
+    constexpr auto factorial(int n) -> double;
 
     // {constexpr} pow for integer exponents
-    constexpr double pow(double base, int exp);
+    constexpr auto pow(double base, int exp) -> double;
 
     // {constexpr} exp function
-    constexpr double exp(double x);
+    constexpr auto exp(double x) -> double;
 
     // {constexpr} log function
-    constexpr double log(double x);
+    constexpr auto log(double x) -> double;
 
     // {constexpr} sqrt function
-    constexpr double sqrt(double x);
+    constexpr auto sqrt(double x) -> double;
 
     // {constexpr} sin function
-    constexpr double sin(double x);
+    constexpr auto sin(double x) -> double;
 
     // {constexpr} cos function
-    constexpr double cos(double x);
+    constexpr auto cos(double x) -> double;
 
     // {constexpr} atan function
-    constexpr double atan(double x);
+    constexpr auto atan(double x) -> double;
 
     // {constexpr} atan2 function
-    constexpr double atan2(double y, double x);
+    constexpr auto atan2(double y, double x) -> double;
 
 } // namespace pyre::math
 

--- a/lib/pyre/math/transcendental.h
+++ b/lib/pyre/math/transcendental.h
@@ -7,11 +7,11 @@
 // Constexpr implementation of transcendental functions until C++26 implements them
 
 // code guard
-#if !defined(pyre_tensor_transcendental_h)
-#define pyre_tensor_transcendental_h
+#if !defined(pyre_math_transcendental_h)
+#define pyre_math_transcendental_h
 
 
-namespace pyre::tensor {
+namespace pyre::math {
 
     // helper function to compute factorial
     constexpr double factorial(int n)
@@ -79,7 +79,7 @@ namespace pyre::tensor {
             return std::log(x);
         }
     }
-    
+
     // helper function to compute sqrt using Newton's method
     constexpr double sqrt_newton(double x, double guess = 1.0, int iterations = 15)
     {
@@ -207,7 +207,7 @@ namespace pyre::tensor {
         }
     }
 
-} // namespace pyre::tensor
+} // namespace pyre::math
 
 
 #endif

--- a/lib/pyre/math/transcendental.icc
+++ b/lib/pyre/math/transcendental.icc
@@ -12,15 +12,15 @@
 
 
 // function to compute factorial of an integer
-constexpr double
-pyre::math::factorial(int n)
+constexpr auto
+pyre::math::factorial(int n) -> double
 {
     return (n <= 1) ? 1 : n * factorial(n - 1);
 }
 
 namespace {
     // helper function to compute power
-    constexpr double pow_helper(double base, int exp)
+    constexpr auto pow_helper(double base, int exp) -> double
     {
         return (exp == 0) ? 1 :
                (exp > 0)  ? base * pow_helper(base, exp - 1) :
@@ -29,8 +29,8 @@ namespace {
 } // namespace
 
 // {constexpr} pow for integer exponents
-constexpr double
-pyre::math::pow(double base, int exp)
+constexpr auto
+pyre::math::pow(double base, int exp) -> double
 {
     if (std::is_constant_evaluated()) {
         return pow_helper(base, exp);
@@ -41,7 +41,7 @@ pyre::math::pow(double base, int exp)
 
 namespace {
     // helper function to compute the series sum
-    constexpr double exp_series(double x, int terms = 15)
+    constexpr auto exp_series(double x, int terms = 15) -> double
     {
         return (terms == 0) ? 1 :
                               pyre::math::pow(x, terms) / pyre::math::factorial(terms)
@@ -50,8 +50,8 @@ namespace {
 } // namespace
 
 // {constexpr} exp function
-constexpr double
-pyre::math::exp(double x)
+constexpr auto
+pyre::math::exp(double x) -> double
 {
     if (std::is_constant_evaluated()) {
         return exp_series(x);
@@ -62,7 +62,7 @@ pyre::math::exp(double x)
 
 namespace {
     // helper function to compute log using Newton's method
-    constexpr double log_newton(double x, double guess = 1.0, int iterations = 15)
+    constexpr auto log_newton(double x, double guess = 1.0, int iterations = 15) -> double
     {
         return (iterations == 0) ?
                    guess :
@@ -72,7 +72,7 @@ namespace {
     }
 
     // {constexpr} log function
-    constexpr double log_helper(double x)
+    constexpr auto log_helper(double x) -> double
     {
         return (x < 0)  ? std::numeric_limits<double>::quiet_NaN() :
                (x == 0) ? -std::numeric_limits<double>::infinity() :
@@ -82,8 +82,8 @@ namespace {
 } // namespace
 
 // {constexpr} log function
-constexpr double
-pyre::math::log(double x)
+constexpr auto
+pyre::math::log(double x) -> double
 {
     if (std::is_constant_evaluated()) {
         return log_helper(x);
@@ -94,22 +94,22 @@ pyre::math::log(double x)
 
 namespace {
     // helper function to compute sqrt using Newton's method
-    constexpr double sqrt_newton(double x, double guess = 1.0, int iterations = 15)
+    constexpr auto sqrt_newton(double x, double guess = 1.0, int iterations = 15) -> double
     {
         return (iterations == 0) ? guess :
                                    sqrt_newton(x, 0.5 * (guess + x / guess), iterations - 1);
     }
 
     // {constexpr} sqrt function
-    constexpr double sqrt_helper(double x)
+    constexpr auto sqrt_helper(double x) -> double
     {
         return (x < 0) ? std::numeric_limits<double>::quiet_NaN() : (x == 0) ? 0.0 : sqrt_newton(x);
     }
 } // namespace
 
 // {constexpr} sqrt function
-constexpr double
-pyre::math::sqrt(double x)
+constexpr auto
+pyre::math::sqrt(double x) -> double
 {
     if (std::is_constant_evaluated()) {
         return sqrt_helper(x);
@@ -120,7 +120,7 @@ pyre::math::sqrt(double x)
 
 namespace {
     // Taylor series expansion for sine
-    constexpr double sin_taylor(double x, int terms = 15)
+    constexpr auto sin_taylor(double x, int terms = 15) -> double
     {
         double result = 0.0;
         double power = x;
@@ -134,8 +134,8 @@ namespace {
 } // namespace
 
 // {constexpr} sin function
-constexpr double
-pyre::math::sin(double x)
+constexpr auto
+pyre::math::sin(double x) -> double
 {
     if (std::is_constant_evaluated()) {
         return sin_taylor(x);
@@ -146,7 +146,7 @@ pyre::math::sin(double x)
 
 namespace {
     // Taylor series expansion for cosine
-    constexpr double cos_taylor(double x, int terms = 15)
+    constexpr auto cos_taylor(double x, int terms = 15) -> double
     {
         double result = 0.0;
         double power = 1.0;
@@ -160,8 +160,8 @@ namespace {
 } // namespace
 
 // {constexpr} cos function
-constexpr double
-pyre::math::cos(double x)
+constexpr auto
+pyre::math::cos(double x) -> double
 {
     if (std::is_constant_evaluated()) {
         return cos_taylor(x);
@@ -172,7 +172,7 @@ pyre::math::cos(double x)
 
 namespace {
     // Taylor series expansion for tangent
-    constexpr double atan_poly(double x, int terms = 15)
+    constexpr auto atan_poly(double x, int terms = 15) -> double
     {
         if (x > 1.0) {
             return M_PI / 2 - pyre::math::atan(1 / x);
@@ -193,8 +193,8 @@ namespace {
 } // namespace
 
 // {constexpr} atan function
-constexpr double
-pyre::math::atan(double x)
+constexpr auto
+pyre::math::atan(double x) -> double
 {
     if (std::is_constant_evaluated()) {
         return atan_poly(x);
@@ -205,7 +205,7 @@ pyre::math::atan(double x)
 
 namespace {
     // Taylor series expansion for arctangent
-    constexpr double atan2_poly(double y, double x)
+    constexpr auto atan2_poly(double y, double x) -> double
     {
         if (x > 0) {
             return pyre::math::atan(y / x);
@@ -224,8 +224,8 @@ namespace {
 } // namespace
 
 // {constexpr} atan2 function
-constexpr double
-pyre::math::atan2(double y, double x)
+constexpr auto
+pyre::math::atan2(double y, double x) -> double
 {
     if (std::is_constant_evaluated()) {
         return atan2_poly(y, x);

--- a/lib/pyre/math/transcendental.icc
+++ b/lib/pyre/math/transcendental.icc
@@ -22,9 +22,9 @@ namespace {
     // helper function to compute power
     constexpr auto pow_helper(double base, int exp) -> double
     {
-        return (exp == 0) ? 1 :
+        return (exp == 0) ? 1.0 :
                (exp > 0)  ? base * pow_helper(base, exp - 1) :
-                            1 / pow_helper(base, -exp);
+                            1.0 / pow_helper(base, -exp);
     }
 } // namespace
 
@@ -41,11 +41,11 @@ pyre::math::pow(double base, int exp) -> double
 
 namespace {
     // helper function to compute the series sum
-    constexpr auto exp_series(double x, int terms = 15) -> double
+    constexpr auto exp_taylor(double x, int terms = 15) -> double
     {
-        return (terms == 0) ? 1 :
+        return (terms == 0) ? 1.0 :
                               pyre::math::pow(x, terms) / pyre::math::factorial(terms)
-                                  + exp_series(x, terms - 1);
+                                  + exp_taylor(x, terms - 1);
     }
 } // namespace
 
@@ -54,7 +54,7 @@ constexpr auto
 pyre::math::exp(double x) -> double
 {
     if (std::is_constant_evaluated()) {
-        return exp_series(x);
+        return exp_taylor(x);
     } else {
         return std::exp(x);
     }
@@ -74,9 +74,9 @@ namespace {
     // {constexpr} log function
     constexpr auto log_helper(double x) -> double
     {
-        return (x < 0)  ? std::numeric_limits<double>::quiet_NaN() :
-               (x == 0) ? -std::numeric_limits<double>::infinity() :
-               (x == 1) ? 0.0 :
+        return (x < 0.0)  ? std::numeric_limits<double>::quiet_NaN() :
+               (x == 0.0) ? -std::numeric_limits<double>::infinity() :
+               (x == 1.0) ? 0.0 :
                           log_newton(x);
     }
 } // namespace
@@ -103,7 +103,7 @@ namespace {
     // {constexpr} sqrt function
     constexpr auto sqrt_helper(double x) -> double
     {
-        return (x < 0) ? std::numeric_limits<double>::quiet_NaN() : (x == 0) ? 0.0 : sqrt_newton(x);
+        return (x < 0.0) ? std::numeric_limits<double>::quiet_NaN() : (x == 0.0) ? 0.0 : sqrt_newton(x);
     }
 } // namespace
 
@@ -124,10 +124,11 @@ namespace {
     {
         double result = 0.0;
         double power = x;
+        int sign = 1;
         for (int i = 0; i < terms; ++i) {
-            int sign = (i % 2 == 0) ? 1 : -1;
             result += sign * power / pyre::math::factorial(2 * i + 1);
             power *= x * x;
+            sign = -sign;
         }
         return result;
     }
@@ -150,10 +151,11 @@ namespace {
     {
         double result = 0.0;
         double power = 1.0;
+        int sign = 1;
         for (int i = 0; i < terms; ++i) {
-            int sign = (i % 2 == 0) ? 1 : -1;
             result += sign * power / pyre::math::factorial(2 * i);
             power *= x * x;
+            sign = -sign;
         }
         return result;
     }
@@ -175,9 +177,9 @@ namespace {
     constexpr auto atan_poly(double x, int terms = 15) -> double
     {
         if (x > 1.0) {
-            return M_PI / 2 - pyre::math::atan(1 / x);
+            return M_PI / 2.0 - pyre::math::atan(1.0 / x);
         } else if (x < -1.0) {
-            return -M_PI / 2 - pyre::math::atan(1 / x);
+            return -M_PI / 2.0 - pyre::math::atan(1.0 / x);
         } else {
             double result = 0.0;
             double term = x;
@@ -204,19 +206,19 @@ pyre::math::atan(double x) -> double
 }
 
 namespace {
-    // Taylor series expansion for arctangent
-    constexpr auto atan2_poly(double y, double x) -> double
+    // manage the cases for the specific quadrants
+    constexpr auto atan2_helper(double y, double x) -> double
     {
-        if (x > 0) {
+        if (x > 0.0) {
             return pyre::math::atan(y / x);
-        } else if (x < 0 && y >= 0) {
+        } else if (x < 0.0 && y >= 0.0) {
             return pyre::math::atan(y / x) + M_PI;
-        } else if (x < 0 && y < 0) {
+        } else if (x < 0.0 && y < 0.0) {
             return pyre::math::atan(y / x) - M_PI;
-        } else if (x == 0 && y > 0) {
-            return M_PI / 2;
-        } else if (x == 0 && y < 0) {
-            return -M_PI / 2;
+        } else if (x == 0.0 && y > 0.0) {
+            return M_PI / 2.0;
+        } else if (x == 0.0 && y < 0.0) {
+            return -M_PI / 2.0;
         }
         // undefined case when x == 0 and y == 0
         return 0.0;
@@ -228,7 +230,7 @@ constexpr auto
 pyre::math::atan2(double y, double x) -> double
 {
     if (std::is_constant_evaluated()) {
-        return atan2_poly(y, x);
+        return atan2_helper(y, x);
     } else {
         return std::atan2(y, x);
     }

--- a/lib/pyre/math/transcendental.icc
+++ b/lib/pyre/math/transcendental.icc
@@ -1,0 +1,240 @@
+// -*- coding: utf-8 -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+//
+
+
+// code guard
+#if !defined(pyre_tensor_transcendental_icc)
+#error this file contains implementation details for math transcendental functions
+#else
+
+
+// function to compute factorial of an integer
+constexpr double
+pyre::math::factorial(int n)
+{
+    return (n <= 1) ? 1 : n * factorial(n - 1);
+}
+
+namespace {
+    // helper function to compute power
+    constexpr double pow_helper(double base, int exp)
+    {
+        return (exp == 0) ? 1 :
+               (exp > 0)  ? base * pow_helper(base, exp - 1) :
+                            1 / pow_helper(base, -exp);
+    }
+} // namespace
+
+// {constexpr} pow for integer exponents
+constexpr double
+pyre::math::pow(double base, int exp)
+{
+    if (std::is_constant_evaluated()) {
+        return pow_helper(base, exp);
+    } else {
+        return std::pow(base, exp);
+    }
+}
+
+namespace {
+    // helper function to compute the series sum
+    constexpr double exp_series(double x, int terms = 15)
+    {
+        return (terms == 0) ? 1 :
+                              pyre::math::pow(x, terms) / pyre::math::factorial(terms)
+                                  + exp_series(x, terms - 1);
+    }
+} // namespace
+
+// {constexpr} exp function
+constexpr double
+pyre::math::exp(double x)
+{
+    if (std::is_constant_evaluated()) {
+        return exp_series(x);
+    } else {
+        return std::exp(x);
+    }
+}
+
+namespace {
+    // helper function to compute log using Newton's method
+    constexpr double log_newton(double x, double guess = 1.0, int iterations = 15)
+    {
+        return (iterations == 0) ?
+                   guess :
+                   log_newton(
+                       x, guess - (pyre::math::exp(guess) - x) / pyre::math::exp(guess),
+                       iterations - 1);
+    }
+
+    // {constexpr} log function
+    constexpr double log_helper(double x)
+    {
+        return (x < 0)  ? std::numeric_limits<double>::quiet_NaN() :
+               (x == 0) ? -std::numeric_limits<double>::infinity() :
+               (x == 1) ? 0.0 :
+                          log_newton(x);
+    }
+} // namespace
+
+// {constexpr} log function
+constexpr double
+pyre::math::log(double x)
+{
+    if (std::is_constant_evaluated()) {
+        return log_helper(x);
+    } else {
+        return std::log(x);
+    }
+}
+
+namespace {
+    // helper function to compute sqrt using Newton's method
+    constexpr double sqrt_newton(double x, double guess = 1.0, int iterations = 15)
+    {
+        return (iterations == 0) ? guess :
+                                   sqrt_newton(x, 0.5 * (guess + x / guess), iterations - 1);
+    }
+
+    // {constexpr} sqrt function
+    constexpr double sqrt_helper(double x)
+    {
+        return (x < 0) ? std::numeric_limits<double>::quiet_NaN() : (x == 0) ? 0.0 : sqrt_newton(x);
+    }
+} // namespace
+
+// {constexpr} sqrt function
+constexpr double
+pyre::math::sqrt(double x)
+{
+    if (std::is_constant_evaluated()) {
+        return sqrt_helper(x);
+    } else {
+        return std::sqrt(x);
+    }
+}
+
+namespace {
+    // Taylor series expansion for sine
+    constexpr double sin_taylor(double x, int terms = 15)
+    {
+        double result = 0.0;
+        double power = x;
+        for (int i = 0; i < terms; ++i) {
+            int sign = (i % 2 == 0) ? 1 : -1;
+            result += sign * power / pyre::math::factorial(2 * i + 1);
+            power *= x * x;
+        }
+        return result;
+    }
+} // namespace
+
+// {constexpr} sin function
+constexpr double
+pyre::math::sin(double x)
+{
+    if (std::is_constant_evaluated()) {
+        return sin_taylor(x);
+    } else {
+        return std::sin(x);
+    }
+}
+
+namespace {
+    // Taylor series expansion for cosine
+    constexpr double cos_taylor(double x, int terms = 15)
+    {
+        double result = 0.0;
+        double power = 1.0;
+        for (int i = 0; i < terms; ++i) {
+            int sign = (i % 2 == 0) ? 1 : -1;
+            result += sign * power / pyre::math::factorial(2 * i);
+            power *= x * x;
+        }
+        return result;
+    }
+} // namespace
+
+// {constexpr} cos function
+constexpr double
+pyre::math::cos(double x)
+{
+    if (std::is_constant_evaluated()) {
+        return cos_taylor(x);
+    } else {
+        return std::cos(x);
+    }
+}
+
+namespace {
+    // Taylor series expansion for tangent
+    constexpr double atan_poly(double x, int terms = 15)
+    {
+        if (x > 1.0) {
+            return M_PI / 2 - pyre::math::atan(1 / x);
+        } else if (x < -1.0) {
+            return -M_PI / 2 - pyre::math::atan(1 / x);
+        } else {
+            double result = 0.0;
+            double term = x;
+            int sign = 1;
+            for (int i = 1; i <= terms; ++i) {
+                result += sign * term / (2 * i - 1);
+                term *= x * x;
+                sign = -sign;
+            }
+            return result;
+        }
+    }
+} // namespace
+
+// {constexpr} atan function
+constexpr double
+pyre::math::atan(double x)
+{
+    if (std::is_constant_evaluated()) {
+        return atan_poly(x);
+    } else {
+        return std::atan(x);
+    }
+}
+
+namespace {
+    // Taylor series expansion for arctangent
+    constexpr double atan2_poly(double y, double x)
+    {
+        if (x > 0) {
+            return pyre::math::atan(y / x);
+        } else if (x < 0 && y >= 0) {
+            return pyre::math::atan(y / x) + M_PI;
+        } else if (x < 0 && y < 0) {
+            return pyre::math::atan(y / x) - M_PI;
+        } else if (x == 0 && y > 0) {
+            return M_PI / 2;
+        } else if (x == 0 && y < 0) {
+            return -M_PI / 2;
+        }
+        // undefined case when x == 0 and y == 0
+        return 0.0;
+    }
+} // namespace
+
+// {constexpr} atan2 function
+constexpr double
+pyre::math::atan2(double y, double x)
+{
+    if (std::is_constant_evaluated()) {
+        return atan2_poly(y, x);
+    } else {
+        return std::atan2(y, x);
+    }
+}
+
+
+#endif
+
+// end of file

--- a/lib/pyre/tensor/Tensor.h
+++ b/lib/pyre/tensor/Tensor.h
@@ -80,7 +80,7 @@ namespace pyre::tensor {
         // copy constructor from a tensor with (potentially) different packing
         template <tensor_c tensorT>
         constexpr Tensor(const tensorT & rhs)
-            requires(std::is_same_v<typename sum<tensor_t, tensorT>::type, tensor_t>);
+            requires(compatible_tensor_c<tensorT, tensor_t>);
 
         // move constructor from a tensor with exact same packing
         template <tensor_c tensorT>
@@ -90,7 +90,7 @@ namespace pyre::tensor {
         // copy assignment operator from a tensor with (potentially) different packing
         template <tensor_c tensorT>
         constexpr Tensor & operator=(const tensorT & rhs)
-            requires(std::is_same_v<typename sum<tensor_t, tensorT>::type, tensor_t>);
+            requires(compatible_tensor_c<tensorT, tensor_t>);
 
         // move assignment operator from a tensor with exact same packing
         template <tensor_c tensorT>

--- a/lib/pyre/tensor/Tensor.h
+++ b/lib/pyre/tensor/Tensor.h
@@ -109,6 +109,10 @@ namespace pyre::tensor {
             return _layout.offset({ J... });
         }
 
+        // cast to atomic type T (enable the tensor is a scalar)
+        constexpr operator T() const
+            requires(scalar_c<tensor_t>);
+
         // support for ranged for loops
         constexpr const auto begin() const;
         constexpr const auto end() const;

--- a/lib/pyre/tensor/Tensor.h
+++ b/lib/pyre/tensor/Tensor.h
@@ -77,17 +77,25 @@ namespace pyre::tensor {
         template <class T2>
         constexpr Tensor(T2 (&&)[S]);
 
-        // copy constructor
-        constexpr Tensor(const Tensor &) = default;
+        // copy constructor from a tensor with (potentially) different packing
+        template <tensor_c tensorT>
+        constexpr Tensor(const tensorT & rhs)
+            requires(std::is_same_v<typename sum<tensor_t, tensorT>::type, tensor_t>);
 
-        // move constructor
-        constexpr Tensor(Tensor &&) noexcept = default;
+        // move constructor from a tensor with exact same packing
+        template <tensor_c tensorT>
+        constexpr Tensor(tensorT &&)
+            requires(std::is_same_v<tensor_t, tensorT>);
 
-        // copy assignment operator
-        constexpr Tensor & operator=(const Tensor &) = default;
+        // copy assignment operator from a tensor with (potentially) different packing
+        template <tensor_c tensorT>
+        constexpr Tensor & operator=(const tensorT & rhs)
+            requires(std::is_same_v<typename sum<tensor_t, tensorT>::type, tensor_t>);
 
-        // move assignment operator
-        constexpr Tensor & operator=(Tensor &&) noexcept = default;
+        // move assignment operator from a tensor with exact same packing
+        template <tensor_c tensorT>
+        constexpr Tensor & operator=(tensorT &&)
+            requires(std::is_same_v<tensor_t, tensorT>);
 
         // destructor
         constexpr ~Tensor();

--- a/lib/pyre/tensor/Tensor.icc
+++ b/lib/pyre/tensor/Tensor.icc
@@ -58,7 +58,7 @@ constexpr pyre::tensor::Tensor<T, packingT, I...>::Tensor(T2 (&&args)[S]) : Tens
 template <typename T, class packingT, int... I>
 template <pyre::tensor::tensor_c tensorT>
 constexpr pyre::tensor::Tensor<T, packingT, I...>::Tensor(const tensorT & rhs)
-    requires(std::is_same_v<typename sum<tensor_t, tensorT>::type, tensor_t>)
+    requires(compatible_tensor_c<tensorT, tensor_t>)
     : _data()
 {
     // assign rhs to this
@@ -81,8 +81,7 @@ template <typename T, class packingT, int... I>
 template <pyre::tensor::tensor_c tensorT>
 constexpr pyre::tensor::Tensor<T, packingT, I...> &
 pyre::tensor::Tensor<T, packingT, I...>::operator=(const tensorT & rhs)
-// TOFIX: define a concept of {compatible} tensors
-    requires(std::is_same_v<typename pyre::tensor::sum<tensor_t, tensorT>::type, tensor_t>)
+    requires(compatible_tensor_c<tensorT, tensor_t>)
 {
     // the type of tensor {lhs} (my type)
     using tensor1_t = tensor_t;

--- a/lib/pyre/tensor/Tensor.icc
+++ b/lib/pyre/tensor/Tensor.icc
@@ -98,11 +98,9 @@ pyre::tensor::Tensor<T, packingT, I...>::operator=(const tensorT & rhs)
         // helper function to assign component at offset K (enumeration relative to the {lhs} packing)
         constexpr auto _component_assignment = []<int K>(
                                                    tensor1_t & lhs, const tensor2_t & rhs) -> void {
-            // TOFIX: perhaps we should put this into a function
-            // get the index corresponding to the offset K in the canonical packing
-            constexpr auto index = tensor1_t::layout().index(K);
-            // map the index into the offset for the packing of {rhs}
-            constexpr auto K2 = tensor2_t::layout().offset(index);
+            // given {K}, offset in the {tensor1_t} packing, get the offset for the same component
+            // in the {tensor2_t} packing
+            constexpr auto K2 = map_offset<K, tensor1_t, tensor2_t>();
             // assign the right-hand side to the left-hand side
             lhs[K] = rhs[K2];
             // all done

--- a/lib/pyre/tensor/Tensor.icc
+++ b/lib/pyre/tensor/Tensor.icc
@@ -93,6 +93,13 @@ pyre::tensor::Tensor<T, packingT, I...>::operator[](int i)
 }
 
 template <typename T, class packingT, int... I>
+constexpr pyre::tensor::Tensor<T, packingT, I...>::operator T() const
+    requires(scalar_c<tensor_t>)
+{
+    return _data[0];
+}
+
+template <typename T, class packingT, int... I>
 constexpr const auto
 pyre::tensor::Tensor<T, packingT, I...>::begin() const
 {

--- a/lib/pyre/tensor/Tensor.icc
+++ b/lib/pyre/tensor/Tensor.icc
@@ -54,6 +54,90 @@ constexpr pyre::tensor::Tensor<T, packingT, I...>::Tensor(T2 (&&args)[S]) : Tens
     return;
 }
 
+// copy constructor from a tensor with (potentially) different packing
+template <typename T, class packingT, int... I>
+template <pyre::tensor::tensor_c tensorT>
+constexpr pyre::tensor::Tensor<T, packingT, I...>::Tensor(const tensorT & rhs)
+    requires(std::is_same_v<typename sum<tensor_t, tensorT>::type, tensor_t>)
+    : _data()
+{
+    // assign rhs to this
+    *this = rhs;
+
+    // all done
+    return;
+}
+
+// move constructor from a tensor with exact same packing
+template <typename T, class packingT, int... I>
+template <pyre::tensor::tensor_c tensorT>
+constexpr pyre::tensor::Tensor<T, packingT, I...>::Tensor(tensorT && other)
+    requires(std::is_same_v<tensor_t, tensorT>)
+    : _data(std::move(other._data))
+{}
+
+// copy assignment operator from a tensor with (potentially) different packing
+template <typename T, class packingT, int... I>
+template <pyre::tensor::tensor_c tensorT>
+constexpr pyre::tensor::Tensor<T, packingT, I...> &
+pyre::tensor::Tensor<T, packingT, I...>::operator=(const tensorT & rhs)
+// TOFIX: define a concept of {compatible} tensors
+    requires(std::is_same_v<typename pyre::tensor::sum<tensor_t, tensorT>::type, tensor_t>)
+{
+    // the type of tensor {lhs} (my type)
+    using tensor1_t = tensor_t;
+    // the type of tensor {rhs} (the type of the right-hand side)
+    using tensor2_t = tensorT;
+
+    // the number of components of the target tensor (lhs)
+    constexpr int D = tensor1_t::size;
+
+    // helper function to perform component-by-component assignment
+    constexpr auto _component_wise_assignment = []<int... J>(
+                                                    tensor1_t & lhs, const tensor2_t & rhs,
+                                                    pyre::tensor::integer_sequence<J...>) -> void {
+        // helper function to assign component at offset K (enumeration relative to the {lhs} packing)
+        constexpr auto _component_assignment = []<int K>(
+                                                   tensor1_t & lhs, const tensor2_t & rhs) -> void {
+            // TOFIX: perhaps we should put this into a function
+            // get the index corresponding to the offset K in the canonical packing
+            constexpr auto index = tensor1_t::layout().index(K);
+            // map the index into the offset for the packing of {rhs}
+            constexpr auto K2 = tensor2_t::layout().offset(index);
+            // assign the right-hand side to the left-hand side
+            lhs[K] = rhs[K2];
+            // all done
+            return;
+        };
+
+        // do assignment for all components
+        ((_component_assignment.template operator()<J>(lhs, rhs)), ...);
+
+        // all done
+        return;
+    };
+
+    // perform component-by-component assignment
+    _component_wise_assignment(*this, rhs, pyre::tensor::make_integer_sequence<D> {});
+
+    // all done
+    return *this;
+}
+
+// move assignment operator from a tensor with exact same packing
+template <typename T, class packingT, int... I>
+template <pyre::tensor::tensor_c tensorT>
+constexpr pyre::tensor::Tensor<T, packingT, I...> &
+pyre::tensor::Tensor<T, packingT, I...>::operator=(tensorT && other)
+    requires(std::is_same_v<tensor_t, tensorT>)
+{
+    // move the data
+    _data = std::move(other._data);
+
+    // all done
+    return *this;
+}
+
 template <typename T, class packingT, int... I>
 constexpr pyre::tensor::Tensor<T, packingT, I...>::~Tensor()
 {}

--- a/lib/pyre/tensor/UnitQuaternion.icc
+++ b/lib/pyre/tensor/UnitQuaternion.icc
@@ -34,8 +34,8 @@ constexpr pyre::tensor::UnitQuaternion<T>::UnitQuaternion(
 template <typename T>
 constexpr pyre::tensor::UnitQuaternion<T>::UnitQuaternion(
     const real_type & theta, const rotation_axis_type & axis) :
-    UnitQuaternion({ std::cos(0.5 * theta), axis[0] * std::sin(0.5 * theta),
-                     axis[1] * std::sin(0.5 * theta), axis[2] * std::sin(0.5 * theta) })
+    UnitQuaternion({ pyre::tensor::cos(0.5 * theta), axis[0] * pyre::tensor::sin(0.5 * theta),
+                     axis[1] * pyre::tensor::sin(0.5 * theta), axis[2] * pyre::tensor::sin(0.5 * theta) })
 {}
 
 template <typename T>
@@ -54,7 +54,7 @@ template <typename T>
 constexpr auto
 pyre::tensor::UnitQuaternion<T>::axis() const -> rotation_axis_type
 {
-    real_type norm = std::sqrt(_qi * _qi + _qj * _qj + _qk * _qk);
+    real_type norm = pyre::tensor::sqrt(_qi * _qi + _qj * _qj + _qk * _qk);
     return rotation_axis_type({ _qi / norm, _qj / norm, _qk / norm });
 }
 
@@ -62,7 +62,7 @@ template <typename T>
 constexpr auto
 pyre::tensor::UnitQuaternion<T>::angle() const -> real_type
 {
-    return 2.0 * std::atan2(std::sqrt(_qi * _qi + _qj * _qj + _qk * _qk), _qr);
+    return 2.0 * pyre::tensor::atan2(pyre::tensor::sqrt(_qi * _qi + _qj * _qj + _qk * _qk), _qr);
 }
 
 template <typename T>

--- a/lib/pyre/tensor/UnitQuaternion.icc
+++ b/lib/pyre/tensor/UnitQuaternion.icc
@@ -34,8 +34,9 @@ constexpr pyre::tensor::UnitQuaternion<T>::UnitQuaternion(
 template <typename T>
 constexpr pyre::tensor::UnitQuaternion<T>::UnitQuaternion(
     const real_type & theta, const rotation_axis_type & axis) :
-    UnitQuaternion({ pyre::tensor::cos(0.5 * theta), axis[0] * pyre::tensor::sin(0.5 * theta),
-                     axis[1] * pyre::tensor::sin(0.5 * theta), axis[2] * pyre::tensor::sin(0.5 * theta) })
+    UnitQuaternion({ pyre::math::cos(0.5 * theta), axis[0] * pyre::math::sin(0.5 * theta),
+                     axis[1] * pyre::math::sin(0.5 * theta),
+                     axis[2] * pyre::math::sin(0.5 * theta) })
 {}
 
 template <typename T>
@@ -54,7 +55,7 @@ template <typename T>
 constexpr auto
 pyre::tensor::UnitQuaternion<T>::axis() const -> rotation_axis_type
 {
-    real_type norm = pyre::tensor::sqrt(_qi * _qi + _qj * _qj + _qk * _qk);
+    real_type norm = pyre::math::sqrt(_qi * _qi + _qj * _qj + _qk * _qk);
     return rotation_axis_type({ _qi / norm, _qj / norm, _qk / norm });
 }
 
@@ -62,7 +63,7 @@ template <typename T>
 constexpr auto
 pyre::tensor::UnitQuaternion<T>::angle() const -> real_type
 {
-    return 2.0 * pyre::tensor::atan2(pyre::tensor::sqrt(_qi * _qi + _qj * _qj + _qk * _qk), _qr);
+    return 2.0 * pyre::math::atan2(pyre::math::sqrt(_qi * _qi + _qj * _qj + _qk * _qk), _qr);
 }
 
 template <typename T>

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -19,6 +19,11 @@ namespace pyre::tensor {
     template <tensor_c tensorT>
     constexpr auto normalize(const tensorT & tensor) -> tensorT;
 
+    // dot product of tensors
+    template <tensor_c tensorT1, tensor_c tensorT2>
+    constexpr auto dot(const tensorT1 & y1, const tensorT2 & y2)
+        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
+
     // tensors operator==
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator==(const tensorT1 & lhs, const tensorT2 & rhs) -> bool

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -232,9 +232,10 @@ namespace pyre::tensor {
     constexpr auto determinant(const matrixT & A) -> typename matrixT::scalar_type
         requires(matrixT::dims[0] == 2);
 
-    // the determinant of a scalar (1x1 improper matrix)
-    template <scalar_c scalarT>
-    constexpr auto determinant(const scalarT & A) -> typename scalarT::scalar_type;
+    // the determinant of a 1x1 matrix
+    template <square_matrix_c matrixT>
+    constexpr auto determinant(const matrixT & A) -> typename matrixT::scalar_type
+        requires(matrixT::dims[0] == 1);
 
     // the inverse of a 3x3 matrix
     template <square_matrix_c matrixT>
@@ -246,9 +247,10 @@ namespace pyre::tensor {
     constexpr auto inverse(const matrixT & A) -> matrixT
         requires(matrixT::dims[0] == 2 && !diagonal_matrix_c<matrixT>);
 
-    // the inverse of a scalar (1x1 improper matrix)
-    template <scalar_c scalarT>
-    constexpr auto inverse(const scalarT & A) -> scalarT;
+    // the inverse of a 1x1 matrix
+    template <square_matrix_c matrixT>
+    constexpr auto inverse(const matrixT & A) -> matrixT
+        requires(matrixT::dims[0] == 1 && !diagonal_matrix_c<matrixT>);
 
     // the inverse of a NxN diagonal matrix
     template <diagonal_matrix_c matrixT>
@@ -257,10 +259,6 @@ namespace pyre::tensor {
     // the trace of a matrix
     template <square_matrix_c matrixT>
     constexpr auto trace(const matrixT & A) -> typename matrixT::scalar_type;
-
-    // the trace of a scalar (1x1 improper matrix)
-    template <scalar_c scalarT>
-    constexpr auto trace(const scalarT & A) -> typename scalarT::scalar_type;
 
     // the transpose of a matrix
     template <int D1, int D2, typename T, class packingT>

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -233,11 +233,6 @@ namespace pyre::tensor {
     constexpr auto inverse(const matrixT & A) -> matrixT
         requires(matrixT::dims[0] == 2 && !diagonal_matrix_c<matrixT>);
 
-    // the inverse of a 1x1 matrix
-    template <square_matrix_c matrixT>
-    constexpr auto inverse(const matrixT & A) -> matrixT
-        requires(matrixT::dims[0] == 1);
-
     // the inverse of a NxN diagonal matrix
     template <diagonal_matrix_c matrixT>
     constexpr auto inverse(const matrixT & A) -> matrixT;

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -21,23 +21,28 @@ namespace pyre::tensor {
 
     // tensors operator==
     template <tensor_c tensorT1, tensor_c tensorT2>
-    constexpr auto operator==(const tensorT1 & lhs, const tensorT2 & rhs) -> bool;
+    constexpr auto operator==(const tensorT1 & lhs, const tensorT2 & rhs) -> bool
+        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
 
     // scalar times tensor
     template <tensor_c tensorT>
-    constexpr auto operator*(const typename tensorT::scalar_type & a, const tensorT & y) -> tensorT;
+    constexpr auto operator*(const typename tensorT::scalar_type & a, const tensorT & y) -> tensorT
+        requires(!scalar_c<tensorT>);
 
     // tensor times scalar
     template <tensor_c tensorT>
-    constexpr auto operator*(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT;
+    constexpr auto operator*(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT
+        requires(!scalar_c<tensorT>);
 
     // scalar times (temporary) tensor
     template <tensor_c tensorT>
-    constexpr auto operator*(const typename tensorT::scalar_type & a, tensorT && y) -> tensorT;
+    constexpr auto operator*(const typename tensorT::scalar_type & a, tensorT && y) -> tensorT
+        requires(!scalar_c<tensorT>);
 
     // (temporary) tensor times scalar
     template <tensor_c tensorT>
-    constexpr auto operator*(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT;
+    constexpr auto operator*(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT
+        requires(!scalar_c<tensorT>);
 
     // row-column vector product
     template <vector_c vectorT1, vector_c vectorT2>
@@ -65,75 +70,79 @@ namespace pyre::tensor {
 
     // tensor divided scalar
     template <tensor_c tensorT>
-    constexpr auto operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT;
+    constexpr auto operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT
+        requires(!scalar_c<tensorT>);
 
     // (temporary) tensor divided scalar
     template <tensor_c tensorT>
-    constexpr auto operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT;
+    constexpr auto operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT
+        requires(!scalar_c<tensorT>);
 
     // tensor plus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(const tensorT1 & y1, const tensorT2 & y2) ->
         typename sum<tensorT1, tensorT2>::type
-        requires(tensorT1::dims == tensorT2::dims);
+        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
 
     // tensor plus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(const tensorT1 & y1, tensorT2 && y2) -> tensorT2
         requires(
-            tensorT1::dims == tensorT2::dims
-            && std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>);
+            tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+            and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>);
 
     // (temporary) tensor plus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(tensorT1 && y1, const tensorT2 & y2) -> tensorT1
         requires(
-            tensorT1::dims == tensorT2::dims
-            && std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>);
+            tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+            and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>);
 
     // (temporary) tensor plus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT1
         requires(
-            tensorT1::dims == tensorT2::dims
-            && std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>);
+            tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+            and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>);
 
     // (temporary) tensor plus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT2
         requires(
-            tensorT1::dims == tensorT2::dims
-            && std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>
-            && !std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>);
+            tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+            and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>
+            and !std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>);
 
     // (unary) minus tensor
     template <tensor_c tensorT>
-    constexpr auto operator-(const tensorT & y) -> tensorT;
+    constexpr auto operator-(const tensorT & y) -> tensorT
+        requires(!scalar_c<tensorT>);
 
     // (unary) minus (temporary) tensor
     template <tensor_c tensorT>
-    constexpr auto operator-(tensorT && y) -> tensorT;
+    constexpr auto operator-(tensorT && y) -> tensorT
+        requires(!scalar_c<tensorT>);
 
     // tensor minus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator-(const tensorT1 & y1, const tensorT2 & y2) -> auto
-        requires(tensorT1::dims == tensorT2::dims);
+        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
 
     // (temporary) tensor minus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator-(tensorT1 && y1, const tensorT2 & y2) -> auto
-        requires(tensorT1::dims == tensorT2::dims);
+        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
 
     // tensor minus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator-(const tensorT1 & y1, tensorT2 && y2) -> auto
-        requires(tensorT1::dims == tensorT2::dims);
+        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
 
 
     // (temporary) tensor minus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator-(tensorT1 && y1, tensorT2 && y2) -> auto
-        requires(tensorT1::dims == tensorT2::dims);
+        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
 
     // Tensor operator*=
     template <tensor_c tensorT, class TENSOR>
@@ -218,10 +227,9 @@ namespace pyre::tensor {
     constexpr auto determinant(const matrixT & A) -> typename matrixT::scalar_type
         requires(matrixT::dims[0] == 2);
 
-    // the determinant of a 1x1 matrix
-    template <square_matrix_c matrixT>
-    constexpr auto determinant(const matrixT & A) -> typename matrixT::scalar_type
-        requires(matrixT::dims[0] == 1);
+    // the determinant of a scalar (1x1 improper matrix)
+    template <scalar_c scalarT>
+    constexpr auto determinant(const scalarT & A) -> typename scalarT::scalar_type;
 
     // the inverse of a 3x3 matrix
     template <square_matrix_c matrixT>
@@ -233,6 +241,10 @@ namespace pyre::tensor {
     constexpr auto inverse(const matrixT & A) -> matrixT
         requires(matrixT::dims[0] == 2 && !diagonal_matrix_c<matrixT>);
 
+    // the inverse of a scalar (1x1 improper matrix)
+    template <scalar_c scalarT>
+    constexpr auto inverse(const scalarT & A) -> scalarT;
+
     // the inverse of a NxN diagonal matrix
     template <diagonal_matrix_c matrixT>
     constexpr auto inverse(const matrixT & A) -> matrixT;
@@ -240,6 +252,10 @@ namespace pyre::tensor {
     // the trace of a matrix
     template <square_matrix_c matrixT>
     constexpr auto trace(const matrixT & A) -> typename matrixT::scalar_type;
+
+    // the trace of a scalar (1x1 improper matrix)
+    template <scalar_c scalarT>
+    constexpr auto trace(const scalarT & A) -> typename scalarT::scalar_type;
 
     // the transpose of a matrix
     template <int D1, int D2, typename T, class packingT>

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -309,6 +309,11 @@ namespace pyre::tensor {
             std::is_same_v<typename matrixT::pack_t, pyre::grid::symmetric_t<2>>
             || std::is_same_v<typename matrixT::pack_t, pyre::grid::diagonal_t<2>>);
 
+    // fourth-order tensor contraction with second-order tensor
+    template <fourth_order_tensor_c tensorT, matrix_c matrixT>
+    constexpr auto operator*(const tensorT & C, const matrixT & A) ->
+        typename contraction<tensorT, matrixT>::type;
+
 } // namespace pyre::tensor
 
 

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -314,6 +314,11 @@ namespace pyre::tensor {
     constexpr auto operator*(const tensorT & C, const matrixT & A) ->
         typename contraction<tensorT, matrixT>::type;
 
+    // second-order tensor contraction with fourth-order tensor
+    template <matrix_c matrixT, fourth_order_tensor_c tensorT>
+    constexpr auto operator*(const matrixT & A, const tensorT & C) ->
+        typename contraction<matrixT, tensorT>::type;
+
 } // namespace pyre::tensor
 
 

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -25,23 +25,19 @@ namespace pyre::tensor {
 
     // scalar times tensor
     template <tensor_c tensorT>
-    constexpr auto operator*(const typename tensorT::scalar_type & a, const tensorT & y) -> tensorT
-        requires(tensorT::size != 1);
+    constexpr auto operator*(const typename tensorT::scalar_type & a, const tensorT & y) -> tensorT;
 
     // tensor times scalar
     template <tensor_c tensorT>
-    constexpr auto operator*(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT
-        requires(tensorT::size != 1);
+    constexpr auto operator*(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT;
 
     // scalar times (temporary) tensor
     template <tensor_c tensorT>
-    constexpr auto operator*(const typename tensorT::scalar_type & a, tensorT && y) -> tensorT
-        requires(tensorT::size != 1);
+    constexpr auto operator*(const typename tensorT::scalar_type & a, tensorT && y) -> tensorT;
 
     // (temporary) tensor times scalar
     template <tensor_c tensorT>
-    constexpr auto operator*(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT
-        requires(tensorT::size != 1);
+    constexpr auto operator*(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT;
 
     // row-column vector product
     template <vector_c vectorT1, vector_c vectorT2>
@@ -69,13 +65,11 @@ namespace pyre::tensor {
 
     // tensor divided scalar
     template <tensor_c tensorT>
-    constexpr auto operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT
-        requires(tensorT::size != 1);
+    constexpr auto operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT;
 
     // (temporary) tensor divided scalar
     template <tensor_c tensorT>
-    constexpr auto operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT
-        requires(tensorT::size != 1);
+    constexpr auto operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT;
 
     // tensor plus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -1213,6 +1213,23 @@ pyre::tensor::function(const matrixT & A, auto f) -> auto
     return symmetric(P * lambda * inverse(P));
 }
 
+// fourth-order tensor contraction with second-order tensor
+template <pyre::tensor::fourth_order_tensor_c tensorT, pyre::tensor::matrix_c matrixT>
+constexpr auto
+pyre::tensor::operator*(const tensorT & C, const matrixT & A) ->
+    typename contraction<tensorT, matrixT>::type
+{
+    using output_type = typename contraction<tensorT, matrixT>::type;
+    output_type result;
+
+    constexpr_for_4<tensorT::dims[0], tensorT::dims[1], tensorT::dims[2], tensorT::dims[3]>(
+        [&C, &A, &result]<int i, int j, int k, int l>() {
+            result[{ i, j }] += C[{ i, j, k, l }] * A[{ k, l }];
+        });
+
+    //
+    return result;
+}
 
 #endif
 

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -45,7 +45,7 @@ pyre::tensor::norm(const tensorT & tensor) -> tensorT::scalar_type
     };
 
     // take the square root of the squared norm
-    return pyre::tensor::sqrt(_norm_square(tensor, make_integer_sequence<D> {}));
+    return pyre::math::sqrt(_norm_square(tensor, make_integer_sequence<D> {}));
 }
 
 // normalize a tensor with its 2-norm
@@ -997,7 +997,7 @@ pyre::tensor::eigenvalues(const symmetric_matrix_t<2, T> & A) -> vector_t<2, T>
     T a22 = A[matrix_input_t::template getOffset<1, 1>()];
     T a12 = A[matrix_input_t::template getOffset<0, 1>()];
 
-    T delta = pyre::tensor::sqrt(4.0 * a12 * a12 + (a11 - a22) * (a11 - a22));
+    T delta = pyre::math::sqrt(4.0 * a12 * a12 + (a11 - a22) * (a11 - a22));
     return vector_t<2, T> { 0.5 * (a11 + a22 + delta), 0.5 * (a11 + a22 - delta) };
 }
 
@@ -1012,7 +1012,7 @@ pyre::tensor::eigenvectors(const symmetric_matrix_t<2, T> & A) -> matrix_t<2, 2,
     T a22 = A[matrix_input_t::template getOffset<1, 1>()];
     T a12 = A[matrix_input_t::template getOffset<0, 1>()];
 
-    T delta = pyre::tensor::sqrt(4.0 * a12 * a12 + (a11 - a22) * (a11 - a22));
+    T delta = pyre::math::sqrt(4.0 * a12 * a12 + (a11 - a22) * (a11 - a22));
 
     // the type of eigenvectors matrix
     using matrix_eigenvector_t = matrix_t<2, 2, T>;
@@ -1048,15 +1048,15 @@ pyre::tensor::eigenvalues(const symmetric_matrix_t<3, T> & A) -> vector_t<3, T>
 
     T p = c2 * c2 - 3.0 * c1;
     T q = -13.5 * c0 - c2 * c2 * c2 + 4.5 * c1 * c2;
-    T num = pyre::tensor::sqrt(27.0 * (0.25 * c1 * c1 * (p - c1) + c0 * (q + 6.75 * c0)));
+    T num = pyre::math::sqrt(27.0 * (0.25 * c1 * c1 * (p - c1) + c0 * (q + 6.75 * c0)));
     T den = q;
-    T phi = 1.0 / 3.0 * pyre::tensor::atan2(num, den);
+    T phi = 1.0 / 3.0 * pyre::math::atan2(num, den);
 
-    T x1 = 2.0 * pyre::tensor::cos(phi);
-    T x2 = -pyre::tensor::cos(phi) - pyre::tensor::sqrt(3.0) * pyre::tensor::sin(phi);
-    T x3 = -pyre::tensor::cos(phi) + pyre::tensor::sqrt(3.0) * pyre::tensor::sin(phi);
+    T x1 = 2.0 * pyre::math::cos(phi);
+    T x2 = -pyre::math::cos(phi) - pyre::math::sqrt(3.0) * pyre::math::sin(phi);
+    T x3 = -pyre::math::cos(phi) + pyre::math::sqrt(3.0) * pyre::math::sin(phi);
 
-    T p_sqrt_3 = pyre::tensor::sqrt(p) / 3.0;
+    T p_sqrt_3 = pyre::math::sqrt(p) / 3.0;
 
     return vector_t<3, T> { p_sqrt_3 * x1 - c2 / 3.0, p_sqrt_3 * x2 - c2 / 3.0,
                             p_sqrt_3 * x3 - c2 / 3.0 };

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -1046,11 +1046,11 @@ pyre::tensor::eigenvalues(const symmetric_matrix_t<3, T> & A) -> vector_t<3, T>
     T q = -13.5 * c0 - c2 * c2 * c2 + 4.5 * c1 * c2;
     T num = std::sqrt(27.0 * (0.25 * c1 * c1 * (p - c1) + c0 * (q + 6.75 * c0)));
     T den = q;
-    T phi = 1.0 / 3.0 * atan2(num, den);
+    T phi = 1.0 / 3.0 * std::atan2(num, den);
 
-    T x1 = 2.0 * cos(phi);
-    T x2 = -cos(phi) - std::sqrt(3.0) * sin(phi);
-    T x3 = -cos(phi) + std::sqrt(3.0) * sin(phi);
+    T x1 = 2.0 * std::cos(phi);
+    T x2 = -std::cos(phi) - std::sqrt(3.0) * std::sin(phi);
+    T x3 = -std::cos(phi) + std::sqrt(3.0) * std::sin(phi);
 
     T p_sqrt_3 = std::sqrt(p) / 3.0;
 

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -28,18 +28,19 @@ pyre::tensor::norm(const tensorT & tensor) -> tensorT::scalar_type
     // helper function
     constexpr auto _norm_square = []<int... I>(
                                       const tensorT & tensor, integer_sequence<I...>) -> T {
+        // get the offset of the {tensorT} packing corresponding to the J-th tensor entry
+        constexpr auto _entry_to_offset = []<int J>() {
+            // ... the offset for the packing of {tensor} of ...
+            return tensorT::layout().offset(
+                // ... the index corresponding to the J-th entry, J = 0, ..., D-1, in a
+                // tensor with canonical layout
+                canonical_tensor_t::layout().index(J));
+        };
+
         // return the sum of all tensor squared components
         return (
-            // sum all the square values ...
-            (pyre::tensor::pow(
-                // ... of {tensor} at...
-                tensor[
-                    // ... the offset for the packing of {tensor} of ...
-                    tensorT::layout().offset(
-                        // ... the index corresponding to the I-th entry, I = 0, ..., D-1, in a
-                        // tensor with canonical layout
-                        canonical_tensor_t::layout().index(I))],
-                2))
+            (tensor[_entry_to_offset.template operator()<I>()]
+             * tensor[_entry_to_offset.template operator()<I>()])
             + ...);
     };
 

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -841,17 +841,6 @@ pyre::tensor::inverse(const matrixT & A) -> matrixT
     return invA;
 }
 
-template <pyre::tensor::square_matrix_c matrixT>
-constexpr auto
-pyre::tensor::inverse(const matrixT & A) -> matrixT
-    requires(matrixT::dims[0] == 1) // 1x1 matrix (scalar)
-{
-    // the type of matrix {A}
-    using matrix_t = matrixT;
-
-    return 1.0 / A[matrix_t::template getOffset<0, 0>()];
-}
-
 template <pyre::tensor::diagonal_matrix_c matrixT>
 constexpr auto
 pyre::tensor::inverse(const matrixT & A) -> matrixT

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -165,6 +165,41 @@ pyre::tensor::operator*(tensorT && y, const typename tensorT::scalar_type & a) -
     return a * std::move(y);
 }
 
+// dot product of tensors
+template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
+constexpr auto
+pyre::tensor::dot(const tensorT1 & y1, const tensorT2 & y2)
+    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
+{
+    // an equivalent canonically packed tensor
+    using canonical_repacking_t = typename tensorT1::canonical_tensor_t;
+    // the number of components of the equivalent canonically packed tensor
+    constexpr int D = canonical_repacking_t::size;
+
+    // helper function to sum component-by-component product
+    constexpr auto _component_wise_dot_sum = []<int... J>(
+                                                 const tensorT1 & lhs, const tensorT2 & rhs,
+                                                 pyre::tensor::integer_sequence<J...>) {
+        // helper function to sum of component K (enumeration relative to the repacking)
+        constexpr auto _component_dot = []<int K>(const tensorT1 & lhs, const tensorT2 & rhs) {
+            // given {K}, offset in the {canonical_repacking_t} packing, get the offset for the same
+            // component for the packing of {lhs}
+            constexpr auto K1 = pyre::tensor::map_offset<K, canonical_repacking_t, tensorT1>();
+            // given {K}, offset in the {canonical_repacking_t} packing, get the offset for the same
+            // component for the packing of {rhs}
+            constexpr auto K2 = pyre::tensor::map_offset<K, canonical_repacking_t, tensorT2>();
+            // all done
+            return lhs[K1] * rhs[K2];
+        };
+
+        // compute product of each component and sum them
+        return (((_component_dot.template operator()<J>(lhs, rhs)) + ...));
+    };
+
+    // sum component-by-component product
+    return _component_wise_dot_sum(y1, y2, pyre::tensor::make_integer_sequence<D> {});
+}
+
 namespace {
     // tensor plus tensor (implementation)
     template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -104,6 +104,7 @@ namespace {
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator==(const tensorT1 & lhs, const tensorT2 & rhs) -> bool
+    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
 {
     // perform component-by-component comparison
     return _tensor_equal(lhs, rhs);
@@ -125,6 +126,7 @@ namespace {
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(const typename tensorT::scalar_type & a, const tensorT & y) -> tensorT
+    requires(!scalar_c<tensorT>)
 {
     // instantiate the result
     tensorT result;
@@ -137,6 +139,7 @@ pyre::tensor::operator*(const typename tensorT::scalar_type & a, const tensorT &
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT
+    requires(!scalar_c<tensorT>)
 {
     return a * y;
 }
@@ -145,6 +148,7 @@ pyre::tensor::operator*(const tensorT & y, const typename tensorT::scalar_type &
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(const typename tensorT::scalar_type & a, tensorT && y) -> tensorT
+    requires(!scalar_c<tensorT>)
 {
     constexpr int D = tensorT::size;
     _tensor_times_scalar(a, y, y, make_integer_sequence<D> {});
@@ -155,6 +159,7 @@ pyre::tensor::operator*(const typename tensorT::scalar_type & a, tensorT && y) -
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT
+    requires(!scalar_c<tensorT>)
 {
     return a * std::move(y);
 }
@@ -229,7 +234,7 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(const tensorT1 & y1, const tensorT2 & y2) ->
     typename sum<tensorT1, tensorT2>::type
-    requires(tensorT1::dims == tensorT2::dims)
+    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
 {
     // compute component-wise summation
     return _tensor_sum(y1, y2);
@@ -240,8 +245,8 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(const tensorT1 & y1, tensorT2 && y2) -> tensorT2
     requires(
-        tensorT1::dims == tensorT2::dims
-        && std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>)
+        tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+        and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>)
 {
     // compute component-wise summation and write the result on y2
     return _tensor_sum(y1, y2, y2);
@@ -252,8 +257,8 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(tensorT1 && y1, const tensorT2 & y2) -> tensorT1
     requires(
-        tensorT1::dims == tensorT2::dims
-        && std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>)
+        tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+        and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>)
 {
     // easy enough
     return y2 + std::move(y1);
@@ -264,8 +269,8 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT1
     requires(
-        tensorT1::dims == tensorT2::dims
-        && std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>)
+        tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+        and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>)
 {
     // pass down y1 as temporary and y2 as const reference
     return std::move(y1) + std::as_const(y2);
@@ -276,9 +281,9 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT2
     requires(
-        tensorT1::dims == tensorT2::dims
-        && std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>
-        && !std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>)
+        tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+        and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>
+        and !std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>)
 {
     // pass down y2 as temporary and y1 as const reference
     return std::move(y2) + std::as_const(y1);
@@ -288,6 +293,7 @@ pyre::tensor::operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT2
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator-(const tensorT & y) -> tensorT
+    requires(!scalar_c<tensorT>)
 {
     // get the tensor size (number of components)
     constexpr int D = tensorT::size;
@@ -307,6 +313,7 @@ pyre::tensor::operator-(const tensorT & y) -> tensorT
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator-(tensorT && y) -> tensorT
+    requires(!scalar_c<tensorT>)
 {
     // write the result on the temporary
     y = -std::as_const(y);
@@ -318,7 +325,7 @@ pyre::tensor::operator-(tensorT && y) -> tensorT
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator-(const tensorT1 & y1, const tensorT2 & y2) -> auto
-    requires(tensorT1::dims == tensorT2::dims)
+    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
 {
     // std::cout << "operator- & &" << std::endl;
     return y1 + (-y2);
@@ -328,7 +335,7 @@ pyre::tensor::operator-(const tensorT1 & y1, const tensorT2 & y2) -> auto
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator-(tensorT1 && y1, const tensorT2 & y2) -> auto
-    requires(tensorT1::dims == tensorT2::dims)
+    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
 {
     // std::cout << "operator- && &" << std::endl;
     return std::move(y1) + (-y2);
@@ -338,7 +345,7 @@ pyre::tensor::operator-(tensorT1 && y1, const tensorT2 & y2) -> auto
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator-(const tensorT1 & y1, tensorT2 && y2) -> auto
-    requires(tensorT1::dims == tensorT2::dims)
+    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
 {
     // std::cout << "operator- & &&" << std::endl;
     return y1 + (-std::move(y2));
@@ -348,7 +355,7 @@ pyre::tensor::operator-(const tensorT1 & y1, tensorT2 && y2) -> auto
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator-(tensorT1 && y1, tensorT2 && y2) -> auto
-    requires(tensorT1::dims == tensorT2::dims)
+    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
 {
     // std::cout << "operator- && &&" << std::endl;
     return std::move(y1) + std::move(-std::move(y2));
@@ -376,6 +383,7 @@ pyre::tensor::operator-=(tensorT & lhs, TENSOR && rhs) -> tensorT &
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT
+    requires(!scalar_c<tensorT>)
 {
     return (1.0 / a) * y;
 }
@@ -384,6 +392,7 @@ pyre::tensor::operator/(const tensorT & y, typename tensorT::scalar_type a) -> t
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT
+    requires(!scalar_c<tensorT>)
 {
     return (1.0 / a) * std::move(y);
 }
@@ -766,15 +775,11 @@ pyre::tensor::determinant(const matrixT & A) -> typename matrixT::scalar_type
     return a11 * a22 - a12 * a21;
 }
 
-template <pyre::tensor::square_matrix_c matrixT>
+template <pyre::tensor::scalar_c scalarT>
 constexpr auto
-pyre::tensor::determinant(const matrixT & A) -> typename matrixT::scalar_type
-    requires(matrixT::dims[0] == 1) // 1x1 matrix
+pyre::tensor::determinant(const scalarT & A) -> typename scalarT::scalar_type
 {
-    // the type of matrix {A}
-    using matrix_t = matrixT;
-
-    return A[matrix_t::template getOffset<0, 0>()];
+    return A;
 }
 
 template <pyre::tensor::square_matrix_c matrixT>
@@ -841,6 +846,14 @@ pyre::tensor::inverse(const matrixT & A) -> matrixT
     return invA;
 }
 
+template <pyre::tensor::scalar_c scalarT>
+constexpr auto
+pyre::tensor::inverse(const scalarT & A) -> scalarT
+{
+    return scalarT { 1.0 / A };
+}
+
+
 template <pyre::tensor::diagonal_matrix_c matrixT>
 constexpr auto
 pyre::tensor::inverse(const matrixT & A) -> matrixT
@@ -881,6 +894,13 @@ pyre::tensor::trace(const matrixT & A) -> typename matrixT::scalar_type
         return (A[matrixT::template getOffset<J, J>()] + ...);
     };
     return _trace(make_integer_sequence<D> {});
+}
+
+template <pyre::tensor::scalar_c scalarT>
+constexpr auto
+pyre::tensor::trace(const scalarT & A) -> typename scalarT::scalar_type
+{
+    return A;
 }
 
 template <int D1, int D2, typename T, class packingT>

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -809,9 +809,10 @@ pyre::tensor::determinant(const matrixT & A) -> typename matrixT::scalar_type
     return a11 * a22 - a12 * a21;
 }
 
-template <pyre::tensor::scalar_c scalarT>
+template <pyre::tensor::square_matrix_c matrixT>
 constexpr auto
-pyre::tensor::determinant(const scalarT & A) -> typename scalarT::scalar_type
+pyre::tensor::determinant(const matrixT & A) -> typename matrixT::scalar_type
+    requires(matrixT::dims[0] == 1) // 1x1 matrix
 {
     return A;
 }
@@ -880,11 +881,12 @@ pyre::tensor::inverse(const matrixT & A) -> matrixT
     return invA;
 }
 
-template <pyre::tensor::scalar_c scalarT>
+template <pyre::tensor::square_matrix_c matrixT>
 constexpr auto
-pyre::tensor::inverse(const scalarT & A) -> scalarT
+pyre::tensor::inverse(const matrixT & A) -> matrixT
+    requires(matrixT::dims[0] == 1 && !diagonal_matrix_c<matrixT>) // 1x1 matrix
 {
-    return scalarT { 1.0 / A };
+    return matrixT { 1.0 / A };
 }
 
 
@@ -928,13 +930,6 @@ pyre::tensor::trace(const matrixT & A) -> typename matrixT::scalar_type
         return (A[matrixT::template getOffset<J, J>()] + ...);
     };
     return _trace(make_integer_sequence<D> {});
-}
-
-template <pyre::tensor::scalar_c scalarT>
-constexpr auto
-pyre::tensor::trace(const scalarT & A) -> typename scalarT::scalar_type
-{
-    return A;
 }
 
 template <int D1, int D2, typename T, class packingT>

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -125,7 +125,6 @@ namespace {
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(const typename tensorT::scalar_type & a, const tensorT & y) -> tensorT
-    requires(tensorT::size != 1)
 {
     // instantiate the result
     tensorT result;
@@ -138,7 +137,6 @@ pyre::tensor::operator*(const typename tensorT::scalar_type & a, const tensorT &
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT
-    requires(tensorT::size != 1)
 {
     return a * y;
 }
@@ -147,7 +145,6 @@ pyre::tensor::operator*(const tensorT & y, const typename tensorT::scalar_type &
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(const typename tensorT::scalar_type & a, tensorT && y) -> tensorT
-    requires(tensorT::size != 1)
 {
     constexpr int D = tensorT::size;
     _tensor_times_scalar(a, y, y, make_integer_sequence<D> {});
@@ -158,7 +155,6 @@ pyre::tensor::operator*(const typename tensorT::scalar_type & a, tensorT && y) -
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT
-    requires(tensorT::size != 1)
 {
     return a * std::move(y);
 }
@@ -380,7 +376,6 @@ pyre::tensor::operator-=(tensorT & lhs, TENSOR && rhs) -> tensorT &
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT
-    requires(tensorT::size != 1)
 {
     return (1.0 / a) * y;
 }
@@ -389,7 +384,6 @@ pyre::tensor::operator/(const tensorT & y, typename tensorT::scalar_type a) -> t
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT
-    requires(tensorT::size != 1)
 {
     return (1.0 / a) * std::move(y);
 }

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -31,7 +31,7 @@ pyre::tensor::norm(const tensorT & tensor) -> tensorT::scalar_type
         // return the sum of all tensor squared components
         return (
             // sum all the square values ...
-            (std::pow(
+            (pyre::tensor::pow(
                 // ... of {tensor} at...
                 tensor[
                     // ... the offset for the packing of {tensor} of ...
@@ -44,7 +44,7 @@ pyre::tensor::norm(const tensorT & tensor) -> tensorT::scalar_type
     };
 
     // take the square root of the squared norm
-    return std::sqrt(_norm_square(tensor, make_integer_sequence<D> {}));
+    return pyre::tensor::sqrt(_norm_square(tensor, make_integer_sequence<D> {}));
 }
 
 // normalize a tensor with its 2-norm
@@ -993,7 +993,7 @@ pyre::tensor::eigenvalues(const symmetric_matrix_t<2, T> & A) -> vector_t<2, T>
     T a22 = A[matrix_input_t::template getOffset<1, 1>()];
     T a12 = A[matrix_input_t::template getOffset<0, 1>()];
 
-    T delta = std::sqrt(4.0 * a12 * a12 + (a11 - a22) * (a11 - a22));
+    T delta = pyre::tensor::sqrt(4.0 * a12 * a12 + (a11 - a22) * (a11 - a22));
     return vector_t<2, T> { 0.5 * (a11 + a22 + delta), 0.5 * (a11 + a22 - delta) };
 }
 
@@ -1008,7 +1008,7 @@ pyre::tensor::eigenvectors(const symmetric_matrix_t<2, T> & A) -> matrix_t<2, 2,
     T a22 = A[matrix_input_t::template getOffset<1, 1>()];
     T a12 = A[matrix_input_t::template getOffset<0, 1>()];
 
-    T delta = std::sqrt(4.0 * a12 * a12 + (a11 - a22) * (a11 - a22));
+    T delta = pyre::tensor::sqrt(4.0 * a12 * a12 + (a11 - a22) * (a11 - a22));
 
     // the type of eigenvectors matrix
     using matrix_eigenvector_t = matrix_t<2, 2, T>;
@@ -1044,15 +1044,15 @@ pyre::tensor::eigenvalues(const symmetric_matrix_t<3, T> & A) -> vector_t<3, T>
 
     T p = c2 * c2 - 3.0 * c1;
     T q = -13.5 * c0 - c2 * c2 * c2 + 4.5 * c1 * c2;
-    T num = std::sqrt(27.0 * (0.25 * c1 * c1 * (p - c1) + c0 * (q + 6.75 * c0)));
+    T num = pyre::tensor::sqrt(27.0 * (0.25 * c1 * c1 * (p - c1) + c0 * (q + 6.75 * c0)));
     T den = q;
-    T phi = 1.0 / 3.0 * std::atan2(num, den);
+    T phi = 1.0 / 3.0 * pyre::tensor::atan2(num, den);
 
-    T x1 = 2.0 * std::cos(phi);
-    T x2 = -std::cos(phi) - std::sqrt(3.0) * std::sin(phi);
-    T x3 = -std::cos(phi) + std::sqrt(3.0) * std::sin(phi);
+    T x1 = 2.0 * pyre::tensor::cos(phi);
+    T x2 = -pyre::tensor::cos(phi) - pyre::tensor::sqrt(3.0) * pyre::tensor::sin(phi);
+    T x3 = -pyre::tensor::cos(phi) + pyre::tensor::sqrt(3.0) * pyre::tensor::sin(phi);
 
-    T p_sqrt_3 = std::sqrt(p) / 3.0;
+    T p_sqrt_3 = pyre::tensor::sqrt(p) / 3.0;
 
     return vector_t<3, T> { p_sqrt_3 * x1 - c2 / 3.0, p_sqrt_3 * x2 - c2 / 3.0,
                             p_sqrt_3 * x3 - c2 / 3.0 };
@@ -1064,7 +1064,9 @@ pyre::tensor::eigenvectors(const symmetric_matrix_t<3, T> & A) -> matrix_t<3, 3,
 {
     // get the eigenvalues
     auto lambda = eigenvalues(A);
-    auto eps = pyre::algebra::epsilon(norm(A));
+    // switch to the following since C++26
+    // auto eps =  pyre::algebra::epsilon(norm(A));
+    auto eps = 1.e-16;
 
     // first eigenvector
     vector_t<3, T> v0;

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -82,12 +82,12 @@ namespace {
             // helper function to sum of component K (enumeration relative to the repacking)
             constexpr auto _component_equal = []<int K>(
                                                   const auto & lhs, const auto & rhs) -> bool {
-                // get the index corresponding to the offset K in the repacking
-                constexpr auto index = repacked_tensor_t::layout().index(K);
-                // map the index into the offset for the packing of y1
-                constexpr auto K1 = tensor1_t::layout().offset(index);
-                // map the index into the offset for the packing of y2
-                constexpr auto K2 = tensor2_t::layout().offset(index);
+                // given {K}, offset in the {repacked_tensor_t} packing, get the offset for the same
+                // component for the packing of {y1}
+                constexpr auto K1 = pyre::tensor::map_offset<K, repacked_tensor_t, tensor1_t>();
+                // given {K}, offset in the {repacked_tensor_t} packing, get the offset for the same
+                // component for the packing of {y2}
+                constexpr auto K2 = pyre::tensor::map_offset<K, repacked_tensor_t, tensor2_t>();
                 // all done
                 return lhs[K1] == rhs[K2];
             };
@@ -187,16 +187,14 @@ namespace {
             // helper function to sum of component K (enumeration relative to the repacking)
             constexpr auto _component_sum =
                 []<int K>(const tensorT1 & y1, const tensorT2 & y2, result_tensor_t & result) {
-                    // get the index corresponding to the offset K in the repacking
-                    constexpr auto index = result_tensor_t::layout().index(K);
-                    // map the index into the offset for the packing of y1
-                    constexpr auto K1 = tensorT1::layout().offset(index);
-                    // map the index into the offset for the packing of y2
-                    constexpr auto K2 = tensorT2::layout().offset(index);
-
+                    // given {K}, offset in the {result_tensor_t} packing, get the offset for the
+                    // same component for the packing of {y1}
+                    constexpr auto K1 = pyre::tensor::map_offset<K, result_tensor_t, tensorT1>();
+                    // given {K}, offset in the {result_tensor_t} packing, get the offset for the
+                    // same component for the packing of {y2}
+                    constexpr auto K2 = pyre::tensor::map_offset<K, result_tensor_t, tensorT2>();
                     // perform the sum of the corresponding entries
                     result[K] = y1[K1] + y2[K2];
-
                     // all done
                     return;
                 };

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -1231,6 +1231,24 @@ pyre::tensor::operator*(const tensorT & C, const matrixT & A) ->
     return result;
 }
 
+// second-order tensor contraction with fourth-order tensor
+template <pyre::tensor::matrix_c matrixT, pyre::tensor::fourth_order_tensor_c tensorT>
+constexpr auto
+pyre::tensor::operator*(const matrixT & A, const tensorT & C) ->
+    typename contraction<matrixT, tensorT>::type
+{
+    using output_type = typename contraction<matrixT, tensorT>::type;
+    output_type result;
+
+    constexpr_for_4<tensorT::dims[0], tensorT::dims[1], tensorT::dims[2], tensorT::dims[3]>(
+        [&C, &A, &result]<int i, int j, int k, int l>() {
+            result[{ i, j }] += C[{ k, l, i, j }] * A[{ k, l }];
+        });
+
+    //
+    return result;
+}
+
 #endif
 
 // end of file

--- a/lib/pyre/tensor/api.h
+++ b/lib/pyre/tensor/api.h
@@ -36,7 +36,7 @@ namespace pyre::tensor {
     // typedef for fourth order tensors
     template <int D1, int D2 = D1, int D3 = D2, int D4 = D3, typename T = real>
     using fourth_order_tensor_t =
-      pyre::tensor::Tensor<T, pyre::grid::canonical_t<4>, D1, D2, D3, D4>;
+        pyre::tensor::Tensor<T, pyre::grid::canonical_t<4>, D1, D2, D3, D4>;
 
     // the zero tensor
     template <class tensorT>

--- a/lib/pyre/tensor/api.h
+++ b/lib/pyre/tensor/api.h
@@ -33,6 +33,11 @@ namespace pyre::tensor {
     template <int D, typename T = real>
     using diagonal_matrix_t = matrix_t<D, D, T, pyre::grid::diagonal_t<2>>;
 
+    // typedef for fourth order tensors
+    template <int D1, int D2 = D1, int D3 = D2, int D4 = D3, typename T = real>
+    using fourth_order_tensor_t =
+      pyre::tensor::Tensor<T, pyre::grid::canonical_t<4>, D1, D2, D3, D4>;
+
     // the zero tensor
     template <class tensorT>
     constexpr auto zero = make_zeros<tensorT>();

--- a/lib/pyre/tensor/api.h
+++ b/lib/pyre/tensor/api.h
@@ -15,11 +15,11 @@ namespace pyre::tensor {
 
     // typedef for vectors
     template <int D, typename T = real, class packingT = pyre::grid::canonical_t<1>>
-    using vector_t = pyre::tensor::Tensor<T, packingT, D>;
+    using vector_t = Tensor<T, packingT, D>;
 
     // typedef for matrices
     template <int D1, int D2 = D1, typename T = real, class packingT = pyre::grid::canonical_t<2>>
-    using matrix_t = pyre::tensor::Tensor<T, packingT, D1, D2>;
+    using matrix_t = Tensor<T, packingT, D1, D2>;
 
     // typedef for square matrices
     template <int D, typename T = real, class packingT = pyre::grid::canonical_t<2>>
@@ -36,7 +36,7 @@ namespace pyre::tensor {
     // typedef for fourth order tensors
     template <int D1, int D2 = D1, int D3 = D2, int D4 = D3, typename T = real>
     using fourth_order_tensor_t =
-        pyre::tensor::Tensor<T, pyre::grid::canonical_t<4>, D1, D2, D3, D4>;
+        Tensor<T, pyre::grid::canonical_t<4>, D1, D2, D3, D4>;
 
     // the zero tensor
     template <class tensorT>

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -54,6 +54,10 @@ namespace pyre::tensor {
     template <class F1, class F2>
     concept tensor_same_shape_c = tensor_c<F1> and tensor_c<F2> and F1::dims == F2::dims;
 
+    // concept of a fourth-order tensor
+    template <class F>
+    concept fourth_order_tensor_c = tensor_c<F> and F::rank == 4;
+
 } // namespace pyre::tensor
 
 

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -20,56 +20,26 @@ namespace pyre::tensor {
         }(c);
     };
 
-    // concept of a matrix
+    // concept of a scalar
     template <class F>
-    concept matrix_c = requires(F c) {
-        // require that F only binds to {matrix_t} specializations
-        []<int D1, int D2, typename T, class packingT>(const matrix_t<D1, D2, T, packingT> &)
-            // with D1 and D2 different than 1 (otherwise it is a vector)
-            requires(D1 != 1 && D2 != 1)
-        {}
-        (c);
-    };
-
-    // concept of a square matrix
-    template <class F>
-    concept square_matrix_c = requires(F c) {
-        // require that F only binds to square {matrix_t} specializations
-        []<int D, typename T, class packingT>(const matrix_t<D, D, T, packingT> &)
-            // with D different than 1 (otherwise it is a scalar)
-            requires(D != 1)
-        {}
-        (c);
-    };
-
-    // concept of a diagonal matrix
-    template <class F>
-    concept diagonal_matrix_c = requires(F c) {
-        // require that F only binds to diagonal {matrix_t} specializations
-        []<int D, typename T>(const matrix_t<D, D, T, pyre::grid::diagonal_t<D>> &)
-            // with D different than 1 (otherwise it is a scalar)
-            requires(D != 1)
-        {}
-        (c);
-    };
+    concept scalar_c = tensor_c<F> and F::size == 1;
 
     // concept of a vector
     template <class F>
-    concept vector_c = requires(F c) {
-        // require that F only binds to {matrix_t} specializations
-        []<int D1, int D2, typename T, class packingT>(const matrix_t<D1, D2, T, packingT> &)
-            // with either D1 or D2 equal to 1 (but not both)
-            requires(!(D1 == 1) != !(D2 == 1))
-        {}
-        (c);
-    } or requires(F c) {
-        // require that F only binds to {vector_t} specializations
-        []<int D, typename T, class packingT>(const vector_t<D, T, packingT> &)
-            // with D different than 1 (otherwise it is a scalar)
-            requires(D != 1)
-        {}
-        (c);
-    };
+    concept vector_c = tensor_c<F> and not scalar_c<F> and (F::rank == 1 || (F::rank == 2 && (F::dims[0] == 1 || F::dims[1] == 1)));
+
+    // concept of a matrix
+    template <class F>
+    concept matrix_c =
+        tensor_c<F> and not scalar_c<F> and F::rank == 2 and (F::dims[0] != 1 && F::dims[1] != 1);
+
+    // concept of a square matrix
+    template <class F>
+    concept square_matrix_c = matrix_c<F> and F::dims[0] == F::dims[1];
+
+    // concept of a diagonal matrix
+    template <class F>
+    concept diagonal_matrix_c = square_matrix_c<F> and F::diagonal;
 
 } // namespace pyre::tensor
 

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -46,6 +46,10 @@ namespace pyre::tensor {
     template <class F>
     concept diagonal_matrix_c = square_matrix_c<F> and F::diagonal;
 
+    // concept of a symmetric matrix
+    template <class F>
+    concept symmetric_matrix_c = square_matrix_c<F> and F::symmetric;
+
 } // namespace pyre::tensor
 
 

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -24,19 +24,13 @@ namespace pyre::tensor {
     template <class F>
     concept scalar_c = tensor_c<F> and F::size == 1;
 
-    // concept of an improper matrix
-    template <class F>
-    concept improper_matrix_c =
-        tensor_c<F> and F::rank == 2 and (F::dims[0] == 1 or F::dims[1] == 1);
-
     // concept of a vector
     template <class F>
-    concept vector_c = tensor_c<F> and (F::rank == 1 or improper_matrix_c<F>) and not scalar_c<F>;
+    concept vector_c = tensor_c<F> and F::rank == 1;
 
     // concept of a matrix
     template <class F>
-    concept matrix_c =
-        tensor_c<F> and F::rank == 2 and not improper_matrix_c<F> and not scalar_c<F>;
+    concept matrix_c = tensor_c<F> and F::rank == 2;
 
     // concept of a square matrix
     template <class F>

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -50,6 +50,10 @@ namespace pyre::tensor {
     template <class F>
     concept symmetric_matrix_c = square_matrix_c<F> and F::symmetric;
 
+    // concept of two tensors having the same shape
+    template <class F1, class F2>
+    concept tensor_same_shape_c = tensor_c<F1> and tensor_c<F2> and F1::dims == F2::dims;
+
 } // namespace pyre::tensor
 
 

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -26,7 +26,8 @@ namespace pyre::tensor {
 
     // concept of an improper matrix
     template <class F>
-    concept improper_matrix_c = tensor_c<F> and F::rank == 2 and (F::dims[0] == 1 or F::dims[1] == 1);
+    concept improper_matrix_c =
+        tensor_c<F> and F::rank == 2 and (F::dims[0] == 1 or F::dims[1] == 1);
 
     // concept of a vector
     template <class F>

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -58,6 +58,16 @@ namespace pyre::tensor {
     template <class F>
     concept fourth_order_tensor_c = tensor_c<F> and F::rank == 4;
 
+    // concept of a compatible pair of tensors
+    // (an instance of {tensorT1} can be assigned to an instance of {tensorT2})
+    template <class tensorT1, class tensorT2>
+    concept compatible_tensor_c =
+        tensor_c<tensorT1> and tensor_c<tensorT2>
+        and std::is_same_v<
+            typename repacking_sum<
+                typename tensorT1::pack_t, typename tensorT2::pack_t>::packing_type,
+            typename tensorT2::pack_t>;
+
 } // namespace pyre::tensor
 
 

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -24,14 +24,18 @@ namespace pyre::tensor {
     template <class F>
     concept scalar_c = tensor_c<F> and F::size == 1;
 
+    // concept of an improper matrix
+    template <class F>
+    concept improper_matrix_c = tensor_c<F> and F::rank == 2 and (F::dims[0] == 1 or F::dims[1] == 1);
+
     // concept of a vector
     template <class F>
-    concept vector_c = tensor_c<F> and not scalar_c<F> and (F::rank == 1 || (F::rank == 2 && (F::dims[0] == 1 || F::dims[1] == 1)));
+    concept vector_c = tensor_c<F> and (F::rank == 1 or improper_matrix_c<F>) and not scalar_c<F>;
 
     // concept of a matrix
     template <class F>
     concept matrix_c =
-        tensor_c<F> and not scalar_c<F> and F::rank == 2 and (F::dims[0] != 1 && F::dims[1] != 1);
+        tensor_c<F> and F::rank == 2 and not improper_matrix_c<F> and not scalar_c<F>;
 
     // concept of a square matrix
     template <class F>

--- a/lib/pyre/tensor/constexpr_for.h
+++ b/lib/pyre/tensor/constexpr_for.h
@@ -1,0 +1,112 @@
+// -*- c++ -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+
+
+// code guard
+#if !defined(pyre_tensor_constexpr_for_h)
+#define pyre_tensor_constexpr_for_h
+
+
+namespace pyre::tensor {
+
+    // constexpr for loop calling function f(i) for each i in (Start, End)
+    template <int End, int Index1 = 0, class F>
+    constexpr void constexpr_for_1(F && f)
+    {
+        if constexpr (Index1 < End) {
+            f.template operator()<Index1>();
+            return constexpr_for_1<End, Index1 + 1>(f);
+        }
+    }
+
+    // take f(i, j) and return f_I(j) := f(I, j) for I fixed
+    template <int I, class F>
+    constexpr auto f_I(F && f)
+    {
+        return [f]<int j>() {
+            f.template operator()<I, j>();
+        };
+    }
+
+    // constexpr for loop calling function f(i, j) for each i,j in (Start, End)x(Start, End)
+    template <int End1, int End2, int Index1 = 0, class F>
+    constexpr void _constexpr_for_2(F && f)
+    {
+        if constexpr (Index1 < End1) {
+            constexpr_for_1<End2>(f_I<Index1>(f));
+            _constexpr_for_2<End1, End2, Index1 + 1>(f);
+        }
+
+        // the above expands to the following for Start=0, End=3:
+        // constexpr_for_1<Start, End>(f_I<0>(f));
+        // constexpr_for_1<Start, End>(f_I<1>(f));
+        // constexpr_for_1<Start, End>(f_I<2>(f));
+    }
+
+    template <int End1, int End2, class F>
+    constexpr void constexpr_for_2(F && f)
+    {
+        _constexpr_for_2<End1, End2, 0>(f);
+    }
+
+    // take f(i, j, k) and return f_IJ(k) := f(I, J, k) for I, J fixed
+    template <int I, class F>
+    constexpr auto f_IJ(F && f)
+    {
+        return [f]<int j, int k>() {
+            f.template operator()<I, j, k>();
+        };
+    }
+
+    // constexpr for loop calling function f(i, j, j) for each i,j,k in (Start, End)x(Start, End)
+    template <int End1, int End2, int End3, int Index1 = 0, int Index2 = 0, class F>
+    constexpr void _constexpr_for_3(F && f)
+    {
+        if constexpr (Index1 < End1) {
+            constexpr_for_2<End2, End3>(f_IJ<Index1>(f));
+            _constexpr_for_3<End1, End2, End3, Index1 + 1, Index2>(f);
+        }
+    }
+
+    template <int End1, int End2, int End3, class F>
+    constexpr void constexpr_for_3(F && f)
+    {
+        _constexpr_for_3<End1, End2, End3, 0, 0>(f);
+    }
+
+    // take f(i, j, k, l) and return f_IJK(l) := f(I, J, K, l) for I, J, K fixed
+    template <int I, class F>
+    constexpr auto f_IJK(F && f)
+    {
+        return [f]<int j, int k, int l>() {
+            f.template operator()<I, j, k, l>();
+        };
+    }
+
+    // constexpr for loop calling function f(i, j, k, l) for each i,j,k,l in (Start, End)x(Start,
+    // End)
+    template <
+        int End1, int End2, int End3, int End4, int Index1 = 0, int Index2 = 0, int Index3 = 0,
+        class F>
+    constexpr void _constexpr_for_4(F && f)
+    {
+        if constexpr (Index1 < End1) {
+            constexpr_for_3<End2, End3, End4>(f_IJK<Index1>(f));
+            _constexpr_for_4<End1, End2, End3, End4, Index1 + 1, Index2, Index3>(f);
+        }
+    }
+
+    template <int End1, int End2, int End3, int End4, class F>
+    constexpr void constexpr_for_4(F && f)
+    {
+        _constexpr_for_4<End1, End2, End3, End4, 0, 0>(f);
+    }
+
+} // namespace pyre::tensor
+
+
+#endif
+
+// end of file

--- a/lib/pyre/tensor/externals.h
+++ b/lib/pyre/tensor/externals.h
@@ -11,7 +11,6 @@
 
 // externals
 #include <cassert>
-#include <cmath>
 #include <functional>
 #include <complex>
 
@@ -19,6 +18,7 @@
 #include <pyre/journal.h>
 #include <pyre/grid.h>
 #include <pyre/algebra/epsilon.h>
+#include <pyre/math.h>
 
 
 // aliases that define implementation choices

--- a/lib/pyre/tensor/factories.h
+++ b/lib/pyre/tensor/factories.h
@@ -1,3 +1,9 @@
+// -*- c++ -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+
+
 // code guard
 #if !defined(pyre_tensor_factories_h)
 #define pyre_tensor_factories_h

--- a/lib/pyre/tensor/factories.h
+++ b/lib/pyre/tensor/factories.h
@@ -36,7 +36,7 @@ namespace pyre::tensor {
     {
         constexpr auto _make_zeros = []<int... J>(integer_sequence<J...>) ->
             typename tensorT::diagonal_tensor_t {
-                constexpr auto fill_zeros = []<int>() consteval -> typename tensorT::scalar_type {
+                constexpr auto fill_zeros = []<int>() -> typename tensorT::scalar_type {
                     return 0;
                 };
                 // return a tensor filled with zeros
@@ -51,7 +51,7 @@ namespace pyre::tensor {
     constexpr auto make_ones() -> tensorT
     {
         constexpr auto _make_ones = []<int... J>(integer_sequence<J...>) -> tensorT {
-            constexpr auto fill_ones = []<int>() consteval -> typename tensorT::scalar_type {
+            constexpr auto fill_ones = []<int>() -> typename tensorT::scalar_type {
                 return 1;
             };
             // return a tensor filled with ones
@@ -116,7 +116,7 @@ namespace pyre::tensor {
     {
         constexpr auto _make_ones = []<int... J>(integer_sequence<J...>) ->
             typename tensorT::diagonal_tensor_t {
-                constexpr auto fill_ones = []<int>() consteval -> typename tensorT::scalar_type {
+                constexpr auto fill_ones = []<int>() -> typename tensorT::scalar_type {
                     return 1;
                 };
                 // return a tensor filled with zeros

--- a/lib/pyre/tensor/factories.h
+++ b/lib/pyre/tensor/factories.h
@@ -68,6 +68,25 @@ namespace pyre::tensor {
         return _make_ones(make_integer_sequence<tensorT::size> {});
     }
 
+    // returns a tensor of class {tensorT} filled with random numbers
+    template <tensor_c tensorT>
+    auto random(const typename tensorT::scalar_type amplitude) -> tensorT
+    {
+        // the scalar type of the tensor
+        using scalar_type = typename tensorT::scalar_type;
+
+        auto _make_random = [&amplitude]<int... J>(integer_sequence<J...>) -> tensorT {
+            auto fill_random = [&amplitude]<int>() -> scalar_type {
+                return amplitude * (2.0 * (scalar_type) rand() / RAND_MAX - 1.0);
+            };
+            // return a tensor filled with random numbers
+            return tensorT(fill_random.template operator()<J>()...);
+        };
+
+        // fill tensor with random numbers
+        return _make_random(make_integer_sequence<tensorT::size> {});
+    }
+
     namespace {
         template <class tensorT, int... I>
         constexpr auto make_basis_element_implementation() -> tensorT

--- a/lib/pyre/tensor/public.h
+++ b/lib/pyre/tensor/public.h
@@ -31,6 +31,8 @@
 #include "Tensor.h"
 // useful functions for {Tensor}
 #include "utilities.h"
+// the {constexpr} implementation of transcendental functions (until c++26)
+#include "transcendental.h"
 // the algebra on tensors
 #include "algebra.h"
 // the quaternions

--- a/lib/pyre/tensor/public.h
+++ b/lib/pyre/tensor/public.h
@@ -33,6 +33,8 @@
 #include "utilities.h"
 // the {constexpr} implementation of transcendental functions (until c++26)
 #include "transcendental.h"
+// {constexpr} version of {for} loops
+#include "constexpr_for.h"
 // the algebra on tensors
 #include "algebra.h"
 // the quaternions

--- a/lib/pyre/tensor/public.h
+++ b/lib/pyre/tensor/public.h
@@ -31,8 +31,6 @@
 #include "Tensor.h"
 // useful functions for {Tensor}
 #include "utilities.h"
-// the {constexpr} implementation of transcendental functions (until c++26)
-#include "transcendental.h"
 // {constexpr} version of {for} loops
 #include "constexpr_for.h"
 // the algebra on tensors

--- a/lib/pyre/tensor/repacking.h
+++ b/lib/pyre/tensor/repacking.h
@@ -11,6 +11,19 @@
 
 
 namespace pyre::tensor {
+
+    // function to map the offset of a tensor {tensor1} with a given packing to the offset of
+    // another tensor {tensor2} with a different packing
+    template <int K, class tensor1, class tensor2>
+    consteval auto map_offset()
+        requires(tensor1::dims == tensor2::dims)
+    {
+        // get the index corresponding to the offset K in the packing of {tensor1}
+        constexpr auto index = tensor1::layout().index(K);
+        // return the offset corresponding to {index} in the packing of {tensor2}
+        return tensor2::layout().offset(index);
+    };
+
     template <class T, class S>
     struct repacking_sum;
 

--- a/lib/pyre/tensor/repacking.h
+++ b/lib/pyre/tensor/repacking.h
@@ -5,6 +5,11 @@
 //
 
 
+// code guard
+#if !defined(pyre_tensor_repacking_h)
+#define pyre_tensor_repacking_h
+
+
 namespace pyre::tensor {
     template <class T, class S>
     struct repacking_sum;
@@ -121,5 +126,7 @@ namespace pyre::tensor {
 
 } // namespace pyre::tensor
 
+
+#endif
 
 // end of file

--- a/lib/pyre/tensor/traits.h
+++ b/lib/pyre/tensor/traits.h
@@ -5,6 +5,11 @@
 //
 
 
+// code guard
+#if !defined(pyre_tensor_traits_h)
+#define pyre_tensor_traits_h
+
+
 namespace pyre::tensor {
 
     // the type resulting from the product of {T1} and {T2}
@@ -96,5 +101,7 @@ namespace pyre::tensor {
 
 } // namespace pyre::tensor
 
+
+#endif
 
 // end of file

--- a/lib/pyre/tensor/traits.h
+++ b/lib/pyre/tensor/traits.h
@@ -19,7 +19,7 @@ namespace pyre::tensor {
         using T2 = typename vectorT2::scalar_type;
 
     public:
-        using type = typename std::result_of<std::multiplies<>(T1, T2)>::type;
+        using type = typename std::invoke_result<std::multiplies<>, T1, T2>::type;
     };
 
     // the vector type resulting from the row-column product of {matrixT} and {vectorT}
@@ -28,7 +28,7 @@ namespace pyre::tensor {
     private:
         using T1 = typename matrixT::scalar_type;
         using T2 = typename vectorT::scalar_type;
-        using scalar_type = typename std::result_of<std::multiplies<>(T1, T2)>::type;
+        using scalar_type = typename std::invoke_result<std::multiplies<>, T1, T2>::type;
 
     public:
         using type = vector_t<matrixT::dims[0], scalar_type>;
@@ -40,7 +40,7 @@ namespace pyre::tensor {
     private:
         using T1 = typename vectorT::scalar_type;
         using T2 = typename matrixT::scalar_type;
-        using scalar_type = typename std::result_of<std::multiplies<>(T1, T2)>::type;
+        using scalar_type = typename std::invoke_result<std::multiplies<>, T1, T2>::type;
 
     public:
         using type = vector_t<matrixT::dims[1], scalar_type>;
@@ -52,7 +52,7 @@ namespace pyre::tensor {
     private:
         using T1 = typename matrixT1::scalar_type;
         using T2 = typename matrixT2::scalar_type;
-        using scalar_type = typename std::result_of<std::multiplies<>(T1, T2)>::type;
+        using scalar_type = typename std::invoke_result<std::multiplies<>, T1, T2>::type;
         using packingT1 = typename matrixT1::pack_t;
         using packingT2 = typename matrixT2::pack_t;
         using repacking_type = typename repacking_prod<packingT1, packingT2>::packing_type;
@@ -73,7 +73,7 @@ namespace pyre::tensor {
     private:
         using T1 = typename vectorT1::scalar_type;
         using T2 = typename vectorT2::scalar_type;
-        using scalar_type = typename std::result_of<std::multiplies<>(T1, T2)>::type;
+        using scalar_type = typename std::invoke_result<std::multiplies<>, T1, T2>::type;
 
     public:
         using type = matrix_t<vectorT1::size, vectorT2::size, scalar_type>;
@@ -87,7 +87,7 @@ namespace pyre::tensor {
     template <typename T1, typename T2, class packingT1, class packingT2, int... I>
     struct sum<tensor_t<T1, packingT1, I...>, tensor_t<T2, packingT2, I...>> {
     private:
-        using scalar_type = typename std::result_of<std::plus<>(T1, T2)>::type;
+        using scalar_type = typename std::invoke_result<std::plus<>, T1, T2>::type;
         using repacking_type = typename repacking_sum<packingT1, packingT2>::packing_type;
 
     public:

--- a/lib/pyre/tensor/traits.h
+++ b/lib/pyre/tensor/traits.h
@@ -12,6 +12,87 @@
 
 namespace pyre::tensor {
 
+    // TOFIX: these functions should probably not be parked here...
+    namespace {
+        // helper function for expanding array in template parameter pack
+        template <
+            typename T, class packingT, auto arr,
+            typename IS = decltype(std::make_index_sequence<arr.size()>())>
+        struct tensor;
+
+        // generator for a {tensor_t} from an array
+        template <typename T, class packingT, auto arr, std::size_t... I>
+        struct tensor<T, packingT, arr, std::index_sequence<I...>> {
+            using type = tensor_t<T, packingT, arr[I]...>;
+        };
+
+        // method to extract the first {N} elements of an array into another array
+        template <int N>
+        constexpr auto first(const auto & array) -> std::array<int, N>
+        {
+            auto _first = [&array]<int... I>(integer_sequence<I...>) -> std::array<int, N> {
+                return { array[I]... };
+            };
+
+            return _first(make_integer_sequence<N> {});
+        }
+
+        // method to extract the last {N} elements of an array into another array
+        template <int N>
+        constexpr auto last(const auto & array) -> std::array<int, N>
+        {
+            auto _last = [&array]<int... I>(integer_sequence<I...>) -> std::array<int, N> {
+                return { array[I + array.size() - N]... };
+            };
+
+            return _last(make_integer_sequence<N> {});
+        }
+
+        // method to check the compatibility of the contracted indices
+        // (i.e. the last N entries of {array1} and the first N entries of {array2} coincide)
+        template <std::size_t N1, std::size_t N2>
+        constexpr auto check(const std::array<int, N1> & array1, const std::array<int, N2> & array2)
+            -> bool
+        {
+            // compute the rank of the contraction
+            constexpr auto N = std::max(N1, N2) - std::min(N1, N2);
+
+            auto _check = [&array1, &array2]<int... I>(integer_sequence<I...>) -> bool {
+                return ((array2[I] == array1[I + array1.size() - N]) && ...);
+            };
+
+            return _check(make_integer_sequence<N> {});
+        }
+    } // namespace
+
+    // the type resulting from the contraction of {T1} and {T2}
+    template <class T1, class T2>
+    struct contraction;
+
+    // the tensor type resulting from the product of two arbitrary tensors {tensorT1} and {tensorT2}
+    template <tensor_c tensorT1, tensor_c tensorT2>
+        requires(check(tensorT1::dims, tensorT2::dims))
+    struct contraction<tensorT1, tensorT2> {
+    private:
+        using T1 = typename tensorT1::scalar_type;
+        using T2 = typename tensorT2::scalar_type;
+        using scalar_type = typename std::invoke_result<std::multiplies<>, T1, T2>::type;
+        static constexpr auto dims1 = tensorT1::dims;
+        static constexpr auto dims2 = tensorT2::dims;
+        static constexpr auto rank1 = dims1.size();
+        static constexpr auto rank2 = dims2.size();
+        static constexpr int rank = std::max(rank1, rank2) - std::min(rank1, rank2);
+        static constexpr auto dims = (rank1 > rank2) ? first<rank>(dims1) : last<rank>(dims2);
+        // using packingT1 = typename tensorT1::pack_t;
+        // using packingT2 = typename tensorT2::pack_t;
+        // using repacking_type = typename repacking_prod<packingT1, packingT2>::packing_type;
+        using repacking_type =
+            typename pyre::grid::Canonical<rank, std::array>; // TOFIX not general wrt packings
+
+    public:
+        using type = typename tensor<scalar_type, repacking_type, dims>::type;
+    };
+
     // the type resulting from the product of {T1} and {T2}
     template <class T1, class T2>
     struct product;

--- a/lib/pyre/tensor/transcendental.h
+++ b/lib/pyre/tensor/transcendental.h
@@ -1,0 +1,215 @@
+// -*- coding: utf-8 -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+//
+
+// Constexpr implementation of transcendental functions until C++26 implements them
+
+// code guard
+#if !defined(pyre_tensor_transcendental_h)
+#define pyre_tensor_transcendental_h
+
+
+namespace pyre::tensor {
+
+    // helper function to compute factorial
+    constexpr double factorial(int n)
+    {
+        return (n <= 1) ? 1 : n * factorial(n - 1);
+    }
+
+    // helper function to compute power
+    constexpr double pow_helper(double base, int exp)
+    {
+        return (exp == 0) ? 1 :
+               (exp > 0)  ? base * pow_helper(base, exp - 1) :
+                            1 / pow_helper(base, -exp);
+    }
+
+    // {constexpr} pow for integer exponents
+    constexpr double pow(double base, int exp)
+    {
+        if (std::is_constant_evaluated()) {
+            return pow_helper(base, exp);
+        } else {
+            return std::pow(base, exp);
+        }
+    }
+
+    // helper function to compute the series sum
+    constexpr double exp_series(double x, int terms = 15)
+    {
+        return (terms == 0) ? 1 : pow(x, terms) / factorial(terms) + exp_series(x, terms - 1);
+    }
+
+    // {constexpr} exp function
+    constexpr double exp(double x)
+    {
+        if (std::is_constant_evaluated()) {
+            return exp_series(x);
+        } else {
+            return std::exp(x);
+        }
+    }
+
+    // helper function to compute log using Newton's method
+    constexpr double log_newton(double x, double guess = 1.0, int iterations = 15)
+    {
+        return (iterations == 0) ?
+                   guess :
+                   log_newton(x, guess - (exp(guess) - x) / exp(guess), iterations - 1);
+    }
+
+    // {constexpr} log function
+    constexpr double log_helper(double x)
+    {
+        return (x < 0)  ? std::numeric_limits<double>::quiet_NaN() :
+               (x == 0) ? -std::numeric_limits<double>::infinity() :
+               (x == 1) ? 0.0 :
+                          log_newton(x);
+    }
+
+    // {constexpr} log function
+    constexpr double log(double x)
+    {
+        if (std::is_constant_evaluated()) {
+            return log_helper(x);
+        } else {
+            return std::log(x);
+        }
+    }
+    
+    // helper function to compute sqrt using Newton's method
+    constexpr double sqrt_newton(double x, double guess = 1.0, int iterations = 15)
+    {
+        return (iterations == 0) ? guess :
+                                   sqrt_newton(x, 0.5 * (guess + x / guess), iterations - 1);
+    }
+
+    // {constexpr} sqrt function
+    constexpr double sqrt_helper(double x)
+    {
+        return (x < 0) ? std::numeric_limits<double>::quiet_NaN() : (x == 0) ? 0.0 : sqrt_newton(x);
+    }
+
+    // {constexpr} sqrt function
+    constexpr double sqrt(double x)
+    {
+        if (std::is_constant_evaluated()) {
+            return sqrt_helper(x);
+        } else {
+            return std::sqrt(x);
+        }
+    }
+
+    // Taylor series expansion for sine
+    constexpr double sin_taylor(double x, int terms = 15)
+    {
+        double result = 0.0;
+        double power = x;
+        for (int i = 0; i < terms; ++i) {
+            int sign = (i % 2 == 0) ? 1 : -1;
+            result += sign * power / factorial(2 * i + 1);
+            power *= x * x;
+        }
+        return result;
+    }
+
+    // {constexpr} sin function
+    constexpr double sin(double x)
+    {
+        if (std::is_constant_evaluated()) {
+            return sin_taylor(x);
+        } else {
+            return std::sin(x);
+        }
+    }
+
+    // Taylor series expansion for cosine
+    constexpr double cos_taylor(double x, int terms = 15)
+    {
+        double result = 0.0;
+        double power = 1.0;
+        for (int i = 0; i < terms; ++i) {
+            int sign = (i % 2 == 0) ? 1 : -1;
+            result += sign * power / factorial(2 * i);
+            power *= x * x;
+        }
+        return result;
+    }
+
+    // {constexpr} cos function
+    constexpr double cos(double x)
+    {
+        if (std::is_constant_evaluated()) {
+            return cos_taylor(x);
+        } else {
+            return std::cos(x);
+        }
+    }
+
+    // Taylor series expansion for tangent
+    constexpr double atan_poly(double x, int terms = 15)
+    {
+        if (x > 1.0) {
+            return M_PI / 2 - atan(1 / x);
+        } else if (x < -1.0) {
+            return -M_PI / 2 - atan(1 / x);
+        } else {
+            double result = 0.0;
+            double term = x;
+            int sign = 1;
+            for (int i = 1; i <= terms; ++i) {
+                result += sign * term / (2 * i - 1);
+                term *= x * x;
+                sign = -sign;
+            }
+            return result;
+        }
+    }
+
+    // {constexpr} atan function
+    constexpr double atan(double x)
+    {
+        if (std::is_constant_evaluated()) {
+            return atan_poly(x);
+        } else {
+            return std::atan(x);
+        }
+    }
+
+    // Taylor series expansion for arctangent
+    constexpr double atan2_poly(double y, double x)
+    {
+        if (x > 0) {
+            return atan(y / x);
+        } else if (x < 0 && y >= 0) {
+            return atan(y / x) + M_PI;
+        } else if (x < 0 && y < 0) {
+            return atan(y / x) - M_PI;
+        } else if (x == 0 && y > 0) {
+            return M_PI / 2;
+        } else if (x == 0 && y < 0) {
+            return -M_PI / 2;
+        }
+        // undefined case when x == 0 and y == 0
+        return 0.0;
+    }
+
+    // {constexpr} atan2 function
+    constexpr double atan2(double y, double x)
+    {
+        if (std::is_constant_evaluated()) {
+            return atan2_poly(y, x);
+        } else {
+            return std::atan2(y, x);
+        }
+    }
+
+} // namespace pyre::tensor
+
+
+#endif
+
+// end of file

--- a/tests/pyre.lib/tensor/quaternion_composition.cc
+++ b/tests/pyre.lib/tensor/quaternion_composition.cc
@@ -7,6 +7,7 @@
 
 // support
 #include <cassert>
+#include <numbers>
 // get the tensor algebra
 #include <pyre/tensor.h>
 

--- a/tests/pyre.lib/tensor/quaternion_composition.cc
+++ b/tests/pyre.lib/tensor/quaternion_composition.cc
@@ -20,37 +20,37 @@ int
 main(int argc, char * argv[])
 {
     // pick an angle
-    constexpr auto angle_1 = std::numbers::pi / 2.0;
+    auto angle_1 = std::numbers::pi / 2.0;
 
     // pick an axis
-    constexpr auto axis_1 = normalize(vector_t<3> { 0.0, 0.0, 1.0 });
+    auto axis_1 = normalize(vector_t<3> { 0.0, 0.0, 1.0 });
 
     // create a quaternion
-    constexpr auto quaternion_1 = quaternion_t(angle_1, axis_1);
+    auto quaternion_1 = quaternion_t(angle_1, axis_1);
 
     // pick an angle
-    constexpr auto angle_2 = std::numbers::pi / 2.0;
+    auto angle_2 = std::numbers::pi / 2.0;
 
     // pick an axis
-    constexpr auto axis_2 = normalize(vector_t<3> { 1.0, 0.0, 0.0 });
+    auto axis_2 = normalize(vector_t<3> { 1.0, 0.0, 0.0 });
 
     // create a quaternion
-    constexpr auto quaternion_2 = quaternion_t(angle_2, axis_2);
+    auto quaternion_2 = quaternion_t(angle_2, axis_2);
 
     // compose the two quaternions
-    constexpr auto quaternion_3 = quaternion_2 * quaternion_1;
+    auto quaternion_3 = quaternion_2 * quaternion_1;
 
     // pick a 3D vector
-    constexpr auto a = vector_t<3> { 1.0, 0.0, 0.0 };
+    auto a = vector_t<3> { 1.0, 0.0, 0.0 };
 
     // rotate {a} with the quaternion
-    constexpr auto b = quaternion_3.rotation() * a;
+    auto b = quaternion_3.rotation() * a;
 
     // the expected result
-    constexpr auto b_exact = vector_t<3> { 0.0, 0.0, 1.0 };
+    auto b_exact = vector_t<3> { 0.0, 0.0, 1.0 };
 
     // check that the expected result is obtained up to a reasonable tolerance
-    static_assert(norm(b - b_exact) < 1.e-15);
+    assert(norm(b - b_exact) < 1.e-15);
 
     // all done
     return 0;

--- a/tests/pyre.lib/tensor/quaternion_inverse.cc
+++ b/tests/pyre.lib/tensor/quaternion_inverse.cc
@@ -20,28 +20,28 @@ int
 main(int argc, char * argv[])
 {
     // pick an angle
-    constexpr auto angle = std::numbers::pi / 2.0;
+    auto angle = std::numbers::pi / 2.0;
 
     // pick an axis
-    constexpr auto axis = normalize(vector_t<3> { 0.0, 0.0, 1.0 });
+    auto axis = normalize(vector_t<3> { 0.0, 0.0, 1.0 });
 
     // create a quaternion
-    constexpr auto quaternion = quaternion_t(angle, axis);
+    auto quaternion = quaternion_t(angle, axis);
 
     // pick a 3D vector
-    constexpr auto a = vector_t<3> { 1.0, 0.0, 0.0 };
+    auto a = vector_t<3> { 1.0, 0.0, 0.0 };
 
     // rotate {a} with the quaternion
-    constexpr auto b = quaternion.rotation() * a;
+    auto b = quaternion.rotation() * a;
 
     // create the quaternion representing the inverse rotation
-    constexpr auto quaternion_inv = quaternion_t(-angle, axis);
+    auto quaternion_inv = quaternion_t(-angle, axis);
 
     // rotate {b} with the inverse quaternion
-    constexpr auto c = quaternion_inv.rotation() * b;
+    auto c = quaternion_inv.rotation() * b;
 
     // check that the composition of the two rotations is the identity
-    static_assert(a == c);
+    assert(a == c);
 
     // all done
     return 0;

--- a/tests/pyre.lib/tensor/quaternion_inverse.cc
+++ b/tests/pyre.lib/tensor/quaternion_inverse.cc
@@ -7,6 +7,7 @@
 
 // support
 #include <cassert>
+#include <numbers>
 // get the tensor algebra
 #include <pyre/tensor.h>
 

--- a/tests/pyre.lib/tensor/tensor_concepts.cc
+++ b/tests/pyre.lib/tensor/tensor_concepts.cc
@@ -24,6 +24,9 @@ main(int argc, char * argv[])
     // a 1x1 matrix is not a (proper) matrix
     static_assert(matrix_c<matrix_t<1, 1>> == false);
 
+    // a 1x1 matrix is a scalar
+    static_assert(scalar_c<matrix_t<1, 1>> == true);
+
     // a 1x1 matrix is not a vector
     static_assert(vector_c<matrix_t<1, 1>> == false);
 

--- a/tests/pyre.lib/tensor/tensor_concepts.cc
+++ b/tests/pyre.lib/tensor/tensor_concepts.cc
@@ -21,8 +21,8 @@ main(int argc, char * argv[])
     // make a channel
     pyre::journal::info_t channel("pyre.tensor.tensor_concepts");
 
-    // a 1x1 matrix is not a (proper) matrix
-    static_assert(matrix_c<matrix_t<1, 1>> == false);
+    // a 1x1 matrix is a (n improper) matrix
+    static_assert(matrix_c<matrix_t<1, 1>> == true);
 
     // a 1x1 matrix is a scalar
     static_assert(scalar_c<matrix_t<1, 1>> == true);
@@ -30,17 +30,17 @@ main(int argc, char * argv[])
     // a 1x1 matrix is not a vector
     static_assert(vector_c<matrix_t<1, 1>> == false);
 
-    // a 1x2 matrix is not a (proper) matrix
-    static_assert(matrix_c<matrix_t<1, 2>> == false);
+    // a 1x2 matrix is a (n improper) matrix
+    static_assert(matrix_c<matrix_t<1, 2>> == true);
 
-    // a 1x2 matrix is a vector
-    static_assert(vector_c<matrix_t<1, 2>> == true);
+    // a 1x2 matrix is not a vector
+    static_assert(vector_c<matrix_t<1, 2>> == false);
 
-    // a 2x1 matrix is not a (proper) matrix
-    static_assert(matrix_c<matrix_t<2, 1>> == false);
+    // a 2x1 matrix is a (n improper) matrix
+    static_assert(matrix_c<matrix_t<2, 1>> == true);
 
-    // a 2x1 matrix is a vector
-    static_assert(vector_c<matrix_t<2, 1>> == true);
+    // a 2x1 matrix is a not vector
+    static_assert(vector_c<matrix_t<2, 1>> == false);
 
     // a 2x2 matrix is a (proper) matrix
     static_assert(matrix_c<matrix_t<2, 2>> == true);
@@ -51,8 +51,8 @@ main(int argc, char * argv[])
     // a 1D vector is a not matrix
     static_assert(matrix_c<vector_t<1>> == false);
 
-    // a 1D vector is not a (proper) vector
-    static_assert(vector_c<vector_t<1>> == false);
+    // a 1D vector is a (n improper) vector
+    static_assert(vector_c<vector_t<1>> == true);
 
     // a 2D vector is a not matrix
     static_assert(matrix_c<vector_t<2>> == false);
@@ -60,14 +60,14 @@ main(int argc, char * argv[])
     // a 2D vector is a (proper) vector
     static_assert(vector_c<vector_t<2>> == true);
 
-    // a 1x1 symmetric matrix is not a (proper) matrix
-    static_assert(matrix_c<symmetric_matrix_t<1>> == false);
+    // a 1x1 symmetric matrix is a (n improper) matrix
+    static_assert(matrix_c<symmetric_matrix_t<1>> == true);
 
     // a 1x1 symmetric matrix is not a vector
     static_assert(vector_c<symmetric_matrix_t<1>> == false);
 
-    // a 1x1 diagonal matrix is not a (proper) matrix
-    static_assert(matrix_c<diagonal_matrix_t<1>> == false);
+    // a 1x1 diagonal matrix is a (n improper) matrix
+    static_assert(matrix_c<diagonal_matrix_t<1>> == true);
 
     // a 1x1 diagonal matrix is not a vector
     static_assert(vector_c<diagonal_matrix_t<1>> == false);

--- a/tests/pyre.lib/tensor/tensor_contractions.cc
+++ b/tests/pyre.lib/tensor/tensor_contractions.cc
@@ -1,0 +1,46 @@
+// -*- coding: utf-8 -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+//
+
+
+// dependencies
+#include <pyre/tensor.h>
+
+using namespace pyre::tensor;
+
+// main program
+int
+main(int argc, char * argv[])
+{
+    // initialize the journal
+    pyre::journal::init(argc, argv);
+    pyre::journal::application("tensor_contractions");
+
+    // make a channel
+    pyre::journal::info_t channel("pyre.tensor.tensor_contractions");
+
+    // the contraction type resulting from a 2x5 matrix and a 5D vector
+    using contraction_matrix_vector = contraction<matrix_t<2, 5>, vector_t<5>>::type;
+    // check that the contraction is a 2D vector
+    static_assert(std::is_same_v<contraction_matrix_vector, vector_t<2>>);
+
+    // the contraction type resulting from a 2D vector and a 2x5 matrix
+    using contraction_vector_matrix = contraction<vector_t<2>, matrix_t<2, 5>>::type;
+    // check that the contraction is a 5D vector
+    static_assert(std::is_same_v<contraction_vector_matrix, vector_t<5>>);
+
+    // the contraction type resulting from fourth order tensor that maps 2x5 matrices into
+    // 2x5 matrices and a 2x5 matrix
+    using contraction_fourth_order_matrix =
+        contraction<fourth_order_tensor_t<2, 5, 2, 5>, matrix_t<2, 5>>::type;
+    // check that the contraction is a 2x5 matrix
+    static_assert(std::is_same_v<contraction_fourth_order_matrix, matrix_t<2, 5>>);
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.lib/tensor/tensor_dot.cc
+++ b/tests/pyre.lib/tensor/tensor_dot.cc
@@ -1,0 +1,51 @@
+// -*- coding: utf-8 -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+//
+
+
+// support
+#include <cassert>
+// get the tensor algebra
+#include <pyre/tensor.h>
+
+
+// use namespace for readability
+using namespace pyre::tensor;
+
+
+// main program
+int
+main(int argc, char * argv[])
+{
+    // initialize the journal
+    pyre::journal::init(argc, argv);
+    pyre::journal::application("tensor_dot");
+
+    // make a channel
+    pyre::journal::info_t channel("pyre.tensor");
+
+    // a canonical tensor
+    constexpr auto tensor_1 = matrix_t<2, 2> { 1.0, 2.0, 3.0, 4.0 };
+
+    // a symmetric tensor
+    constexpr auto tensor_2 = symmetric_matrix_t<2> { -1.0, -2.0, -4.0 };
+
+    // compute the dot product of {tensor_1} and {tensor_2}
+    constexpr auto result = dot(tensor_1, tensor_2);
+
+    // report
+    channel << "tensor_1 = " << tensor_1 << pyre::journal::newline;
+    channel << "tensor_2 = " << tensor_2 << pyre::journal::newline;
+    channel << "dot(tensor_1, tensor_2) = " << result << pyre::journal::endl;
+
+    // check the result
+    static_assert(result == -27.0);
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.lib/tensor/tensor_eigenvalues.cc
+++ b/tests/pyre.lib/tensor/tensor_eigenvalues.cc
@@ -19,6 +19,9 @@ using namespace pyre::tensor;
 int
 main(int argc, char * argv[])
 {
+    // tolerance
+    constexpr auto tol = 1e-16;
+
     {
         // the packing-agnostic canonical basis of R^2x2
         constexpr auto e_00 = unit<matrix_t<2>, 0, 0>;
@@ -38,7 +41,7 @@ main(int argc, char * argv[])
         constexpr auto eigenvectors_A = eigenvectors(A);
 
         // product of eigenvalues is equal to determinant
-        static_assert(lambda_A[0] * lambda_A[1] == determinant(A));
+        static_assert(lambda_A[0] * lambda_A[1] - determinant(A) < tol);
 
         // sum of eigenvalues is equal to trace
         static_assert(lambda_A[0] + lambda_A[1] == trace(A));
@@ -79,7 +82,7 @@ main(int argc, char * argv[])
         constexpr auto eigenvectors_B = eigenvectors(B);
 
         // product of eigenvalues is equal to determinant
-        static_assert(lambda_B[0] * lambda_B[1] * lambda_B[2] == determinant(B));
+        static_assert(lambda_B[0] * lambda_B[1] * lambda_B[2] - determinant(B) < tol);
 
         // sum of eigenvalues is equal to trace
         static_assert(lambda_B[0] + lambda_B[1] + lambda_B[2] == trace(B));

--- a/tests/pyre.lib/tensor/tensor_eigenvalues_transformation.cc
+++ b/tests/pyre.lib/tensor/tensor_eigenvalues_transformation.cc
@@ -20,16 +20,16 @@ int
 main(int argc, char * argv[])
 {
     // exp(zero) = one
-    static_assert(function(zero<matrix_t<2>>, pyre::tensor::exp) == identity<matrix_t<2>>);
+    static_assert(function(zero<matrix_t<2>>, pyre::math::exp) == identity<matrix_t<2>>);
 
     // log(one) = zero
-    static_assert(function(identity<matrix_t<2>>, pyre::tensor::log) == zero<matrix_t<2>>);
+    static_assert(function(identity<matrix_t<2>>, pyre::math::log) == zero<matrix_t<2>>);
 
     // exp(zero) = one
-    static_assert(function(zero<matrix_t<3>>, pyre::tensor::exp) == identity<matrix_t<3>>);
+    static_assert(function(zero<matrix_t<3>>, pyre::math::exp) == identity<matrix_t<3>>);
 
     // log(one) = zero
-    static_assert(function(identity<matrix_t<3>>, pyre::tensor::log) == zero<matrix_t<3>>);
+    static_assert(function(identity<matrix_t<3>>, pyre::math::log) == zero<matrix_t<3>>);
 
     // all done
     return 0;

--- a/tests/pyre.lib/tensor/tensor_eigenvalues_transformation.cc
+++ b/tests/pyre.lib/tensor/tensor_eigenvalues_transformation.cc
@@ -19,25 +19,17 @@ using namespace pyre::tensor;
 int
 main(int argc, char * argv[])
 {
-    // define constexpr versions of exp and log
-    constexpr auto constexpr_exp = [](double x) {
-        return std::exp(x);
-    };
-    constexpr auto constexpr_log = [](double x) {
-        return std::log(x);
-    };
-
     // exp(zero) = one
-    static_assert(function(zero<matrix_t<2>>, constexpr_exp) == identity<matrix_t<2>>);
+    static_assert(function(zero<matrix_t<2>>, pyre::tensor::exp) == identity<matrix_t<2>>);
 
     // log(one) = zero
-    static_assert(function(identity<matrix_t<2>>, constexpr_log) == zero<matrix_t<2>>);
+    static_assert(function(identity<matrix_t<2>>, pyre::tensor::log) == zero<matrix_t<2>>);
 
     // exp(zero) = one
-    static_assert(function(zero<matrix_t<3>>, constexpr_exp) == identity<matrix_t<3>>);
+    static_assert(function(zero<matrix_t<3>>, pyre::tensor::exp) == identity<matrix_t<3>>);
 
     // log(one) = zero
-    static_assert(function(identity<matrix_t<3>>, constexpr_log) == zero<matrix_t<3>>);
+    static_assert(function(identity<matrix_t<3>>, pyre::tensor::log) == zero<matrix_t<3>>);
 
     // all done
     return 0;

--- a/tests/pyre.lib/tensor/tensor_eigenvalues_transformation.cc
+++ b/tests/pyre.lib/tensor/tensor_eigenvalues_transformation.cc
@@ -21,10 +21,10 @@ main(int argc, char * argv[])
 {
     // define constexpr versions of exp and log
     constexpr auto constexpr_exp = [](double x) {
-        return exp(x);
+        return std::exp(x);
     };
     constexpr auto constexpr_log = [](double x) {
-        return log(x);
+        return std::log(x);
     };
 
     // exp(zero) = one

--- a/tests/pyre.lib/tensor/tensor_fourth_order_contraction.cc
+++ b/tests/pyre.lib/tensor/tensor_fourth_order_contraction.cc
@@ -18,32 +18,62 @@ using namespace pyre::tensor;
 int
 main(int argc, char * argv[])
 {
-    // construct a fourth-order tensor filled with ones
-    constexpr auto C = ones<fourth_order_tensor_t<3, 3, 3, 3>>;
+    {
+        // construct a fourth-order tensor filled with ones
+        constexpr auto C = ones<fourth_order_tensor_t<3, 3, 3, 3>>;
 
-    // construct a matrix {A}
-    constexpr auto a = 1.0;
-    constexpr auto b = 2.0;
-    constexpr auto c = -1.0;
-    constexpr auto d = -3.0;
-    constexpr auto e = 1.0;
-    constexpr auto f = -1.0;
-    constexpr auto A = matrix_t<3, 3> { a, d, e, d, b, f, e, f, c };
+        // construct a matrix {A}
+        constexpr auto a = 1.0;
+        constexpr auto b = 2.0;
+        constexpr auto c = -1.0;
+        constexpr auto d = -3.0;
+        constexpr auto e = 1.0;
+        constexpr auto f = -1.0;
+        constexpr auto A = matrix_t<3, 3> { a, d, e, d, b, f, e, f, c };
 
-    // compute {B} as the contraction of {C} and {A}
-    constexpr auto B = C * A;
+        // compute {B} as the contraction of {C} and {A}
+        constexpr auto B = C * A;
 
-    // check that each component of {B} equals the sum of all entries in {A}
-    constexpr auto sum = a + b + c + 2.0 * d + 2.0 * e + 2.0 * f;
-    static_assert((B[{ 0, 0 }] == sum));
-    static_assert((B[{ 0, 1 }] == sum));
-    static_assert((B[{ 0, 2 }] == sum));
-    static_assert((B[{ 1, 0 }] == sum));
-    static_assert((B[{ 1, 1 }] == sum));
-    static_assert((B[{ 1, 2 }] == sum));
-    static_assert((B[{ 2, 0 }] == sum));
-    static_assert((B[{ 2, 1 }] == sum));
-    static_assert((B[{ 2, 2 }] == sum));
+        // check that each component of {B} equals the sum of all entries in {A}
+        constexpr auto sum = a + b + c + 2.0 * d + 2.0 * e + 2.0 * f;
+        static_assert((B[{ 0, 0 }] == sum));
+        static_assert((B[{ 0, 1 }] == sum));
+        static_assert((B[{ 0, 2 }] == sum));
+        static_assert((B[{ 1, 0 }] == sum));
+        static_assert((B[{ 1, 1 }] == sum));
+        static_assert((B[{ 1, 2 }] == sum));
+        static_assert((B[{ 2, 0 }] == sum));
+        static_assert((B[{ 2, 1 }] == sum));
+        static_assert((B[{ 2, 2 }] == sum));
+    }
+
+    {
+        // construct a fourth-order tensor
+        constexpr auto C =
+            fourth_order_tensor_t<2, 2, 2, 2> { 1.0, 2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
+                                                9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0 };
+
+        // construct a matrix {A}
+        constexpr auto A = matrix_t<2, 2> { 1.0, 2.0, -1.0, -2.0 };
+
+        // compute {B} as the contraction of {C} and {A}, {C} on the right
+        constexpr auto B_right = A * C;
+
+        // check that each component of {B} are correct
+        static_assert((B_right[{ 0, 0 }] == -24.0));
+        static_assert((B_right[{ 0, 1 }] == -24.0));
+        static_assert((B_right[{ 1, 0 }] == -24.0));
+        static_assert((B_right[{ 1, 1 }] == -24.0));
+
+        // compute {B} as the contraction of {C} and {A}, {C} on the left
+        constexpr auto B_left = C * A;
+
+        // check that each component of {B} are correct
+        static_assert((B_left[{ 0, 0 }] == -6.0));
+        static_assert((B_left[{ 0, 1 }] == -6.0));
+        static_assert((B_left[{ 1, 0 }] == -6.0));
+        static_assert((B_left[{ 1, 1 }] == -6.0));
+    }
 
     // all done
     return 0;

--- a/tests/pyre.lib/tensor/tensor_fourth_order_contraction.cc
+++ b/tests/pyre.lib/tensor/tensor_fourth_order_contraction.cc
@@ -1,0 +1,53 @@
+// -*- coding: utf-8 -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+//
+
+
+// support
+#include <cassert>
+// get the tensor algebra
+#include <pyre/tensor.h>
+
+// use namespace for readability
+using namespace pyre::tensor;
+
+
+// main program
+int
+main(int argc, char * argv[])
+{
+    // construct a fourth-order tensor filled with ones
+    constexpr auto C = ones<fourth_order_tensor_t<3, 3, 3, 3>>;
+
+    // construct a matrix {A}
+    constexpr auto a = 1.0;
+    constexpr auto b = 2.0;
+    constexpr auto c = -1.0;
+    constexpr auto d = -3.0;
+    constexpr auto e = 1.0;
+    constexpr auto f = -1.0;
+    constexpr auto A = matrix_t<3, 3> { a, d, e, d, b, f, e, f, c };
+
+    // compute {B} as the contraction of {C} and {A}
+    constexpr auto B = C * A;
+
+    // check that each component of {B} equals the sum of all entries in {A}
+    constexpr auto sum = a + b + c + 2.0 * d + 2.0 * e + 2.0 * f;
+    static_assert((B[{ 0, 0 }] == sum));
+    static_assert((B[{ 0, 1 }] == sum));
+    static_assert((B[{ 0, 2 }] == sum));
+    static_assert((B[{ 1, 0 }] == sum));
+    static_assert((B[{ 1, 1 }] == sum));
+    static_assert((B[{ 1, 2 }] == sum));
+    static_assert((B[{ 2, 0 }] == sum));
+    static_assert((B[{ 2, 1 }] == sum));
+    static_assert((B[{ 2, 2 }] == sum));
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.lib/tensor/tensor_matrix_assignment.cc
+++ b/tests/pyre.lib/tensor/tensor_matrix_assignment.cc
@@ -1,0 +1,89 @@
+// -*- coding: utf-8 -*-
+//
+// bianca giovanardi
+// (c) 1998-2024 all rights reserved
+//
+
+
+// support
+#include <cassert>
+// get the tensor algebra
+#include <pyre/tensor.h>
+
+
+// use namespace for readability
+using namespace pyre::tensor;
+
+
+// main program
+int
+main(int argc, char * argv[])
+{
+    // the packing-agnostic canonical basis of R^2x2
+    constexpr auto e00 = unit<matrix_t<2>, 0, 0>;
+    constexpr auto e01 = unit<matrix_t<2>, 0, 1>;
+    constexpr auto e10 = unit<matrix_t<2>, 1, 0>;
+    constexpr auto e11 = unit<matrix_t<2>, 1, 1>;
+    // the out-of-diagonal basis element for symmetric matrices
+    constexpr auto e01_sym = unit<symmetric_matrix_t<2>, 0, 1>;
+
+    // build a canonical matrix
+    constexpr auto A_canonical = 1.0 * e00 - 1.0 * e01 - 1.0 * e10 + 2.0 * e11;
+
+    // build a symmetric matrix
+    constexpr auto A_symmetric = 1.0 * e00 - 1.0 * e01_sym + 2.0 * e11;
+
+    // build a diagonal matrix
+    constexpr auto A_diagonal = 1.0 * e00 + 2.0 * e11;
+
+    // assign a canonical matrix to a canonical matrix
+    constexpr matrix_t<2> B_canonical = A_canonical;
+
+    // verify that the assignment worked
+    static_assert(B_canonical == A_canonical);
+
+    // assign a symmetric matrix to a symmetric matrix
+    constexpr symmetric_matrix_t<2> B_symmetric = A_symmetric;
+
+    // verify that the assignment worked
+    static_assert(B_symmetric == A_symmetric);
+
+    // assign a diagonal matrix to a diagonal matrix
+    constexpr diagonal_matrix_t<2> B_diagonal = A_diagonal;
+
+    // verify that the assignment worked
+    static_assert(B_diagonal == A_diagonal);
+
+    // assign a symmetric matrix to a canonical matrix
+    constexpr matrix_t<2> B_canonical_1 = A_symmetric;
+
+    // verify that the assignment worked
+    static_assert(B_canonical_1 == A_symmetric);
+
+    // assign a diagonal matrix to a canonical matrix
+    constexpr matrix_t<2> B_canonical_2 = A_diagonal;
+
+    // verify that the assignment worked
+    static_assert(B_canonical_2 == A_diagonal);
+
+    // assign a canonical matrix to a symmetric matrix (illegal, compiler error)
+    // constexpr symmetric_matrix_t<2> C_symmetric = A_canonical;
+
+    // assign a diagonal matrix to a symmetric matrix
+    constexpr symmetric_matrix_t<2> C_symmetric = A_diagonal;
+
+    // verify that the assignment worked
+    static_assert(C_symmetric == A_diagonal);
+
+    // assign a canonical matrix to a diagonal matrix (illegal, compiler error)
+    // constexpr diagonal_matrix_t<2> D_diagonal = A_canonical;
+
+    // assign a symmetric matrix to a diagonal matrix (illegal, compiler error)
+    // constexpr diagonal_matrix_t<2> D_diagonal = A_symmetric;
+
+    // all done
+    return 0;
+}
+
+
+// end of file


### PR DESCRIPTION
- revisited concepts of scalar, vector and matrix
- implemented contraction of fourth-order tensors with second-order tensors
- {tensor} now builds correctly with clang / libc++
- copying and assigning tensors now supports tensors with different but compatible packings (e.g. a diagonal tensor can be copied into / assigned to a canonical tensor, but not viceversa)
- implemented {dot} product of tensors
- implemented factory method to build tensors with random entries 