### PR TITLE
Benchmarks with `google-benchmark`

### DIFF
--- a/.cmake/pyre_benchmarks.cmake
+++ b/.cmake/pyre_benchmarks.cmake
@@ -17,7 +17,7 @@ function(pyre_benchmark_driver benchmarkfile)
   # with some macros
   target_compile_definitions(${target} PRIVATE PYRE_CORE)
   # link against my libraries
-  target_link_libraries(${target} PUBLIC pyre journal)
+  target_link_libraries(${target} PUBLIC pyre journal benchmark::benchmark)
   # specify the directory for the target compilation products
   pyre_target_directory(${target} benchmarks)
 
@@ -38,7 +38,7 @@ function(pyre_benchmark_driver_cxx20 benchmarkfile)
   # with some macros
   target_compile_definitions(${target} PRIVATE PYRE_CORE)
   # link against my libraries
-  target_link_libraries(${target} PUBLIC pyre journal)
+  target_link_libraries(${target} PUBLIC pyre journal benchmark::benchmark)
   # request c++20 to build the target
   target_compile_features(${target} PUBLIC cxx_std_20)
   target_compile_definitions(${target} PRIVATE WITH_CXX20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,8 @@ endif()
 
 # if we are building the benchmarks
 if(PYRE_BUILD_BENCHMARKS)
+  # find the benchmark library
+  find_package(benchmark REQUIRED)
 
   # get my functions
   include(pyre_benchmarks)

--- a/benchmarks/pyre.lib/tensor/matrix_norm.cc
+++ b/benchmarks/pyre.lib/tensor/matrix_norm.cc
@@ -5,239 +5,141 @@
 //
 
 
+// get the benchmark library
+#include <benchmark/benchmark.h>
+
 // get array
 #include <array>
-
-// get support
-#include <pyre/timers.h>
-#include <pyre/journal.h>
+// get tensor
 #include <pyre/tensor.h>
 
 
-// type aliases
-using process_timer_t = pyre::timers::process_timer_t;
-
-
-void
-norm_3D(int N)
+auto
+norm_3D_array(const auto & matrix)
 {
-    // make a channel
-    pyre::journal::info_t channel("tests.timer.norm");
-
-    // make a timer
-    process_timer_t t("tests.timer");
-
-    channel << "Computing " << N << " norms (3x3)" << pyre::journal::endl;
-
-
-    // ARRAY
-
-    // array tensor
-    std::array<double, 9> tensor_c { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, -1.0, 2.0, -2.0 };
-    double result_c = 0;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // norm (array)
-        result_c += std::sqrt(
-            tensor_c[0] * tensor_c[0] + tensor_c[1] * tensor_c[1] + tensor_c[2] * tensor_c[2]
-            + tensor_c[3] * tensor_c[3] + tensor_c[4] * tensor_c[4] + tensor_c[5] * tensor_c[5]
-            + tensor_c[6] * tensor_c[6] + tensor_c[7] * tensor_c[7] + tensor_c[8] * tensor_c[8]);
-    }
-
-    // stop the timer
-    t.stop();
-
-    // report
-    channel << "array " << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_c << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-
-    // PYRE TENSOR
-    // tensor matrix
-    pyre::tensor::matrix_t<3> tensor { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, -1.0, 2.0, -2.0 };
-    pyre::tensor::real result_tensor = 0.;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // norm (tensor)
-        result_tensor += pyre::tensor::norm(tensor);
-    }
-
-    // stop the timer
-    t.stop();
-
-    // report
-    channel << "pyre tensor" << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_tensor << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-    // all done
-    return;
+    // return the norm of the matrix
+    return std::sqrt(
+        matrix[0] * matrix[0] + matrix[1] * matrix[1] + matrix[2] * matrix[2]
+        + matrix[3] * matrix[3] + matrix[4] * matrix[4] + matrix[5] * matrix[5]
+        + matrix[6] * matrix[6] + matrix[7] * matrix[7] + matrix[8] * matrix[8]);
 }
 
-void
-norm_9D_diag(int N)
+auto
+norm_3D_symmetric_array(const auto & matrix)
 {
-    // make a channel
-    pyre::journal::info_t channel("tests.timer.norm");
-
-    // make a timer
-    process_timer_t t("tests.timer");
-
-    channel << "Computing " << N << " norms (9x9, diagonal)" << pyre::journal::endl;
-
-
-    // ARRAY
-
-    // array tensor
-    std::array<double, 9> tensor_c { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, -1.0, 2.0, -2.0 };
-    double result_c = 0;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // norm (array)
-        result_c += std::sqrt(
-            tensor_c[0] * tensor_c[0] + tensor_c[1] * tensor_c[1] + tensor_c[2] * tensor_c[2]
-            + tensor_c[3] * tensor_c[3] + tensor_c[4] * tensor_c[4] + tensor_c[5] * tensor_c[5]
-            + tensor_c[6] * tensor_c[6] + tensor_c[7] * tensor_c[7] + tensor_c[8] * tensor_c[8]);
-    }
-
-    // stop the timer
-    t.stop();
-
-    // report
-    channel << "array " << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_c << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-
-    // PYRE TENSOR
-    // tensor matrix
-    pyre::tensor::diagonal_matrix_t<9> tensor = { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, -1.0, 2.0, -2.0 };
-    pyre::tensor::real result_tensor = 0.;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // norm (tensor)
-        result_tensor += pyre::tensor::norm(tensor);
-    }
-
-    // stop the timer
-    t.stop();
-
-    // report
-    channel << "pyre tensor" << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_tensor << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-    // all done
-    return;
+    // return the norm of the matrix
+    return std::sqrt(
+        matrix[0] * matrix[0] + 2.0 * matrix[1] * matrix[1] + 2.0 * matrix[2] * matrix[2]
+        + 2.0 * matrix[3] * matrix[3] + matrix[4] * matrix[4]);
 }
 
-void
-norm_3D_sym(int N)
+auto
+norm_9D_diagonal_array(const auto & matrix)
 {
-    // make a channel
-    pyre::journal::info_t channel("tests.timer.norm");
+    // return the norm of the matrix
+    return std::sqrt(
+        matrix[0] * matrix[0] + matrix[1] * matrix[1] + matrix[2] * matrix[2]
+        + matrix[3] * matrix[3] + matrix[4] * matrix[4] + matrix[5] * matrix[5]
+        + matrix[6] * matrix[6] + matrix[7] * matrix[7] + matrix[8] * matrix[8]);
+}
 
-    // make a timer
-    process_timer_t t("tests.timer");
+auto
+norm_tensor(const auto & matrix)
+{
+    // return the norm of the matrix
+    return pyre::tensor::norm(matrix);
+}
 
-    channel << "Computing " << N << " norms (3x3, symmetric)" << pyre::journal::endl;
+static void
+Norm3DArray(benchmark::State & state)
+{
+    // build the matrix
+    auto matrix = std::array<double, 9> { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, -1.0, 2.0, -2.0 };
 
-
-    // ARRAY
-
-    // array tensor
-    std::array<double, 6> tensor_c { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0 };
-    double result_c = 0;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // norm (array)
-        result_c += std::sqrt(
-            tensor_c[0] * tensor_c[0] + 2.0 * tensor_c[1] * tensor_c[1]
-            + 2.0 * tensor_c[2] * tensor_c[2] + 2.0 * tensor_c[3] * tensor_c[3]
-            + tensor_c[4] * tensor_c[4]);
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(norm_3D_array(matrix));
     }
+}
 
-    // stop the timer
-    t.stop();
+static void
+Norm3DTensor(benchmark::State & state)
+{
+    // build the matrix
+    auto matrix = pyre::tensor::matrix_t<3> { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, -1.0, 2.0, -2.0 };
 
-    // report
-    channel << "array " << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_c << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-
-    // PYRE TENSOR
-    // tensor matrix
-    pyre::tensor::symmetric_matrix_t<3> tensor = { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0 };
-    pyre::tensor::real result_tensor = 0.;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // norm (tensor)
-        result_tensor += pyre::tensor::norm(tensor);
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(norm_tensor(matrix));
     }
+}
 
-    // stop the timer
-    t.stop();
+static void
+Norm3DSymmetricArray(benchmark::State & state)
+{
+    // build the matrix
+    auto matrix = std::array<double, 6> { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0 };
 
-    // report
-    channel << "pyre tensor" << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_tensor << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(norm_3D_symmetric_array(matrix));
+    }
+}
 
-    // all done
-    return;
+static void
+Norm3DSymmetricTensor(benchmark::State & state)
+{
+    // build the matrix
+    auto matrix = pyre::tensor::symmetric_matrix_t<3> { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0 };
+
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(norm_tensor(matrix));
+    }
+}
+
+static void
+Norm9DDiagonalArray(benchmark::State & state)
+{
+    // build the matrix
+    auto matrix = std::array<double, 9> { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, -1.0, 2.0, -2.0 };
+
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(norm_9D_diagonal_array(matrix));
+    }
+}
+
+static void
+Norm9DDiagonalTensor(benchmark::State & state)
+{
+    // build the matrix
+    auto matrix =
+        pyre::tensor::diagonal_matrix_t<9> { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, -1.0, 2.0, -2.0 };
+
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(norm_tensor(matrix));
+    }
 }
 
 
-int
-main()
-{
-    // number of times to do operation
-    int N = 1 << 25;
+// run benchmark for 3D matrix (array)
+BENCHMARK(Norm3DArray);
+// run benchmark for 3D matrix (tensor)
+BENCHMARK(Norm3DTensor);
+// run benchmark for 3D symmetric matrix (array)
+BENCHMARK(Norm3DSymmetricArray);
+// run benchmark for 3D symmetric matrix (tensor)
+BENCHMARK(Norm3DSymmetricTensor);
+// run benchmark for 9D diagonal matrix (array)
+BENCHMARK(Norm9DDiagonalArray);
+// run benchmark for 9D diagonal matrix (tensor)
+BENCHMARK(Norm9DDiagonalTensor);
 
-    // run benchmark for 3D matrix
-    norm_3D(N);
 
-    // run benchmark for a 9D diagonal matrix
-    norm_9D_diag(N);
-
-    // run benchmark for a 3D symmetric matrix
-    norm_3D_sym(N);
-
-    // all done
-    return 0;
-}
+// run all benchmarks
+BENCHMARK_MAIN();
 
 
 // end of file

--- a/benchmarks/pyre.lib/tensor/matrix_times_scalar.cc
+++ b/benchmarks/pyre.lib/tensor/matrix_times_scalar.cc
@@ -5,104 +5,68 @@
 //
 
 
+// get the benchmark library
+#include <benchmark/benchmark.h>
+
 // get array
 #include <array>
-
-// get support
-#include <pyre/timers.h>
-#include <pyre/journal.h>
+// get tensor
 #include <pyre/tensor.h>
 
 
-// type aliases
-using process_timer_t = pyre::timers::process_timer_t;
-
-
-void
-matrix_times_scalar(int N)
+auto
+multiply_tensor(const auto & matrix, const auto & scalar)
 {
-    // make a channel
-    pyre::journal::info_t channel("tests.timer.matrix_times_scalar");
+    // return the multiplication
+    return scalar * matrix;
+}
 
-    // make a timer
-    process_timer_t t("tests.timer");
-
-    channel << "Computing " << N << " scalar-matrix multiplications" << pyre::journal::endl;
-
-
-    // ARRAY
-    // a scalar
-    pyre::tensor::real scalar = std::sqrt(2);
-
-    // array tensor
-    std::array<double, 9> tensor_c { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, 2.0, -1.0, 0.0 };
-    std::array<double, 9> result_c { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // scalar * vector (array)
-        for (size_t i = 0; i < tensor_c.size(); ++i) {
-            result_c[i] += scalar * tensor_c[i];
-        }
+auto
+multiply_array(const auto & matrix, const auto & scalar)
+{
+    // multiply the matrix by the scalar
+    auto result = std::array<double, 9> { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+    for (size_t i = 0; i < matrix.size(); ++i) {
+        result[i] = matrix[i] * scalar;
     }
 
-    // stop the timer
-    t.stop();
+    // return the result
+    return result;
+}
 
-    // report
-    channel << "array (for loop)" << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_c[0] << ", " << result_c[1] << ", " << result_c[2] << ", "
-            << result_c[3] << ", " << result_c[4] << ", " << result_c[5] << ", " << result_c[6]
-            << ", " << result_c[7] << ", " << result_c[8] << pyre::journal::newline
-            << "process time = " << t.ms() << " ms " << pyre::journal::newline
-            << pyre::journal::outdent(1) << pyre::journal::endl;
+static void
+MatrixTimesScalarArray(benchmark::State & state)
+{
+    // build the matrices
+    auto matrix = std::array<double, 9> { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, 2.0, -1.0, 0.0 };
 
-
-    // PYRE TENSOR (operator*)
-    // tensor vector
-    pyre::tensor::matrix_t<3> tensor { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, 2.0, -1.0, 0.0 };
-    pyre::tensor::matrix_t<3> result_tensor { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // scalar * vector (tensor)
-        result_tensor += scalar * tensor;
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(multiply_array(matrix, std::sqrt(2.0)));
     }
+}
 
-    // stop the timer
-    t.stop();
+static void
+MatrixTimesScalarTensor(benchmark::State & state)
+{
+    // build the matrices
+    auto matrix = pyre::tensor::matrix_t<3> { 1.0, -1.0, 2.0, 1.0, 0.0, 1.0, 2.0, -1.0, 0.0 };
 
-    // report
-    channel << "pyre tensor (result_tensor += scalar * tensor)" << pyre::journal::newline
-            << pyre::journal::indent(1) << "result = " << result_tensor << pyre::journal::newline
-            << "process time = " << t.ms() << " ms " << pyre::journal::newline
-            << pyre::journal::outdent(1) << pyre::journal::endl;
-
-    // all done
-    return;
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(multiply_tensor(matrix, std::sqrt(2.0)));
+    }
 }
 
 
-int
-main()
-{
-    // number of times to do operation
-    int N = 1 << 25;
+// run benchmark for 3D matrices (array)
+BENCHMARK(MatrixTimesScalarArray);
+// run benchmark for 3D matrices (tensor)
+BENCHMARK(MatrixTimesScalarTensor);
 
-    // scalar * matrix
-    matrix_times_scalar(N);
 
-    // all done
-    return 0;
-}
+// run all benchmarks
+BENCHMARK_MAIN();
 
 
 // end of file

--- a/benchmarks/pyre.lib/tensor/vector_norm.cc
+++ b/benchmarks/pyre.lib/tensor/vector_norm.cc
@@ -5,101 +5,67 @@
 //
 
 
+// get the benchmark library
+#include <benchmark/benchmark.h>
+
 // get array
 #include <array>
-
-// get support
-#include <pyre/timers.h>
-#include <pyre/journal.h>
+// get tensor
 #include <pyre/tensor.h>
 
 
-// type aliases
-using process_timer_t = pyre::timers::process_timer_t;
-
-
-void
-norm_vector(int N)
+auto
+norm_tensor(const auto & vector)
 {
-    // make a channel
-    pyre::journal::info_t channel("tests.timer.norm_vector");
-
-    // make a timer
-    process_timer_t t("tests.timer");
-
-    channel << "Computing " << N << " norms of vectors" << pyre::journal::endl;
-
-
-    // ARRAY
-
-    // array vector
-    std::array<double, 3> vector_c { 1.0, -1.0, 2.0 };
-    double result_c = 0.0;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        double squared_sum = 0.;
-        // norm of a vector (array)
-        for (size_t i = 0; i < vector_c.size(); ++i) {
-            squared_sum += vector_c[i] * vector_c[i];
-        }
-
-        result_c += std::sqrt(squared_sum);
-    }
-
-    // stop the timer
-    t.stop();
-
-    // report
-    channel << "array (for loop) " << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_c << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-
-    // PYRE TENSOR
-    // tensor vector
-    pyre::tensor::vector_t<3> vector { 1.0, -1.0, 2.0 };
-    pyre::tensor::real result_tensor = 0.;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // norm of a vector (tensor)
-        result_tensor += pyre::tensor::norm(vector);
-    }
-
-    // stop the timer
-    t.stop();
-
-    // report
-    channel << "pyre tensor" << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_tensor << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-    // all done
-    return;
+    // return the norm of the vector
+    return pyre::tensor::norm(vector);
 }
 
-
-int
-main()
+auto
+norm_array(const auto & vector)
 {
-    // number of times to do operation
-    int N = 1 << 25;
+    // compute the norm of the vector
+    double squared_sum = 0.;
+    for (size_t i = 0; i < vector.size(); ++i) {
+        squared_sum += vector[i] * vector[i];
+    }
 
-    // norm of a vector
-    norm_vector(N);
-
-    // all done
-    return 0;
+    // return the norm of the vector
+    return std::sqrt(squared_sum);
 }
+
+static void
+VectorNormArray(benchmark::State & state)
+{
+    // build the vector
+    auto vector = std::array<double, 3> { 1.0, -1.0, 2.0 };
+
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(norm_array(vector));
+    }
+}
+
+static void
+VectorNormTensor(benchmark::State & state)
+{
+    // build the vector
+    auto vector = pyre::tensor::vector_t<3> { 1.0, -1.0, 2.0 };
+
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(norm_tensor(vector));
+    }
+}
+
+// run benchmark for 3D vector (array)
+BENCHMARK(VectorNormArray);
+// run benchmark for 3D vector (tensor)
+BENCHMARK(VectorNormTensor);
+
+
+// run all benchmarks
+BENCHMARK_MAIN();
 
 
 // end of file

--- a/benchmarks/pyre.lib/tensor/vector_plus_vector.cc
+++ b/benchmarks/pyre.lib/tensor/vector_plus_vector.cc
@@ -5,101 +5,70 @@
 //
 
 
+// get the benchmark library
+#include <benchmark/benchmark.h>
+
 // get array
 #include <array>
-
-// get support
-#include <pyre/timers.h>
-#include <pyre/journal.h>
+// get tensor
 #include <pyre/tensor.h>
 
 
-// type aliases
-using process_timer_t = pyre::timers::process_timer_t;
-
-
-void
-vector_plus_vector(int N)
+auto
+sum_tensor(const auto & vector_1, const auto & vector_2)
 {
-    // make a channel
-    pyre::journal::info_t channel("tests.timer.vector_plus_vector");
+    // return the sum of the two vectors
+    return vector_1 + vector_2;
+}
 
-    // make a timer
-    process_timer_t t("tests.timer");
-
-    channel << "Computing " << N << " vector-vector sums" << pyre::journal::endl;
-
-
-    // ARRAY
-
-    // array vector
-    std::array<double, 3> vector1_c { 1.0, -1.0, 2.0 };
-    std::array<double, 3> vector2_c { 1.0, -1.0, 2.0 };
-    std::array<double, 3> result_c { 0.0, 0.0, 0.0 };
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // vector + vector (array)
-        for (size_t i = 0; i < vector1_c.size(); ++i) {
-            result_c[i] += vector2_c[i] + vector1_c[i];
-        }
+auto
+sum_array(const auto & vector_1, const auto & vector_2)
+{
+    // compute the sum of the two vectors
+    auto result = std::array<double, 3> { 0.0, 0.0, 0.0 };
+    for (size_t i = 0; i < result.size(); ++i) {
+        result[i] += vector_1[i] + vector_2[i];
     }
 
-    // stop the timer
-    t.stop();
+    // return the result
+    return result;
+}
 
-    // report
-    channel << "array (for loop) " << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = [ " << result_c[0] << ", " << result_c[1] << ", " << result_c[2] << " ]"
-            << pyre::journal::newline << "process time = " << t.ms() << " ms "
-            << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
+static void
+VectorSumArray(benchmark::State & state)
+{
+    // build the vectors
+    auto vector_1 = std::array<double, 3> { 1.0, -1.0, 2.0 };
+    auto vector_2 = std::array<double, 3> { 1.0, -1.0, 2.0 };
 
-
-    // PYRE TENSOR
-    // tensor vector
-    pyre::tensor::vector_t<3> vector1 { 1.0, -1.0, 2.0 };
-    pyre::tensor::vector_t<3> vector2 { 1.0, -1.0, 2.0 };
-    pyre::tensor::vector_t<3> result_tensor { 0.0, 0.0, 0.0 };
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // vector + vector (tensor)
-        result_tensor += vector2 + vector1;
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(sum_array(vector_1, vector_2));
     }
+}
 
-    // stop the timer
-    t.stop();
+static void
+VectorSumTensor(benchmark::State & state)
+{
+    // build the vectors
+    auto vector_1 = pyre::tensor::vector_t<3> { 1.0, -1.0, 2.0 };
+    auto vector_2 = pyre::tensor::vector_t<3> { 1.0, -1.0, 2.0 };
 
-    // report
-    channel << "pyre tensor" << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_tensor << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-    // all done
-    return;
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(sum_tensor(vector_1, vector_2));
+    }
 }
 
 
-int
-main()
-{
-    // number of times to do operation
-    int N = 1 << 25;
+// run benchmark for 3D vector (array)
+BENCHMARK(VectorSumArray);
+// run benchmark for 3D vector (tensor)
+BENCHMARK(VectorSumTensor);
 
-    // vector plus vector
-    vector_plus_vector(N);
 
-    // all done
-    return 0;
-}
+// run all benchmarks
+BENCHMARK_MAIN();
 
 
 // end of file

--- a/benchmarks/pyre.lib/tensor/vector_scalar_product.cc
+++ b/benchmarks/pyre.lib/tensor/vector_scalar_product.cc
@@ -5,125 +5,70 @@
 //
 
 
+// get the benchmark library
+#include <benchmark/benchmark.h>
+
 // get array
 #include <array>
-
-// get support
-#include <pyre/timers.h>
-#include <pyre/journal.h>
+// get tensor
 #include <pyre/tensor.h>
 
 
-// type aliases
-using process_timer_t = pyre::timers::process_timer_t;
-
-
-void
-vector_scalar_product(int N)
+auto
+dot_tensor(const auto & vector_1, const auto & vector_2)
 {
-    // make a channel
-    pyre::journal::info_t channel("tests.timer.vector_scalar_product");
+    // return the dot product of the vectors
+    return vector_1 * vector_2;
+}
 
-    // make a timer
-    process_timer_t t("tests.timer");
-
-    channel << "Computing " << N << " scalar products" << pyre::journal::endl;
-
-
-    // ARRAY FOR LOOP
-    // array vector
-    std::array<double, 3> vector_array_1 { 1.0, -1.0, 2.0 };
-    std::array<double, 3> vector_array_2 { 1.0, 1.0, 2.0 };
-    double result_array_for = 0.0;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    // vector * vector (array, for loop)
-    for (int n = 0; n < N; ++n) {
-        for (size_t i = 0; i < vector_array_1.size(); ++i) {
-            result_array_for += vector_array_1[i] * vector_array_2[i];
-        }
+auto
+dot_array(const auto & vector_1, const auto & vector_2)
+{
+    // compute the dot of the two vectors
+    auto result = 0.0;
+    for (size_t i = 0; i < vector_1.size(); ++i) {
+        result += vector_1[i] + vector_2[i];
     }
 
-    // stop the timer
-    t.stop();
+    // return the result
+    return result;
+}
 
-    // report
-    channel << "array (for loop)" << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_array_for << pyre::journal::newline
-            << "process time = " << t.ms() << " ms " << pyre::journal::newline
-            << pyre::journal::outdent(1) << pyre::journal::endl;
+static void
+VectorDotArray(benchmark::State & state)
+{
+    // build the vectors
+    auto vector_1 = std::array<double, 3> { 1.0, -1.0, 2.0 };
+    auto vector_2 = std::array<double, 3> { 1.0, 1.0, 2.0 };
 
-
-    // ARRAY EXPANDED BY HAND
-    double result_array = 0.0;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    // vector * vector (array, expanded)
-    for (int n = 0; n < N; ++n) {
-        result_array += vector_array_1[0] * vector_array_2[0]
-                      + vector_array_1[1] * vector_array_2[1]
-                      + vector_array_1[2] * vector_array_2[2];
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(dot_array(vector_1, vector_2));
     }
+}
 
-    // stop the timer
-    t.stop();
+static void
+VectorDotTensor(benchmark::State & state)
+{
+    // build the vectors
+    auto vector_1 = pyre::tensor::vector_t<3> { 1.0, -1.0, 2.0 };
+    auto vector_2 = pyre::tensor::vector_t<3> { 1.0, 1.0, 2.0 };
 
-    // report
-    channel << "array (expanded)" << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_array << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-
-    // PYRE TENSOR
-    // tensor vector
-    pyre::tensor::vector_t<3> vector_1 { 1.0, -1.0, 2.0 };
-    pyre::tensor::vector_t<3> vector_2 { 1.0, 1.0, 2.0 };
-    auto result_tensor = 0.0;
-
-    // reset timer
-    t.reset();
-    // start timer
-    t.start();
-
-    for (int n = 0; n < N; ++n) {
-        // vector * vector (tensor)
-        result_tensor += vector_1 * vector_2;
+    // repeat the operation sufficient number of times
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(dot_tensor(vector_1, vector_2));
     }
-
-    // stop the timer
-    t.stop();
-
-    // report
-    channel << "pyre tensor" << pyre::journal::newline << pyre::journal::indent(1)
-            << "result = " << result_tensor << pyre::journal::newline << "process time = " << t.ms()
-            << " ms " << pyre::journal::newline << pyre::journal::outdent(1) << pyre::journal::endl;
-
-
-    // all done
-    return;
 }
 
 
-int
-main()
-{
-    // number of times to do operation
-    int N = 1 << 25;
+// run benchmark for 3D vector (array)
+BENCHMARK(VectorDotArray);
+// run benchmark for 3D vector (tensor)
+BENCHMARK(VectorDotTensor);
 
-    // vector * vector
-    vector_scalar_product(N);
 
-    // all done
-    return 0;
-}
+// run all benchmarks
+BENCHMARK_MAIN();
 
 
 // end of file

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -29,7 +29,7 @@ pyre::tensor::norm(const tensorT & tensor) -> tensorT::scalar_type
     constexpr auto _norm_square = []<int... I>(
                                       const tensorT & tensor, integer_sequence<I...>) -> T {
         // get the offset of the {tensorT} packing corresponding to the J-th tensor entry
-        constexpr auto _entry_to_offset = []<int J>() {
+        auto _entry_to_offset = []<int J>() consteval {
             // ... the offset for the packing of {tensor} of ...
             return tensorT::layout().offset(
                 // ... the index corresponding to the J-th entry, J = 0, ..., D-1, in a


### PR DESCRIPTION
- Added `google-benchmark` support under `CMake`
- Rewritten all `pyre::tensor` benchmarks with `google-benchmark` syntax
- Fixed one minor inefficiency that emerged in `pyre::tensor`  