### PR TITLE
Issue129: adjust the uses of the canonical packing by pyre::tensor

### DIFF
--- a/.mm/journal.lib.tests
+++ b/.mm/journal.lib.tests
@@ -15,8 +15,9 @@ journal.lib.tests.harness :=
 # arguments to pass to each test case
 journal.lib.tests.argv :=
 # c++ compiler arguments
-journal.lib.tests.c++.defines := PYRE_CORE
-journal.lib.tests.c++.flags += -Wall $($(compiler.c++).std.c++17)
+journal.lib.tests.c++.flags += $(journal.lib.c++.flags)
+journal.lib.tests.c++.defines += $(journal.lib.c++.defines)
+
 # c compiler arguments
 journal.lib.tests.c.defines := PYRE_CORE
 journal.lib.tests.c.flags += -Wall $($(compiler.c).std.c11)

--- a/.mm/journal.mm
+++ b/.mm/journal.mm
@@ -28,8 +28,8 @@ journal.lib.incdir := $(builder.dest.inc)pyre/journal/
 # the main api header file; it is deposited one level above the rest
 journal.lib.gateway := journal.h
 # compiler control
-journal.lib.c++.defines += PYRE_CORE
-journal.lib.c++.flags += $($(compiler.c++).std.c++17)
+journal.lib.c++.flags += $(pyre.lib.c++.flags)
+journal.lib.c++.defines += $(pyre.lib.c++.defines)
 
 
 # the journal extension meta-data
@@ -42,8 +42,8 @@ journal.ext.capsule :=
 journal.ext.wraps := journal.lib
 journal.ext.extern := pybind11 python
 # compiler control
-journal.ext.lib.c++.defines += PYRE_CORE
-journal.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+journal.ext.lib.c++.flags += $(journal.lib.c++.flags)
+journal.ext.lib.c++.defines += $(journal.lib.c++.defines)
 
 
 # get the testsuites

--- a/.mm/pyre-cuda.lib.tests
+++ b/.mm/pyre-cuda.lib.tests
@@ -10,8 +10,8 @@ pyre-cuda.lib.tests.prerequisites := pyre-cuda.lib
 pyre-cuda.lib.tests.extern := pyre-cuda.lib pyre.lib journal.lib cuda
 
 # c++ compiler arguments
-pyre-cuda.lib.tests.c++.defines := PYRE_CORE
-pyre-cuda.lib.tests.c++.flags += -Wall $($(compiler.c++).std.c++17)
+pyre-cuda.lib.tests.c++.defines += $(pyre.lib.c++.defines)
+pyre-cuda.lib.tests.c++.flags += -Wall $(pyre.lib.c++.flags)
 
 
 # end of file

--- a/.mm/pyre-cuda.mm
+++ b/.mm/pyre-cuda.mm
@@ -34,8 +34,10 @@ pyre-cuda.lib.incdir := $(builder.dest.inc)pyre/cuda/
 pyre-cuda.lib.languages := c++ cuda
 pyre-cuda.lib.prerequisites := journal.lib pyre.lib
 pyre-cuda.lib.extern := pyre.lib pyre cuda
-pyre-cuda.lib.c++.flags += $($(compiler.c++).std.c++17)
-pyre-cuda.lib.cuda.flags += $(nvcc.std.c++17)
+pyre-cuda.lib.c++.flags += $(pyre.lib.c++.flags)
+pyre-cuda.lib.c++.defines += $(pyre.lib.c++.defines)
+pyre-cuda.lib.cuda.flags += $(nvcc.std.c++20)
+pyre-cuda.lib.cuda.defines += $(pyre.lib.c++.defines)
 
 # the extension
 pyre-cuda.ext.root := extensions/cuda/
@@ -44,7 +46,8 @@ pyre-cuda.ext.pkg := pyre-cuda.pkg
 pyre-cuda.ext.wraps :=
 pyre-cuda.ext.capsule :=
 pyre-cuda.ext.extern := pyre.lib journal.lib cuda python
-pyre-cuda.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+pyre-cuda.ext.lib.c++.flags += $(pyre-cuda.lib.c++.flags)
+pyre-cuda.ext.lib.c++.defines += $(pyre-cuda.lib.c++.defines)
 pyre-cuda.ext.lib.prerequisites += journal.lib pyre.lib
 
 # cuda configuration: make sure linking includes these libraries

--- a/.mm/pyre-gsl.mm
+++ b/.mm/pyre-gsl.mm
@@ -37,7 +37,8 @@ pyre-gsl.ext.wraps :=
 pyre-gsl.ext.capsule.destination := pyre/gsl/
 pyre-gsl.ext.lib.prerequisites := journal.lib pyre.lib
 pyre-gsl.ext.extern := pyre.lib journal.lib gsl
-pyre-gsl.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+pyre-gsl.ext.lib.c++.flags += $(pyre.lib.c++.flags)
+pyre-gsl.ext.lib.c++.defines += $(pyre.lib.c++.defines)
 
 #
 # adjustments that depend on  the availability of external dependencies

--- a/.mm/pyre-mpi.lib.tests
+++ b/.mm/pyre-mpi.lib.tests
@@ -8,7 +8,8 @@
 pyre-mpi.lib.tests.stem := mpi.lib
 pyre-mpi.lib.tests.prerequisites := pyre-mpi.lib
 pyre-mpi.lib.tests.extern := pyre-mpi.lib journal.lib mpi
-pyre-mpi.lib.tests.c++.flags += -Wall $($(compiler.c++).std.c++17)
+pyre-mpi.lib.tests.c++.flags += $(pyre.lib.c++.flags)
+pyre-mpi.lib.tests.c++.defines += $(pyre.lib.c++.defines)
 
 
 # set up a macro for the hostfile

--- a/.mm/pyre-mpi.mm
+++ b/.mm/pyre-mpi.mm
@@ -33,7 +33,8 @@ pyre-mpi.lib.incdir := $(builder.dest.inc)pyre/mpi/
 pyre-mpi.lib.gateway := mpi.h
 pyre-mpi.lib.prerequisites := journal.lib
 pyre-mpi.lib.extern := journal.lib mpi
-pyre-mpi.lib.c++.flags += $($(compiler.c++).std.c++17)
+pyre-mpi.lib.c++.flags += $(pyre.lib.c++.flags)
+pyre-mpi.lib.c++.defines += $(pyre.lib.c++.defines)
 
 # the mpi extension meta-data
 pyre-mpi.ext.root := extensions/mpi/
@@ -43,7 +44,8 @@ pyre-mpi.ext.wraps := pyre-mpi.lib
 pyre-mpi.ext.capsule.destination := pyre/mpi/
 pyre-mpi.ext.lib.prerequisites := pyre-mpi.lib pyre.lib
 pyre-mpi.ext.extern := pyre.lib journal.lib mpi python
-pyre-mpi.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+pyre-mpi.ext.lib.c++.flags += $(pyre-mpi.lib.c++.flags)
+pyre-mpi.ext.lib.c++.defines += $(pyre-mpi.lib.c++.defines)
 
 
 # get the testsuites

--- a/.mm/pyre.lib.tests
+++ b/.mm/pyre.lib.tests
@@ -47,7 +47,7 @@ tests.pyre.lib.grid.grid_mmap_get.pre := tests.pyre.lib.grid.grid_mmap_set
 #  - remove the check when c++20 becomes the minimum required
 #  - in the meantime, add more versions as they are supported
 pyre.lib.tests.drivers.exclude += \
-${if ${findstring $($(compiler.c++).std.c++20),$(pyre.lib.tests.c++.flags)},,\
+${if $(pyre.c++20),,\
     tensor/tensor_canonical_arithmetics.cc \
     tensor/tensor_canonical_basis.cc \
     tensor/tensor_cayley_hamilton_theorem.cc \
@@ -83,7 +83,7 @@ ${if ${findstring $($(compiler.c++).std.c++20),$(pyre.lib.tests.c++.flags)},,\
 #  - remove the check when c++20 becomes the minimum required
 #  - in the meantime, add more versions as they are supported
 pyre.lib.tests.drivers.exclude += \
-${if ${findstring $($(compiler.c++).std.c++20),$(pyre.lib.tests.c++.flags)},,\
+${if $(pyre.c++20),,\
     grid/symmetric_sanity.cc \
     grid/symmetric_visit.cc \
     grid/diagonal_visit.cc \

--- a/.mm/pyre.lib.tests
+++ b/.mm/pyre.lib.tests
@@ -10,8 +10,8 @@ pyre.lib.tests.prerequisites := pyre.lib journal.lib
 pyre.lib.tests.extern := pyre.lib $(pyre.lib.extern)
 
 # c++ compiler arguments
-pyre.lib.tests.c++.defines := PYRE_CORE
-pyre.lib.tests.c++.flags += -Wall $($(compiler.c++).std.c++17)
+pyre.lib.tests.c++.defines += $(pyre.lib.c++.defines)
+pyre.lib.tests.c++.flags += -Wall $(pyre.lib.c++.flags)
 
 
 # cleanup

--- a/.mm/pyre.lib.tests
+++ b/.mm/pyre.lib.tests
@@ -42,8 +42,12 @@ tests.pyre.lib.memory.constmap_oob.pre := tests.pyre.lib.memory.map_write
 tests.pyre.lib.grid.grid_mmap_set.pre := tests.pyre.lib.grid.grid_mmap_sanity
 tests.pyre.lib.grid.grid_mmap_get.pre := tests.pyre.lib.grid.grid_mmap_set
 
-# exclude the tensor tests (require c++20)
+# conditionally exclude tensor tests that require c++20 or greater
+# NOTE:
+#  - remove the check when c++20 becomes the minimum required
+#  - in the meantime, add more versions as they are supported
 pyre.lib.tests.drivers.exclude += \
+${if ${findstring $($(compiler.c++).std.c++20),$(pyre.lib.tests.c++.flags)},,\
     tensor/tensor_canonical_arithmetics.cc \
     tensor/tensor_canonical_basis.cc \
     tensor/tensor_cayley_hamilton_theorem.cc \
@@ -71,13 +75,19 @@ pyre.lib.tests.drivers.exclude += \
     tensor/tensor_symmetry.cc \
     tensor/tensor_transpose.cc \
     tensor/tensor_utilities.cc \
+}
 
 
-# exclude the compact packing tests (require c++20)
+# conditionally exclude compact packing tests that require c++20 or greater
+# NOTE:
+#  - remove the check when c++20 becomes the minimum required
+#  - in the meantime, add more versions as they are supported
 pyre.lib.tests.drivers.exclude += \
+${if ${findstring $($(compiler.c++).std.c++20),$(pyre.lib.tests.c++.flags)},,\
     grid/symmetric_sanity.cc \
     grid/symmetric_visit.cc \
     grid/diagonal_visit.cc \
+}
 
 
 # end of file

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -55,7 +55,7 @@ pyre.lib.c++.flags += -Wall $($(compiler.c++).std.c++17)
 
 # additional macros that enable features sensitive to the c++ standard version
 pyre.lib.c++.defines += \
-  ${if ${findstring $($(compiler.c++).std.c++17),$(pyre.lib.c++.flags)},,\
+  ${if ${findstring $($(compiler.c++).std.c++20),$(pyre.lib.c++.flags)},,\
     HAVE_COMPACT_PACKINGS WITH_CXX20 \
   }
 

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -51,7 +51,14 @@ pyre.lib.root := lib/pyre/
 pyre.lib.stem := pyre
 pyre.lib.prerequisites += journal.lib
 pyre.lib.c++.defines += PYRE_CORE
-pyre.lib.c++.flags += $($(compiler.c++).std.c++17)
+pyre.lib.c++.flags += -Wall $($(compiler.c++).std.c++17)
+
+# additional macros that enable features sensitive to the c++ standard version
+pyre.lib.c++.defines += \
+  ${if ${findstring $($(compiler.c++).std.c++17),$(pyre.lib.c++.flags)},,\
+    HAVE_COMPACT_PACKINGS WITH_CXX20 \
+  }
+
 # external dependencies
 pyre.lib.extern := \
     journal.lib \
@@ -79,7 +86,8 @@ host.ext.pkg := pyre.pkg
 host.ext.wraps := pyre.lib
 host.ext.capsule :=
 host.ext.extern := journal.lib python
-host.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+host.ext.lib.c++.defines += $(pyre.lib.c++.defines)
+host.ext.lib.c++.flags += $(pyre.lib.c++.flags)
 host.ext.lib.prerequisites += journal.lib # pyre.lib is added automatically
 
 
@@ -90,7 +98,8 @@ h5.ext.pkg := pyre.pkg
 h5.ext.wraps := pyre.lib
 h5.ext.capsule :=
 h5.ext.extern = journal.lib hdf5 ${if ${findstring mpi,$(hdf5.parallel)},mpi} pybind11 python
-h5.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+h5.ext.lib.c++.defines += $(pyre.lib.c++.defines)
+h5.ext.lib.c++.flags += $(pyre.lib.c++.flags)
 h5.ext.lib.prerequisites += journal.lib # pyre.lib is added automatically
 
 
@@ -101,7 +110,8 @@ postgres.ext.pkg := pyre.pkg
 postgres.ext.wraps := pyre.lib
 postgres.ext.capsule :=
 postgres.ext.extern := journal.lib libpq python
-postgres.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+postgres.ext.lib.c++.defines += $(pyre.lib.c++.defines)
+postgres.ext.lib.c++.flags += $(pyre.lib.c++.flags)
 postgres.ext.lib.prerequisites += journal.lib # pyre.lib is added automatically
 
 

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -60,7 +60,7 @@ pyre.lib.root := lib/pyre/
 pyre.lib.stem := pyre
 pyre.lib.prerequisites += journal.lib
 pyre.lib.c++.defines += PYRE_CORE
-pyre.lib.c++.flags += -Wall $($(compiler.c++).std.c++20)
+pyre.lib.c++.flags += -Wall $($(compiler.c++).std.c++17)
 
 # additional macros that enable features sensitive to the c++ standard version
 pyre.lib.c++.defines += \

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -55,7 +55,7 @@ pyre.lib.c++.flags += -Wall $($(compiler.c++).std.c++17)
 
 # additional macros that enable features sensitive to the c++ standard version
 pyre.lib.c++.defines += \
-  ${if ${findstring $($(compiler.c++).std.c++20),$(pyre.lib.c++.flags)},,\
+  ${if ${findstring $($(compiler.c++).std.c++20),$(pyre.lib.c++.flags)},\
     HAVE_COMPACT_PACKINGS WITH_CXX20 \
   }
 

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -25,6 +25,15 @@ pyre.tests := pyre.python.tests pyre.pkg.tests pyre.lib.tests pyre.ext.tests sql
 pyre.verbatim := pyre.templates
 
 
+# predicates that check the c++ standard in use
+# these are low resolution tests and may not be good enough
+pyre.c++20 = \
+  ${findstring \
+    $($(compiler.c++).std.c++20), \
+    $(pyre.lib.c++.flags) \
+  }
+
+
 # if we have {hdf5}, build the {h5} extension
 ${if ${findstring hdf5,$(extern.available)},\
     ${eval pyre.extensions += h5.ext} \
@@ -51,11 +60,11 @@ pyre.lib.root := lib/pyre/
 pyre.lib.stem := pyre
 pyre.lib.prerequisites += journal.lib
 pyre.lib.c++.defines += PYRE_CORE
-pyre.lib.c++.flags += -Wall $($(compiler.c++).std.c++17)
+pyre.lib.c++.flags += -Wall $($(compiler.c++).std.c++20)
 
 # additional macros that enable features sensitive to the c++ standard version
 pyre.lib.c++.defines += \
-  ${if ${findstring $($(compiler.c++).std.c++20),$(pyre.lib.c++.flags)},\
+  ${if $(pyre.c++20),\
     HAVE_COMPACT_PACKINGS WITH_CXX20 \
   }
 

--- a/lib/pyre/grid/Canonical.h
+++ b/lib/pyre/grid/Canonical.h
@@ -100,7 +100,7 @@ public:
     // static interface
 public:
     // the number of axes
-    static constexpr auto rank() -> T;
+    static constexpr auto rank() -> int;
 
     // implementation details: static helpers
 protected:

--- a/lib/pyre/grid/Canonical.h
+++ b/lib/pyre/grid/Canonical.h
@@ -84,7 +84,7 @@ public:
     template <T... shape>
     constexpr auto cslice(index_const_reference base) const;
     // when only the rank of the slice is known at compile time
-    template <T sliceRank = N>
+    template <int sliceRank = N>
     constexpr auto slice(index_const_reference base, shape_const_reference shape) const;
 
     // iteration support: iterators generate sequences of indices

--- a/lib/pyre/grid/Canonical.icc
+++ b/lib/pyre/grid/Canonical.icc
@@ -241,7 +241,7 @@ pyre::grid::Canonical<N, T, containerT>::cslice(index_const_reference base) cons
 
 // when the shape is not known at compile time
 template <int N, typename T, template <typename, std::size_t> class containerT>
-template <T sliceRank>
+template <int sliceRank>
 constexpr auto
 pyre::grid::Canonical<N, T, containerT>::slice(
     index_const_reference base, shape_const_reference rawShape) const

--- a/lib/pyre/grid/Canonical.icc
+++ b/lib/pyre/grid/Canonical.icc
@@ -351,7 +351,7 @@ pyre::grid::Canonical<N, T, containerT>::box(
 // static interface
 template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Canonical<N, T, containerT>::rank() -> T
+pyre::grid::Canonical<N, T, containerT>::rank() -> int
 {
     // easy enough
     return N;

--- a/lib/pyre/grid/Diagonal.h
+++ b/lib/pyre/grid/Diagonal.h
@@ -19,7 +19,7 @@ class pyre::grid::Diagonal {
     // types
 public:
     // alias for me
-    using diagonal_type = Diagonal<N, containerT>;
+    using diagonal_type = Diagonal<N, int, containerT>;
     using diagonal_const_reference = const diagonal_type &;
     // my parts
     // rank order

--- a/lib/pyre/grid/Diagonal.h
+++ b/lib/pyre/grid/Diagonal.h
@@ -14,7 +14,7 @@
 //
 //    Z_s1 x ... x Z_sn -> Z_(s1 * ... * sn)
 //
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 class pyre::grid::Diagonal {
     // types
 public:
@@ -23,13 +23,13 @@ public:
     using diagonal_const_reference = const diagonal_type &;
     // my parts
     // rank order
-    using order_type = Order<containerT<int, N>>;
+    using order_type = Order<containerT<T, N>>;
     using order_const_reference = const order_type &;
     // rank specifications
-    using shape_type = Shape<containerT<int, N>>;
+    using shape_type = Shape<containerT<T, N>>;
     using shape_const_reference = const shape_type &;
     // indices
-    using index_type = Index<containerT<int, N>>;
+    using index_type = Index<containerT<T, N>>;
     using index_const_reference = const index_type &;
     // offsets
     using difference_type = typename index_type::difference_type;

--- a/lib/pyre/grid/Diagonal.icc
+++ b/lib/pyre/grid/Diagonal.icc
@@ -14,8 +14,8 @@
 
 // constructor that assumes that the physical layout corresponds to the parameters given and
 // infers the nudge
-template <int N, template <typename, std::size_t> class containerT>
-constexpr pyre::grid::Diagonal<N, containerT>::Diagonal(
+template <int N, typename T, template <typename, std::size_t> class containerT>
+constexpr pyre::grid::Diagonal<N, T, containerT>::Diagonal(
     shape_const_reference shape, index_const_reference origin, order_const_reference order) :
     _shape { shape },
     _order { order },
@@ -28,45 +28,45 @@ constexpr pyre::grid::Diagonal<N, containerT>::Diagonal(
 
 // interface
 // accessors for the user supplied information
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::shape() const -> shape_type
+pyre::grid::Diagonal<N, T, containerT>::shape() const -> shape_type
 {
     // easy enough
     return _shape;
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::order() const -> order_type
+pyre::grid::Diagonal<N, T, containerT>::order() const -> order_type
 {
     // easy enough
     return _order;
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::origin() const -> index_type
+pyre::grid::Diagonal<N, T, containerT>::origin() const -> index_type
 {
     // easy enough
     return _origin;
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::nudge() const -> difference_type
+pyre::grid::Diagonal<N, T, containerT>::nudge() const -> difference_type
 {
     // easy enough
     return _nudge;
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::cells() const -> std::size_t
+pyre::grid::Diagonal<N, T, containerT>::cells() const -> std::size_t
 {
     // the number of cells in the diagonal plus a cell to store the off-diagonal zero
     return _D + 1;
@@ -74,14 +74,13 @@ pyre::grid::Diagonal<N, containerT>::cells() const -> std::size_t
 
 
 // from {difference_type} to {index_type}
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::index(difference_type offset) const -> index_type
+pyre::grid::Diagonal<N, T, containerT>::index(difference_type offset) const -> index_type
 {
     // helper function to build an {index_type} repeating {offset} N times
-    constexpr auto _getIndex =
-        []<int... I>(difference_type offset, integer_sequence<I...>)->index_type
-    {
+    constexpr auto _getIndex = []<int... I>(
+                                   difference_type offset, integer_sequence<I...>) -> index_type {
         // helper template function returning {offset}
         constexpr auto _wrap = []<int>(difference_type offset) -> difference_type {
             return offset;
@@ -95,14 +94,13 @@ pyre::grid::Diagonal<N, containerT>::index(difference_type offset) const -> inde
     return _getIndex(offset, make_integer_sequence<N> {}) + _origin;
 }
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::_isDiagonalIndex(index_const_reference index) -> bool
+pyre::grid::Diagonal<N, T, containerT>::_isDiagonalIndex(index_const_reference index) -> bool
 {
     // helper function needed to check if it is a diagonal index
-    auto _checkDiagonalIndex =
-        []<int... I>(index_const_reference index, integer_sequence<I...>)->bool
-    {
+    auto _checkDiagonalIndex = []<int... I>(
+                                   index_const_reference index, integer_sequence<I...>) -> bool {
         // if all indices are equal
         if (((index[I] == index[I + 1]) && ...)) {
             // then the index is on the diagonal
@@ -117,9 +115,9 @@ pyre::grid::Diagonal<N, containerT>::_isDiagonalIndex(index_const_reference inde
 };
 
 // from {index_type} to {difference_type}
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::offset(index_const_reference index) const -> difference_type
+pyre::grid::Diagonal<N, T, containerT>::offset(index_const_reference index) const -> difference_type
 {
     // if {index} is on the diagonal
     if (_isDiagonalIndex(index)) {
@@ -133,18 +131,18 @@ pyre::grid::Diagonal<N, containerT>::offset(index_const_reference index) const -
 
 
 // syntactic sugar for the packing isomorphism
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::operator[](difference_type offset) const -> index_type
+pyre::grid::Diagonal<N, T, containerT>::operator[](difference_type offset) const -> index_type
 {
     // easy enough
     return index(offset);
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::operator[](index_const_reference index) const
+pyre::grid::Diagonal<N, T, containerT>::operator[](index_const_reference index) const
     -> difference_type
 {
     // easy enough
@@ -153,27 +151,27 @@ pyre::grid::Diagonal<N, containerT>::operator[](index_const_reference index) con
 
 
 // iteration support
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::begin() const -> index_iterator
+pyre::grid::Diagonal<N, T, containerT>::begin() const -> index_iterator
 {
     // make an iterator that generates index in my packing {order}, starting at my {origin}
     return index_iterator(shape(), order(), origin());
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::begin(index_const_reference step) const -> index_iterator
+pyre::grid::Diagonal<N, T, containerT>::begin(index_const_reference step) const -> index_iterator
 {
     // make an iterator that generates index in my packing {order}, starting at my {origin}
     return index_iterator(shape(), order(), origin(), step);
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::end() const -> index_iterator
+pyre::grid::Diagonal<N, T, containerT>::end() const -> index_iterator
 {
     // form the end of the container
     auto end = _origin + _shape;
@@ -183,9 +181,9 @@ pyre::grid::Diagonal<N, containerT>::end() const -> index_iterator
 
 
 // static interface
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::rank() -> int
+pyre::grid::Diagonal<N, T, containerT>::rank() -> int
 {
     // easy enough
     return N;
@@ -193,9 +191,9 @@ pyre::grid::Diagonal<N, containerT>::rank() -> int
 
 
 // compute the shift necessary so that {origin}, i.e. the smallest index, maps to offset zero
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Diagonal<N, containerT>::_initShift(index_const_reference origin) -> difference_type
+pyre::grid::Diagonal<N, T, containerT>::_initShift(index_const_reference origin) -> difference_type
 {
     // assert that the origin is on the diagonal
     assert(_isDiagonalIndex(origin));

--- a/lib/pyre/grid/Symmetric.h
+++ b/lib/pyre/grid/Symmetric.h
@@ -14,7 +14,7 @@
 //
 //    Z_s1 x ... x Z_sn -> Z_(s1 * ... * sn)
 //
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 class pyre::grid::Symmetric {
     // types
 public:
@@ -23,13 +23,13 @@ public:
     using symmetric_const_reference = const symmetric_type &;
     // my parts
     // rank order
-    using order_type = Order<containerT<int, N>>;
+    using order_type = Order<containerT<T, N>>;
     using order_const_reference = const order_type &;
     // rank specifications
-    using shape_type = Shape<containerT<int, N>>;
+    using shape_type = Shape<containerT<T, N>>;
     using shape_const_reference = const shape_type &;
     // indices
-    using index_type = Index<containerT<int, N>>;
+    using index_type = Index<containerT<T, N>>;
     using index_const_reference = const index_type &;
     // offsets
     using difference_type = typename index_type::difference_type;

--- a/lib/pyre/grid/Symmetric.h
+++ b/lib/pyre/grid/Symmetric.h
@@ -19,7 +19,7 @@ class pyre::grid::Symmetric {
     // types
 public:
     // alias for me
-    using symmetric_type = Symmetric<N, containerT>;
+    using symmetric_type = Symmetric<N, int, containerT>;
     using symmetric_const_reference = const symmetric_type &;
     // my parts
     // rank order
@@ -94,9 +94,9 @@ private:
 
     // the offset associated with the M-rank index {i, j...} in a symmetric packing of rank {M} and
     // dimension {D}
-    template <int M, class... T>
-    static constexpr int _offset(int D, int i, T... j)
-        requires(sizeof...(T) == M - 1 && M > 1);
+    template <int M, class... S>
+    static constexpr int _offset(int D, int i, S... j)
+        requires(sizeof...(S) == M - 1 && M > 1);
     template <int M>
     static constexpr int _offset(int D, int i)
         requires(M == 1);

--- a/lib/pyre/grid/Symmetric.icc
+++ b/lib/pyre/grid/Symmetric.icc
@@ -107,10 +107,10 @@ pyre::grid::Symmetric<N, T, containerT>::_offset(int D, int i)
 
 
 template <int N, typename T, template <typename, std::size_t> class containerT>
-template <int M, class... T>
+template <int M, class... S>
 constexpr int
-pyre::grid::Symmetric<N, T, containerT>::_offset(int D, int i, T... j)
-    requires(sizeof...(T) == M - 1 && M > 1)
+pyre::grid::Symmetric<N, T, containerT>::_offset(int D, int i, S... j)
+    requires(sizeof...(S) == M - 1 && M > 1)
 {
     // calculate the offset associated with the rank M index {i, j...}
     return

--- a/lib/pyre/grid/Symmetric.icc
+++ b/lib/pyre/grid/Symmetric.icc
@@ -14,8 +14,8 @@
 
 // constructor that assumes that the physical layout corresponds to the parameters given and
 // infers the nudge
-template <int N, template <typename, std::size_t> class containerT>
-constexpr pyre::grid::Symmetric<N, containerT>::Symmetric(
+template <int N, typename T, template <typename, std::size_t> class containerT>
+constexpr pyre::grid::Symmetric<N, T, containerT>::Symmetric(
     shape_const_reference shape, index_const_reference origin, order_const_reference order) :
     _shape { shape },
     _order { order },
@@ -26,37 +26,37 @@ constexpr pyre::grid::Symmetric<N, containerT>::Symmetric(
 
 // interface
 // accessors for the user supplied information
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::shape() const -> shape_type
+pyre::grid::Symmetric<N, T, containerT>::shape() const -> shape_type
 {
     // easy enough
     return _shape;
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::order() const -> order_type
+pyre::grid::Symmetric<N, T, containerT>::order() const -> order_type
 {
     // easy enough
     return _order;
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::origin() const -> index_type
+pyre::grid::Symmetric<N, T, containerT>::origin() const -> index_type
 {
     // easy enough
     return _origin;
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 template <int M>
 constexpr int
-pyre::grid::Symmetric<N, containerT>::_entries(int D)
+pyre::grid::Symmetric<N, T, containerT>::_entries(int D)
     requires(M == 1)
 {
     // easy enough
@@ -64,10 +64,10 @@ pyre::grid::Symmetric<N, containerT>::_entries(int D)
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 template <int M>
 constexpr int
-pyre::grid::Symmetric<N, containerT>::_entries(int D)
+pyre::grid::Symmetric<N, T, containerT>::_entries(int D)
     requires(M > 1)
 {
     // add up the total number of entries for all ranks
@@ -80,10 +80,10 @@ pyre::grid::Symmetric<N, containerT>::_entries(int D)
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 template <int M>
 constexpr int
-pyre::grid::Symmetric<N, containerT>::_entriesBeforeRank(int i, int D)
+pyre::grid::Symmetric<N, T, containerT>::_entriesBeforeRank(int i, int D)
 {
     // add up the total number of entries for each rank less than {i}
     int result = 0;
@@ -95,10 +95,10 @@ pyre::grid::Symmetric<N, containerT>::_entriesBeforeRank(int i, int D)
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 template <int M>
 constexpr int
-pyre::grid::Symmetric<N, containerT>::_offset(int D, int i)
+pyre::grid::Symmetric<N, T, containerT>::_offset(int D, int i)
     requires(M == 1)
 {
     // easy enough
@@ -106,10 +106,10 @@ pyre::grid::Symmetric<N, containerT>::_offset(int D, int i)
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 template <int M, class... T>
 constexpr int
-pyre::grid::Symmetric<N, containerT>::_offset(int D, int i, T... j)
+pyre::grid::Symmetric<N, T, containerT>::_offset(int D, int i, T... j)
     requires(sizeof...(T) == M - 1 && M > 1)
 {
     // calculate the offset associated with the rank M index {i, j...}
@@ -120,20 +120,20 @@ pyre::grid::Symmetric<N, containerT>::_offset(int D, int i, T... j)
         + _offset<M - 1>(D - i, j...);
 }
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 template <int M>
 constexpr int
-pyre::grid::Symmetric<N, containerT>::_getFirstRankIndex(int D, int & offset)
+pyre::grid::Symmetric<N, T, containerT>::_getFirstRankIndex(int D, int & offset)
     requires(M == 1)
 {
     // easy enough
     return offset;
 }
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 template <int M>
 constexpr int
-pyre::grid::Symmetric<N, containerT>::_getFirstRankIndex(int D, int & offset)
+pyre::grid::Symmetric<N, T, containerT>::_getFirstRankIndex(int D, int & offset)
     requires(M > 1)
 {
     // guess an index for this rank (start from the top)
@@ -158,9 +158,9 @@ pyre::grid::Symmetric<N, containerT>::_getFirstRankIndex(int D, int & offset)
     return K;
 }
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::cells() const -> std::size_t
+pyre::grid::Symmetric<N, T, containerT>::cells() const -> std::size_t
 {
     // the number of cells in the upper- (or lower-) diagonal part
     return _entries<N>(_D);
@@ -168,9 +168,9 @@ pyre::grid::Symmetric<N, containerT>::cells() const -> std::size_t
 
 
 // from {difference_type} to {index_type}
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::index(difference_type offset) const -> index_type
+pyre::grid::Symmetric<N, T, containerT>::index(difference_type offset) const -> index_type
 {
     // the index to fill in
     index_type index;
@@ -182,8 +182,7 @@ pyre::grid::Symmetric<N, containerT>::index(difference_type offset) const -> ind
     index[0] = _getFirstRankIndex<N>(_D, offset_);
 
     // helper function to get the next indices (i = 1, ..., N - 1)
-    auto _getIndices = [&offset_]<int... I>(index_t<N> & idx, int D, integer_sequence<I...>)
-    {
+    auto _getIndices = [&offset_]<int... I>(index_t<N> & idx, int D, integer_sequence<I...>) {
         // get the next index (I + 1) as:
         ((idx[I + 1] =
               // the first index (corresponding to this offset) in a rank (N - (I + 1)) packing of
@@ -203,17 +202,17 @@ pyre::grid::Symmetric<N, containerT>::index(difference_type offset) const -> ind
 
 
 // from {index_type} to {difference_type}
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::offset(index_const_reference index) const -> difference_type
+pyre::grid::Symmetric<N, T, containerT>::offset(index_const_reference index) const
+    -> difference_type
 {
     // shift by the origin and sort the indices
     index_type sorted_index = index - _origin;
     std::sort(sorted_index.begin(), sorted_index.end());
 
     // helper function to shift the indices (i, j, k, ...) into (i, j - i, k - j, ...)
-    auto _shiftIndices = []<int... I>(index_t<N> & idx, integer_sequence<I...>)
-    {
+    auto _shiftIndices = []<int... I>(index_t<N> & idx, integer_sequence<I...>) {
         // iterate in reverse order to avoid overwriting entries before using them
         ((idx[(N - 2 - I) + 1] -= idx[N - 2 - I]), ...);
         // all done
@@ -224,8 +223,7 @@ pyre::grid::Symmetric<N, containerT>::offset(index_const_reference index) const 
     _shiftIndices(sorted_index, make_integer_sequence<N - 1> {});
 
     // helper function needed to expand the array in a parameter pack
-    auto _getOffset = []<int... I>(index_t<N> idx, int D, integer_sequence<I...>)
-    {
+    auto _getOffset = []<int... I>(index_t<N> idx, int D, integer_sequence<I...>) {
         return _offset<N>(D, idx[I]...);
     };
 
@@ -235,18 +233,18 @@ pyre::grid::Symmetric<N, containerT>::offset(index_const_reference index) const 
 
 
 // syntactic sugar for the packing isomorphism
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::operator[](difference_type offset) const -> index_type
+pyre::grid::Symmetric<N, T, containerT>::operator[](difference_type offset) const -> index_type
 {
     // easy enough
     return index(offset);
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::operator[](index_const_reference index) const
+pyre::grid::Symmetric<N, T, containerT>::operator[](index_const_reference index) const
     -> difference_type
 {
     // easy enough
@@ -255,27 +253,27 @@ pyre::grid::Symmetric<N, containerT>::operator[](index_const_reference index) co
 
 
 // iteration support
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::begin() const -> index_iterator
+pyre::grid::Symmetric<N, T, containerT>::begin() const -> index_iterator
 {
     // make an iterator that generates index in my packing {order}, starting at my {origin}
     return index_iterator(shape(), order(), origin());
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::begin(index_const_reference step) const -> index_iterator
+pyre::grid::Symmetric<N, T, containerT>::begin(index_const_reference step) const -> index_iterator
 {
     // make an iterator that generates index in my packing {order}, starting at my {origin}
     return index_iterator(shape(), order(), origin(), step);
 }
 
 
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::end() const -> index_iterator
+pyre::grid::Symmetric<N, T, containerT>::end() const -> index_iterator
 {
     // form the end of the container
     auto end = _origin + _shape;
@@ -285,9 +283,9 @@ pyre::grid::Symmetric<N, containerT>::end() const -> index_iterator
 
 
 // static interface
-template <int N, template <typename, std::size_t> class containerT>
+template <int N, typename T, template <typename, std::size_t> class containerT>
 constexpr auto
-pyre::grid::Symmetric<N, containerT>::rank() -> int
+pyre::grid::Symmetric<N, T, containerT>::rank() -> int
 {
     // easy enough
     return N;

--- a/lib/pyre/grid/api.h
+++ b/lib/pyre/grid/api.h
@@ -47,11 +47,13 @@ namespace pyre::grid {
         int N, typename T = int, template <typename, std::size_t> class containerT = std::array>
     using canonical_t = Canonical<N, T, containerT>;
     // the symmetric packing strategy
-    template <int N, template <typename, std::size_t> class containerT = std::array>
-    using symmetric_t = Symmetric<N, containerT>;
+    template <
+        int N, typename T = int, template <typename, std::size_t> class containerT = std::array>
+    using symmetric_t = Symmetric<N, T, containerT>;
     // the diagonal packing strategy
-    template <int N, template <typename, std::size_t> class containerT = std::array>
-    using diagonal_t = Diagonal<N, containerT>;
+    template <
+        int N, typename T = int, template <typename, std::size_t> class containerT = std::array>
+    using diagonal_t = Diagonal<N, T, containerT>;
 
     // the grid
     template <class packingT, class storageT>

--- a/lib/pyre/grid/forward.h
+++ b/lib/pyre/grid/forward.h
@@ -64,10 +64,10 @@ namespace pyre::grid {
     template <int N, typename T, template <typename, std::size_t> class containerT>
     class Canonical;
     // the symmetric packing strategy
-    template <int N, template <typename, std::size_t> class containerT>
+    template <int N, typename T, template <typename, std::size_t> class containerT>
     class Symmetric;
     // the diagonal packing strategy
-    template <int N, template <typename, std::size_t> class containerT>
+    template <int N, typename T, template <typename, std::size_t> class containerT>
     class Diagonal;
 
     // bringing it all together

--- a/lib/pyre/tensor/repacking.h
+++ b/lib/pyre/tensor/repacking.h
@@ -29,20 +29,20 @@ namespace pyre::tensor {
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Canonical<N, containerT>, pyre::grid::Canonical<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Canonical<N, containerT>, pyre::grid::Symmetric<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Symmetric<N, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Symmetric<N, containerT>, pyre::grid::Canonical<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Symmetric<N, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
@@ -53,14 +53,14 @@ namespace pyre::tensor {
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Diagonal<N, containerT>, pyre::grid::Canonical<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Diagonal<N, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Canonical<N, containerT>, pyre::grid::Diagonal<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Diagonal<N, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
@@ -85,20 +85,20 @@ namespace pyre::tensor {
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Canonical<N, containerT>, pyre::grid::Canonical<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Canonical<N, containerT>, pyre::grid::Symmetric<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Symmetric<N, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Symmetric<N, containerT>, pyre::grid::Canonical<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Symmetric<N, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
@@ -109,14 +109,14 @@ namespace pyre::tensor {
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Diagonal<N, containerT>, pyre::grid::Canonical<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Diagonal<N, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Canonical<N, containerT>, pyre::grid::Diagonal<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Diagonal<N, containerT>> {
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
@@ -128,13 +128,13 @@ namespace pyre::tensor {
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
         pyre::grid::Diagonal<N, containerT>, pyre::grid::Symmetric<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
         pyre::grid::Symmetric<N, containerT>, pyre::grid::Diagonal<N, containerT>> {
-        using packing_type = pyre::grid::Canonical<N, containerT>;
+        using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
 } // namespace pyre::tensor

--- a/lib/pyre/tensor/repacking.h
+++ b/lib/pyre/tensor/repacking.h
@@ -35,49 +35,50 @@ namespace pyre::tensor {
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Symmetric<N, containerT>> {
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Symmetric<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Symmetric<N, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        pyre::grid::Symmetric<N, int, containerT>, pyre::grid::Canonical<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Symmetric<N, containerT>, pyre::grid::Symmetric<N, containerT>> {
-        using packing_type = pyre::grid::Symmetric<N, containerT>;
+        pyre::grid::Symmetric<N, int, containerT>, pyre::grid::Symmetric<N, int, containerT>> {
+        using packing_type = pyre::grid::Symmetric<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Diagonal<N, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        pyre::grid::Diagonal<N, int, containerT>, pyre::grid::Canonical<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Diagonal<N, containerT>> {
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Diagonal<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
-    struct repacking_sum<pyre::grid::Diagonal<N, containerT>, pyre::grid::Diagonal<N, containerT>> {
-        using packing_type = pyre::grid::Diagonal<N, containerT>;
+    struct repacking_sum<
+        pyre::grid::Diagonal<N, int, containerT>, pyre::grid::Diagonal<N, int, containerT>> {
+        using packing_type = pyre::grid::Diagonal<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Diagonal<N, containerT>, pyre::grid::Symmetric<N, containerT>> {
-        using packing_type = pyre::grid::Symmetric<N, containerT>;
+        pyre::grid::Diagonal<N, int, containerT>, pyre::grid::Symmetric<N, int, containerT>> {
+        using packing_type = pyre::grid::Symmetric<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_sum<
-        pyre::grid::Symmetric<N, containerT>, pyre::grid::Diagonal<N, containerT>> {
-        using packing_type = pyre::grid::Symmetric<N, containerT>;
+        pyre::grid::Symmetric<N, int, containerT>, pyre::grid::Diagonal<N, int, containerT>> {
+        using packing_type = pyre::grid::Symmetric<N, int, containerT>;
     };
 
     template <class T, class S>
@@ -91,49 +92,49 @@ namespace pyre::tensor {
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Symmetric<N, containerT>> {
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Symmetric<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Symmetric<N, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        pyre::grid::Symmetric<N, int, containerT>, pyre::grid::Canonical<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Symmetric<N, containerT>, pyre::grid::Symmetric<N, containerT>> {
-        using packing_type = pyre::grid::Symmetric<N, containerT>;
+        pyre::grid::Symmetric<N, int, containerT>, pyre::grid::Symmetric<N, int, containerT>> {
+        using packing_type = pyre::grid::Symmetric<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Diagonal<N, containerT>, pyre::grid::Canonical<N, int, containerT>> {
+        pyre::grid::Diagonal<N, int, containerT>, pyre::grid::Canonical<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Diagonal<N, containerT>> {
+        pyre::grid::Canonical<N, int, containerT>, pyre::grid::Diagonal<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Diagonal<N, containerT>, pyre::grid::Diagonal<N, containerT>> {
-        using packing_type = pyre::grid::Diagonal<N, containerT>;
+        pyre::grid::Diagonal<N, int, containerT>, pyre::grid::Diagonal<N, int, containerT>> {
+        using packing_type = pyre::grid::Diagonal<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Diagonal<N, containerT>, pyre::grid::Symmetric<N, containerT>> {
+        pyre::grid::Diagonal<N, int, containerT>, pyre::grid::Symmetric<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 
     template <int N, template <typename, std::size_t> class containerT>
     struct repacking_prod<
-        pyre::grid::Symmetric<N, containerT>, pyre::grid::Diagonal<N, containerT>> {
+        pyre::grid::Symmetric<N, int, containerT>, pyre::grid::Diagonal<N, int, containerT>> {
         using packing_type = pyre::grid::Canonical<N, int, containerT>;
     };
 

--- a/lib/pyre/tensor/traits.h
+++ b/lib/pyre/tensor/traits.h
@@ -87,7 +87,7 @@ namespace pyre::tensor {
         // using packingT2 = typename tensorT2::pack_t;
         // using repacking_type = typename repacking_prod<packingT1, packingT2>::packing_type;
         using repacking_type =
-            typename pyre::grid::Canonical<rank, std::array>; // TOFIX not general wrt packings
+            typename pyre::grid::Canonical<rank, int, std::array>; // TOFIX not general wrt packings
 
     public:
         using type = typename tensor<scalar_type, repacking_type, dims>::type;


### PR DESCRIPTION
The `pyre::grid::Canonical` packing now requires an extra template argument to specify the type to use for the index and shape entries. The intent was to support very large grids by avoiding overflows in offset calculations. For the record, the culprit there was `std::inner_product` whose intermediate multiplications are not cast to the result type by some STL implementations, as of this writing.

When implementing this, I made two mistakes:

- there was a runaway generalization of the interface of `pyre::grid::Canonical::slice`
- `pyre::tensor` uses of `pyre::grid::Canonical` were not updated

The former is fixed in this PR. The latter is partly a consequence of `pyre::tensor` not using the `pyre::grid::canonical_t` type alias that was adjusted to accommodate the change in `pyre::grid::Canonical`. I missed this because `pyre::tensor` requires C++ 20 but stock `pyre` is still held back at C++ 17.

The solution suggested here is to assume that large grid support has nothing to do with `pyre::tensor` and therefore continue using `int` as the index and shape entry types.