### PR TITLE
Functionality enhancements in `tensor`

### DIFF
--- a/.cmake/pyre_tests_pyre_lib.cmake
+++ b/.cmake/pyre_tests_pyre_lib.cmake
@@ -404,6 +404,9 @@ pyre_add_definitions(tests/pyre.lib/tensor/tensor_iterators.cc ${definitions})
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_literals.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_literals.cc ${definitions})
 
+pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_matrix_build.cc)
+pyre_add_definitions(tests/pyre.lib/tensor/tensor_matrix_build.cc ${definitions})
+
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/tensor_matrix_assignment.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/tensor_matrix_assignment.cc ${definitions})
 

--- a/.cmake/pyre_tests_pyre_lib.cmake
+++ b/.cmake/pyre_tests_pyre_lib.cmake
@@ -437,6 +437,9 @@ pyre_add_definitions(tests/pyre.lib/tensor/tensor_utilities.cc ${definitions})
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/quaternion_composition.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/quaternion_composition.cc ${definitions})
 
+pyre_test_driver_cxx20(tests/pyre.lib/tensor/quaternion_from_rotation_matrix.cc)
+pyre_add_definitions(tests/pyre.lib/tensor/quaternion_from_rotation_matrix.cc ${definitions})
+
 pyre_test_driver_cxx20(tests/pyre.lib/tensor/quaternion_inverse.cc)
 pyre_add_definitions(tests/pyre.lib/tensor/quaternion_inverse.cc ${definitions})
 

--- a/.mm/pyre.lib.tests
+++ b/.mm/pyre.lib.tests
@@ -71,6 +71,7 @@ ${if $(pyre.c++20),,\
     tensor/tensor_matrix_product.cc \
     tensor/tensor_print.cc \
     tensor/quaternion_composition.cc \
+    tensor/quaternion_from_rotation_matrix.cc \
     tensor/quaternion_inverse.cc \
     tensor/tensor_symmetry.cc \
     tensor/tensor_transpose.cc \

--- a/.mm/pyre.lib.tests
+++ b/.mm/pyre.lib.tests
@@ -64,6 +64,7 @@ ${if $(pyre.c++20),,\
     tensor/tensor_iterators.cc \
     tensor/tensor_linear_system.cc \
     tensor/tensor_literals.cc \
+    tensor/tensor_matrix_build.cc \
     tensor/tensor_matrix_assignment.cc \
     tensor/tensor_matrix_equal.cc \
     tensor/tensor_matrix_norm.cc \

--- a/lib/pyre/math/transcendental.h
+++ b/lib/pyre/math/transcendental.h
@@ -34,6 +34,15 @@ namespace pyre::math {
     // {constexpr} cos function
     constexpr auto cos(double x) -> double;
 
+    // {constexpr} tan function
+    constexpr auto tan(double x) -> double;
+
+    // {constexpr} asin function
+    constexpr auto asin(double x) -> double;
+
+    // {constexpr} acos function
+    constexpr auto acos(double x) -> double;
+
     // {constexpr} atan function
     constexpr auto atan(double x) -> double;
 

--- a/lib/pyre/math/transcendental.icc
+++ b/lib/pyre/math/transcendental.icc
@@ -174,6 +174,39 @@ pyre::math::cos(double x) -> double
     }
 }
 
+// {constexpr} tan function
+constexpr auto
+pyre::math::tan(double x) -> double
+{
+    if (std::is_constant_evaluated()) {
+        return pyre::math::sin(x) / pyre::math::cos(x);
+    } else {
+        return std::tan(x);
+    }
+}
+
+// {constexpr} asin function
+constexpr auto
+pyre::math::asin(double x) -> double
+{
+    if (std::is_constant_evaluated()) {
+        return pyre::math::atan(x / pyre::math::sqrt(1.0 - x * x));
+    } else {
+        return std::asin(x);
+    }
+}
+
+// {constexpr} acos function
+constexpr auto
+pyre::math::acos(double x) -> double
+{
+    if (std::is_constant_evaluated()) {
+        return pyre::math::atan(pyre::math::sqrt(1.0 - x * x) / x);
+    } else {
+        return std::acos(x);
+    }
+}
+
 namespace {
     // Taylor series expansion for tangent
     constexpr auto atan_poly(double x, int terms = 15) -> double

--- a/lib/pyre/tensor/Tensor.h
+++ b/lib/pyre/tensor/Tensor.h
@@ -117,10 +117,6 @@ namespace pyre::tensor {
             return _layout.offset({ J... });
         }
 
-        // cast to atomic type T (enable the tensor is a scalar)
-        constexpr operator T() const
-            requires(scalar_c<tensor_t>);
-
         // support for ranged for loops
         constexpr const auto begin() const;
         constexpr const auto end() const;

--- a/lib/pyre/tensor/Tensor.icc
+++ b/lib/pyre/tensor/Tensor.icc
@@ -175,14 +175,6 @@ pyre::tensor::Tensor<T, packingT, I...>::operator[](int i)
 }
 
 template <typename T, class packingT, int... I>
-constexpr pyre::tensor::Tensor<T, packingT, I...>::
-operator T() const
-    requires(scalar_c<tensor_t>)
-{
-    return _data[0];
-}
-
-template <typename T, class packingT, int... I>
 constexpr const auto
 pyre::tensor::Tensor<T, packingT, I...>::begin() const
 {

--- a/lib/pyre/tensor/UnitQuaternion.h
+++ b/lib/pyre/tensor/UnitQuaternion.h
@@ -51,6 +51,18 @@ namespace pyre::tensor {
         constexpr ~UnitQuaternion() = default;
 
     public:
+        // get the component {r} of this quaternion
+        constexpr auto r() const -> real_type;
+
+        // get the component {i} of this quaternion
+        constexpr auto i() const -> real_type;
+
+        // get the component {j} of this quaternion
+        constexpr auto j() const -> real_type;
+
+        // get the component {k} of this quaternion
+        constexpr auto k() const -> real_type;
+
         // get the rotation matrix associated with this quaternion
         constexpr auto rotation() const -> rotation_matrix_type;
 

--- a/lib/pyre/tensor/UnitQuaternion.h
+++ b/lib/pyre/tensor/UnitQuaternion.h
@@ -39,6 +39,9 @@ namespace pyre::tensor {
         // constructor with an angle and an axis of rotation
         constexpr UnitQuaternion(const real_type &, const rotation_axis_type &);
 
+        // constructor from a rotation matrix representation
+        constexpr UnitQuaternion(const rotation_matrix_type &);
+
     public:
         // default metamethods
         constexpr UnitQuaternion(const UnitQuaternion &) = default;

--- a/lib/pyre/tensor/UnitQuaternion.icc
+++ b/lib/pyre/tensor/UnitQuaternion.icc
@@ -48,6 +48,38 @@ constexpr pyre::tensor::UnitQuaternion<T>::UnitQuaternion(const rotation_matrix_
         pyre::tensor::normalize(pyre::tensor::axis(pyre::tensor::skew(matrix))))
 {}
 
+// get the component {r} of this quaternion
+template <typename T>
+constexpr auto
+pyre::tensor::UnitQuaternion<T>::r() const -> real_type
+{
+    return _qr;
+}
+
+// get the component {i} of this quaternion
+template <typename T>
+constexpr auto
+pyre::tensor::UnitQuaternion<T>::i() const -> real_type
+{
+    return _qi;
+}
+
+// get the component {j} of this quaternion
+template <typename T>
+constexpr auto
+pyre::tensor::UnitQuaternion<T>::j() const -> real_type
+{
+    return _qj;
+}
+
+// get the component {k} of this quaternion
+template <typename T>
+constexpr auto
+pyre::tensor::UnitQuaternion<T>::k() const -> real_type
+{
+    return _qk;
+}
+
 template <typename T>
 constexpr auto
 pyre::tensor::UnitQuaternion<T>::rotation() const -> rotation_matrix_type

--- a/lib/pyre/tensor/UnitQuaternion.icc
+++ b/lib/pyre/tensor/UnitQuaternion.icc
@@ -40,6 +40,14 @@ constexpr pyre::tensor::UnitQuaternion<T>::UnitQuaternion(
           axis[1] * pyre::math::sin(0.5 * theta), axis[2] * pyre::math::sin(0.5 * theta) })
 {}
 
+// constructor from a rotation matrix representation
+template <typename T>
+constexpr pyre::tensor::UnitQuaternion<T>::UnitQuaternion(const rotation_matrix_type & matrix) :
+    UnitQuaternion(
+        pyre::math::acos(0.5 * (pyre::tensor::trace(matrix) - 1.0)),
+        pyre::tensor::normalize(pyre::tensor::axis(pyre::tensor::skew(matrix))))
+{}
+
 template <typename T>
 constexpr auto
 pyre::tensor::UnitQuaternion<T>::rotation() const -> rotation_matrix_type

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -196,6 +196,12 @@ namespace pyre::tensor {
         -> square_matrix_t<3, typename vectorT::scalar_type, packingT>
         requires(vectorT::size == 3);
 
+    // the vector representing a skew symmetric matrix
+    template <square_matrix_c matrixT>
+    constexpr auto axis(const matrixT & A)
+        -> vector_t<3, typename matrixT::scalar_type>
+        requires(matrixT::dims[0] == 3);
+
     // the skew symmetric part of a square matrix
     template <square_matrix_c matrixT>
     constexpr auto skew(const matrixT & A) -> auto;

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -315,7 +315,7 @@ namespace pyre::tensor {
 
     // extract column {I} of a matrix
     template <int I, matrix_c matrixT>
-    constexpr auto col(const matrixT & A)
+    constexpr auto column(const matrixT & A)
         -> vector_t<matrixT::dims[0], typename matrixT::scalar_type>;
 
     // apply a function to a matrix

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -208,8 +208,7 @@ namespace pyre::tensor {
 
     // the vector representing a skew symmetric matrix
     template <square_matrix_c matrixT>
-    constexpr auto axis(const matrixT & A)
-        -> vector_t<3, typename matrixT::scalar_type>
+    constexpr auto axis(const matrixT & A) -> vector_t<3, typename matrixT::scalar_type>
         requires(matrixT::dims[0] == 3);
 
     // the skew symmetric part of a square matrix

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -190,6 +190,16 @@ namespace pyre::tensor {
         requires(tensor_same_shape_c<vectorT, vectorTs...>)
     constexpr auto columns(const vectorT & v, const vectorTs &... vs);
 
+    // returns the rows of the input matrix as vectors
+    template <class matrixT>
+        requires(matrix_c<matrixT>)
+    constexpr auto rows(const matrixT & A);
+
+    // returns the columns of the input matrix as vectors
+    template <class matrixT>
+        requires(matrix_c<matrixT>)
+    constexpr auto columns(const matrixT & A);
+
     // builds a square matrix with all zeros except the diagonal is equal to v
     template <vector_c vectorT>
     constexpr auto matrix_diagonal(const vectorT & v)

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -70,11 +70,11 @@ namespace pyre::tensor {
 
     // tensor divided scalar
     template <tensor_c tensorT>
-    constexpr auto operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT;
+    constexpr auto operator/(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT;
 
     // (temporary) tensor divided scalar
     template <tensor_c tensorT>
-    constexpr auto operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT;
+    constexpr auto operator/(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT;
 
     // tensor plus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -22,32 +22,27 @@ namespace pyre::tensor {
     // dot product of tensors
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto dot(const tensorT1 & y1, const tensorT2 & y2)
-        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
+        requires(tensor_same_shape_c<tensorT1, tensorT2>);
 
     // tensors operator==
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator==(const tensorT1 & lhs, const tensorT2 & rhs) -> bool
-        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
+        requires(tensor_same_shape_c<tensorT1, tensorT2>);
 
     // scalar times tensor
     template <tensor_c tensorT>
-    constexpr auto operator*(const typename tensorT::scalar_type & a, const tensorT & y) -> tensorT
-        requires(!scalar_c<tensorT>);
+    constexpr auto operator*(const typename tensorT::scalar_type & a, const tensorT & y) -> tensorT;
 
     // tensor times scalar
     template <tensor_c tensorT>
-    constexpr auto operator*(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT
-        requires(!scalar_c<tensorT>);
+    constexpr auto operator*(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT;
 
     // scalar times (temporary) tensor
     template <tensor_c tensorT>
-    constexpr auto operator*(const typename tensorT::scalar_type & a, tensorT && y) -> tensorT
-        requires(!scalar_c<tensorT>);
-
+    constexpr auto operator*(const typename tensorT::scalar_type & a, tensorT && y) -> tensorT;
     // (temporary) tensor times scalar
     template <tensor_c tensorT>
-    constexpr auto operator*(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT
-        requires(!scalar_c<tensorT>);
+    constexpr auto operator*(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT;
 
     // row-column vector product
     template <vector_c vectorT1, vector_c vectorT2>
@@ -75,79 +70,75 @@ namespace pyre::tensor {
 
     // tensor divided scalar
     template <tensor_c tensorT>
-    constexpr auto operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT
-        requires(!scalar_c<tensorT>);
+    constexpr auto operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT;
 
     // (temporary) tensor divided scalar
     template <tensor_c tensorT>
-    constexpr auto operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT
-        requires(!scalar_c<tensorT>);
+    constexpr auto operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT;
 
     // tensor plus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(const tensorT1 & y1, const tensorT2 & y2) ->
         typename sum<tensorT1, tensorT2>::type
-        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
+        requires(tensor_same_shape_c<tensorT1, tensorT2>);
 
     // tensor plus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(const tensorT1 & y1, tensorT2 && y2) -> tensorT2
         requires(
-            tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+            tensor_same_shape_c<tensorT1, tensorT2>
             and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>);
 
     // (temporary) tensor plus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(tensorT1 && y1, const tensorT2 & y2) -> tensorT1
         requires(
-            tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+            tensor_same_shape_c<tensorT1, tensorT2>
             and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>);
 
     // (temporary) tensor plus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT1
         requires(
-            tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+            tensor_same_shape_c<tensorT1, tensorT2>
             and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>);
 
     // (temporary) tensor plus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT2
         requires(
-            tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+            tensor_same_shape_c<tensorT1, tensorT2>
             and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>
             and !std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>);
 
     // (unary) minus tensor
     template <tensor_c tensorT>
-    constexpr auto operator-(const tensorT & y) -> tensorT
-        requires(!scalar_c<tensorT>);
+    constexpr auto operator-(const tensorT & y) -> tensorT;
 
     // (unary) minus (temporary) tensor
     template <tensor_c tensorT>
-    constexpr auto operator-(tensorT && y) -> tensorT
-        requires(!scalar_c<tensorT>);
+    constexpr auto operator-(tensorT && y) -> tensorT;
 
     // tensor minus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator-(const tensorT1 & y1, const tensorT2 & y2) -> auto
-        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
+        requires(tensor_same_shape_c<tensorT1, tensorT2>);
 
     // (temporary) tensor minus tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator-(tensorT1 && y1, const tensorT2 & y2) -> auto
-        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
+        requires(tensor_same_shape_c<tensorT1, tensorT2>);
 
     // tensor minus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator-(const tensorT1 & y1, tensorT2 && y2) -> auto
-        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
+        requires(tensor_same_shape_c<tensorT1, tensorT2>);
 
 
     // (temporary) tensor minus (temporary) tensor
     template <tensor_c tensorT1, tensor_c tensorT2>
     constexpr auto operator-(tensorT1 && y1, tensorT2 && y2) -> auto
-        requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>);
+        requires(tensor_same_shape_c<tensorT1, tensorT2>);
 
     // Tensor operator*=
     template <tensor_c tensorT, class TENSOR>

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -191,6 +191,10 @@ namespace pyre::tensor {
         requires(matrix_c<matrixT>)
     constexpr auto columns(const matrixT & A);
 
+    // trivial specialization of the previous function: extract the columns from a (column) vector
+    template <vector_c vectorT>
+    constexpr auto columns(const vectorT & v);
+
     // builds a square matrix with all zeros except the diagonal is equal to v
     template <vector_c vectorT>
     constexpr auto matrix_diagonal(const vectorT & v)

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -180,6 +180,16 @@ namespace pyre::tensor {
     constexpr auto matrix_column(const vectorT & v)
         -> matrix_t<vectorT::size, vectorT::size, typename vectorT::scalar_type, packingT>;
 
+    // builds a matrix with prescribed rows
+    template <class packingT = canonical_packing_t<2>, vector_c vectorT, vector_c... vectorTs>
+        requires(tensor_same_shape_c<vectorT, vectorTs...>)
+    constexpr auto rows(const vectorT & v, const vectorTs &... vs);
+
+    // builds a matrix with prescribed columns
+    template <class packingT = canonical_packing_t<2>, vector_c vectorT, vector_c... vectorTs>
+        requires(tensor_same_shape_c<vectorT, vectorTs...>)
+    constexpr auto columns(const vectorT & v, const vectorTs &... vs);
+
     // builds a square matrix with all zeros except the diagonal is equal to v
     template <vector_c vectorT>
     constexpr auto matrix_diagonal(const vectorT & v)

--- a/lib/pyre/tensor/algebra.h
+++ b/lib/pyre/tensor/algebra.h
@@ -173,12 +173,12 @@ namespace pyre::tensor {
 
     // builds a matrix with prescribed rows
     template <class packingT = canonical_packing_t<2>, vector_c vectorT, vector_c... vectorTs>
-        requires(tensor_same_shape_c<vectorT, vectorTs...>)
+        requires(tensor_same_shape_c<vectorT, vectorTs...> && sizeof...(vectorTs) > 0)
     constexpr auto rows(const vectorT & v, const vectorTs &... vs);
 
     // builds a matrix with prescribed columns
     template <class packingT = canonical_packing_t<2>, vector_c vectorT, vector_c... vectorTs>
-        requires(tensor_same_shape_c<vectorT, vectorTs...>)
+        requires(tensor_same_shape_c<vectorT, vectorTs...> && sizeof...(vectorTs) > 0)
     constexpr auto columns(const vectorT & v, const vectorTs &... vs);
 
     // returns the rows of the input matrix as vectors

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -1175,7 +1175,6 @@ template <int I, pyre::tensor::matrix_c matrixT>
 constexpr auto
 pyre::tensor::row(const matrixT & A) -> vector_t<matrixT::dims[1], typename matrixT::scalar_type>
 {
-    constexpr int D1 = matrixT::dims[0];
     constexpr int D2 = matrixT::dims[1];
     using T = typename matrixT::scalar_type;
 
@@ -1197,7 +1196,6 @@ constexpr auto
 pyre::tensor::col(const matrixT & A) -> vector_t<matrixT::dims[0], typename matrixT::scalar_type>
 {
     constexpr int D1 = matrixT::dims[0];
-    constexpr int D2 = matrixT::dims[1];
     using T = typename matrixT::scalar_type;
 
     auto _col = [&A]<int... J>(integer_sequence<J...>) -> vector_t<D1, T> {

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -694,6 +694,26 @@ pyre::tensor::skew(const vectorT & a) -> square_matrix_t<3, typename vectorT::sc
     return A;
 }
 
+// the vector representing a skew symmetric matrix
+template <pyre::tensor::square_matrix_c matrixT>
+constexpr auto
+pyre::tensor::axis(const matrixT & A) -> vector_t<3, typename matrixT::scalar_type>
+    requires(matrixT::dims[0] == 3)
+{
+    // the type of the vector to be returned
+    using vector_t = vector_t<3, typename matrixT::scalar_type>;
+
+    // assert that the matrix is skew symmetric
+    assert((A[matrixT::template getOffset<2, 1>()] == -A[matrixT::template getOffset<1, 2>()]));
+    assert((A[matrixT::template getOffset<0, 2>()] == -A[matrixT::template getOffset<2, 0>()]));
+    assert((A[matrixT::template getOffset<1, 0>()] == -A[matrixT::template getOffset<0, 1>()]));
+
+    // all done
+    return vector_t { A[matrixT::template getOffset<2, 1>()],
+                      A[matrixT::template getOffset<0, 2>()],
+                      A[matrixT::template getOffset<1, 0>()] };
+}
+
 template <pyre::tensor::vector_c vectorT>
 constexpr auto
 pyre::tensor::cross(const vectorT & a, const vectorT & b) -> auto

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -412,7 +412,8 @@ template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT
 {
-    return (1.0 / a) * y;
+    using scalar_t = typename tensorT::scalar_type;
+    return (scalar_t { 1 } / a) * y;
 }
 
 // (temporary) tensor divided scalar
@@ -420,7 +421,8 @@ template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT
 {
-    return (1.0 / a) * std::move(y);
+    using scalar_t = typename tensorT::scalar_type;
+    return (scalar_t { 1 } / a) * std::move(y);
 }
 
 // dyadic vector product

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -410,7 +410,7 @@ pyre::tensor::operator-=(tensorT & lhs, TENSOR && rhs) -> tensorT &
 // tensor divided scalar
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
-pyre::tensor::operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT
+pyre::tensor::operator/(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT
 {
     using scalar_t = typename tensorT::scalar_type;
     return (scalar_t { 1 } / a) * y;
@@ -419,7 +419,7 @@ pyre::tensor::operator/(const tensorT & y, typename tensorT::scalar_type a) -> t
 // (temporary) tensor divided scalar
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
-pyre::tensor::operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT
+pyre::tensor::operator/(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT
 {
     using scalar_t = typename tensorT::scalar_type;
     return (scalar_t { 1 } / a) * std::move(y);

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -1093,7 +1093,7 @@ pyre::tensor::symmetric(const matrixT & A) -> typename matrixT::symmetric_tensor
             return;
         };
         // fill all (lower diagonal, diagonal included) rows in column K
-        (_fill_row.template operator()<K>(make_integer_sequence<K+1> {}), ...);
+        (_fill_row.template operator()<K>(make_integer_sequence<K + 1> {}), ...);
     };
 
     // fill all columns

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -500,6 +500,86 @@ pyre::tensor::matrix_column(const vectorT & v)
     return _fill_matrix_column(matrix_result_t(), v, make_integer_sequence<vectorT::size> {});
 }
 
+// builds a matrix with prescribed rows
+template <class packingT, pyre::tensor::vector_c vectorT, pyre::tensor::vector_c... vectorTs>
+    requires(pyre::tensor::tensor_same_shape_c<vectorT, vectorTs...>)
+constexpr auto
+pyre::tensor::rows(const vectorT & v, const vectorTs &... vs)
+{
+    // the number of rows in the result matrix
+    constexpr int n_rows = 1 + sizeof...(vectorTs);
+    // the number of columns in the result matrix
+    constexpr int n_cols = vectorT::size;
+    // the scalar type of the result matrix
+    using scalar_t =
+        std::common_type_t<typename vectorT::scalar_type, typename vectorTs::scalar_type...>;
+    // the type type of the result matrix
+    using matrix_result_t = pyre::tensor::matrix_t<n_rows, n_cols, scalar_t, packingT>;
+
+    // create the result matrix
+    auto result = matrix_result_t {};
+
+    // helper lambda to write one row {row}
+    auto write_row = [&]<int row, int... cols>(
+                         auto & result, const auto & vec, integer_sequence<cols...>) {
+        ((result[{ row, cols }] = vec[{ cols }]), ...);
+    };
+
+    // helper lambda to write all rows
+    auto write_rows = [&]<int... rows>(integer_sequence<rows...>) {
+        ((write_row.template operator()<rows>(
+             result, std::get<rows>(std::forward_as_tuple(v, vs...)),
+             make_integer_sequence<n_cols> {})),
+         ...);
+    };
+
+    // assemble the result matrix
+    write_rows(make_integer_sequence<n_rows> {});
+
+    // return the result matrix
+    return result;
+}
+
+// builds a matrix with prescribed columns
+template <class packingT, pyre::tensor::vector_c vectorT, pyre::tensor::vector_c... vectorTs>
+    requires(pyre::tensor::tensor_same_shape_c<vectorT, vectorTs...>)
+constexpr auto
+pyre::tensor::columns(const vectorT & v, const vectorTs &... vs)
+{
+    // the number of rows in the result matrix
+    constexpr int n_rows = vectorT::size;
+    // the number of columns in the result matrix
+    constexpr int n_cols = 1 + sizeof...(vectorTs);
+    // the scalar type of the result matrix
+    using scalar_t =
+        std::common_type_t<typename vectorT::scalar_type, typename vectorTs::scalar_type...>;
+    // the type type of the result matrix
+    using matrix_result_t = pyre::tensor::matrix_t<n_rows, n_cols, scalar_t, packingT>;
+
+    // create the result matrix
+    auto result = matrix_result_t {};
+
+    // helper lambda to write one column {column}
+    auto write_col = [&]<int col, int... rows>(
+                         auto & result, const auto & vec, integer_sequence<rows...>) {
+        ((result[{ rows, col }] = vec[{ rows }]), ...);
+    };
+
+    // helper lambda to write all columns
+    auto write_cols = [&]<int... cols>(integer_sequence<cols...>) {
+        ((write_col.template operator()<cols>(
+             result, std::get<cols>(std::forward_as_tuple(v, vs...)),
+             make_integer_sequence<n_rows> {})),
+         ...);
+    };
+
+    // assemble the result matrix
+    write_cols(make_integer_sequence<n_cols> {});
+
+    // return the result matrix
+    return result;
+}
+
 // builds a square matrix with all zeros except the diagonal is equal to v
 template <pyre::tensor::vector_c vectorT>
 constexpr auto

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -671,7 +671,7 @@ pyre::tensor::operator*(const vectorT & v, const matrixT & A) -> product<vectorT
     constexpr auto _matrix_times_vector = []<int... K>(
                                               const matrixT & A, const vectorT & v,
                                               integer_sequence<K...>) -> vector_output_type {
-        return vector_output_type((col<K>(A) * v)...);
+        return vector_output_type((column<K>(A) * v)...);
     };
     return _matrix_times_vector(A, v, make_integer_sequence<matrixT::dims[1]> {});
 }
@@ -1201,8 +1201,8 @@ pyre::tensor::eigenvectors(const symmetric_matrix_t<3, T> & A) -> matrix_t<3, 3,
 
     // first eigenvector
     vector_t<3, T> v0;
-    auto a = col<0>(A) - lambda[0] * vector_t<3, T> { 1, 0, 0 };
-    auto b = col<1>(A) - lambda[0] * vector_t<3, T> { 0, 1, 0 };
+    auto a = column<0>(A) - lambda[0] * vector_t<3, T> { 1, 0, 0 };
+    auto b = column<1>(A) - lambda[0] * vector_t<3, T> { 0, 1, 0 };
     if (norm(a) <= eps) {
         v0 = vector_t<3, T> { 1, 0, 0 };
     } else if (norm(b) <= eps) {
@@ -1219,9 +1219,9 @@ pyre::tensor::eigenvectors(const symmetric_matrix_t<3, T> & A) -> matrix_t<3, 3,
     vector_t<3, T> v1;
     // second eigenvalue is repeated
     if (lambda[1] == lambda[0]) {
-        auto a = col<0>(A) - lambda[0] * vector_t<3, T> { 1, 0, 0 };
+        auto a = column<0>(A) - lambda[0] * vector_t<3, T> { 1, 0, 0 };
         if (norm(a) <= eps) {
-            auto b = col<1>(A) - lambda[0] * vector_t<3, T> { 0, 1, 0 };
+            auto b = column<1>(A) - lambda[0] * vector_t<3, T> { 0, 1, 0 };
             if (norm(b) <= eps) {
                 v1 = vector_t<3, T> { 0, 1, 0 };
             } else {
@@ -1231,8 +1231,8 @@ pyre::tensor::eigenvectors(const symmetric_matrix_t<3, T> & A) -> matrix_t<3, 3,
             v1 = cross(v0, a);
         }
     } else { // lambda[1] != lambda[0]
-        auto a = col<0>(A) - lambda[1] * vector_t<3, T> { 1, 0, 0 };
-        auto b = col<1>(A) - lambda[1] * vector_t<3, T> { 0, 1, 0 };
+        auto a = column<0>(A) - lambda[1] * vector_t<3, T> { 1, 0, 0 };
+        auto b = column<1>(A) - lambda[1] * vector_t<3, T> { 0, 1, 0 };
         if (norm(a) <= eps) {
             v1 = vector_t<3, T> { 1, 0, 0 };
         } else if (norm(b) <= eps) {
@@ -1292,7 +1292,7 @@ pyre::tensor::row(const matrixT & A) -> vector_t<matrixT::dims[1], typename matr
 // extract column {I} of a matrix
 template <int I, pyre::tensor::matrix_c matrixT>
 constexpr auto
-pyre::tensor::col(const matrixT & A) -> vector_t<matrixT::dims[0], typename matrixT::scalar_type>
+pyre::tensor::column(const matrixT & A) -> vector_t<matrixT::dims[0], typename matrixT::scalar_type>
 {
     constexpr int D1 = matrixT::dims[0];
     using T = typename matrixT::scalar_type;

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -1250,7 +1250,7 @@ pyre::tensor::eigenvectors(const symmetric_matrix_t<3, T> & A) -> matrix_t<3, 3,
     vector_t<3, T> v2 = cross(v0, v1);
 
     // build and return the matrix of eigenvectors
-    return matrix_column<0>(v0) + matrix_column<1>(v1) + matrix_column<2>(v2);
+    return columns(v0, v1, v2);
 }
 
 template <int D, typename T>

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -610,6 +610,15 @@ pyre::tensor::columns(const matrixT & A)
     return _fill_columns(A, make_integer_sequence<n_cols> {});
 }
 
+// trivial specialization of the previous function: extract the columns from a (column) vector
+template <pyre::tensor::vector_c vectorT>
+constexpr auto
+pyre::tensor::columns(const vectorT & v)
+{
+    // nothing to be done
+    return v;
+}
+
 // builds a square matrix with all zeros except the diagonal is equal to v
 template <pyre::tensor::vector_c vectorT>
 constexpr auto

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -580,6 +580,42 @@ pyre::tensor::columns(const vectorT & v, const vectorTs &... vs)
     return result;
 }
 
+// returns the rows of the input matrix as vectors
+template <class matrixT>
+    requires(pyre::tensor::matrix_c<matrixT>)
+constexpr auto
+pyre::tensor::rows(const matrixT & A)
+{
+    // the number of rows
+    constexpr int n_rows = matrixT::dims[0];
+
+    // fill out the rows
+    constexpr auto _fill_rows = []<int... Is>(const matrixT & J, integer_sequence<Is...>) {
+        return std::array { pyre::tensor::row<Is>(J)... };
+    };
+
+    // return the array of columns
+    return _fill_rows(A, make_integer_sequence<n_rows> {});
+}
+
+// returns the columns of the input matrix as vectors
+template <class matrixT>
+    requires(pyre::tensor::matrix_c<matrixT>)
+constexpr auto
+pyre::tensor::columns(const matrixT & A)
+{
+    // the number of columns
+    constexpr int n_cols = matrixT::dims[1];
+
+    // fill out the columns
+    constexpr auto _fill_columns = []<int... Is>(const matrixT & J, integer_sequence<Is...>) {
+        return std::array { pyre::tensor::column<Is>(J)... };
+    };
+
+    // return the array of columns
+    return _fill_columns(A, make_integer_sequence<n_cols> {});
+}
+
 // builds a square matrix with all zeros except the diagonal is equal to v
 template <pyre::tensor::vector_c vectorT>
 constexpr auto

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -105,7 +105,7 @@ namespace {
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator==(const tensorT1 & lhs, const tensorT2 & rhs) -> bool
-    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
+    requires(tensor_same_shape_c<tensorT1, tensorT2>)
 {
     // perform component-by-component comparison
     return _tensor_equal(lhs, rhs);
@@ -127,7 +127,6 @@ namespace {
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(const typename tensorT::scalar_type & a, const tensorT & y) -> tensorT
-    requires(!scalar_c<tensorT>)
 {
     // instantiate the result
     tensorT result;
@@ -140,7 +139,6 @@ pyre::tensor::operator*(const typename tensorT::scalar_type & a, const tensorT &
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(const tensorT & y, const typename tensorT::scalar_type & a) -> tensorT
-    requires(!scalar_c<tensorT>)
 {
     return a * y;
 }
@@ -149,7 +147,6 @@ pyre::tensor::operator*(const tensorT & y, const typename tensorT::scalar_type &
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(const typename tensorT::scalar_type & a, tensorT && y) -> tensorT
-    requires(!scalar_c<tensorT>)
 {
     constexpr int D = tensorT::size;
     _tensor_times_scalar(a, y, y, make_integer_sequence<D> {});
@@ -160,7 +157,6 @@ pyre::tensor::operator*(const typename tensorT::scalar_type & a, tensorT && y) -
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator*(tensorT && y, const typename tensorT::scalar_type & a) -> tensorT
-    requires(!scalar_c<tensorT>)
 {
     return a * std::move(y);
 }
@@ -169,7 +165,7 @@ pyre::tensor::operator*(tensorT && y, const typename tensorT::scalar_type & a) -
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::dot(const tensorT1 & y1, const tensorT2 & y2)
-    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
+    requires(tensor_same_shape_c<tensorT1, tensorT2>)
 {
     // an equivalent canonically packed tensor
     using canonical_repacking_t = typename tensorT1::canonical_tensor_t;
@@ -268,7 +264,7 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(const tensorT1 & y1, const tensorT2 & y2) ->
     typename sum<tensorT1, tensorT2>::type
-    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
+    requires(tensor_same_shape_c<tensorT1, tensorT2>)
 {
     // compute component-wise summation
     return _tensor_sum(y1, y2);
@@ -279,7 +275,7 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(const tensorT1 & y1, tensorT2 && y2) -> tensorT2
     requires(
-        tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+        tensor_same_shape_c<tensorT1, tensorT2>
         and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>)
 {
     // compute component-wise summation and write the result on y2
@@ -291,7 +287,7 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(tensorT1 && y1, const tensorT2 & y2) -> tensorT1
     requires(
-        tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+        tensor_same_shape_c<tensorT1, tensorT2>
         and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>)
 {
     // easy enough
@@ -303,7 +299,7 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT1
     requires(
-        tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+        tensor_same_shape_c<tensorT1, tensorT2>
         and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>)
 {
     // pass down y1 as temporary and y2 as const reference
@@ -315,7 +311,7 @@ template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT2
     requires(
-        tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>
+        tensor_same_shape_c<tensorT1, tensorT2>
         and std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT2>
         and !std::is_same_v<typename sum<tensorT1, tensorT2>::type, tensorT1>)
 {
@@ -327,7 +323,6 @@ pyre::tensor::operator+(tensorT1 && y1, tensorT2 && y2) -> tensorT2
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator-(const tensorT & y) -> tensorT
-    requires(!scalar_c<tensorT>)
 {
     // get the tensor size (number of components)
     constexpr int D = tensorT::size;
@@ -347,7 +342,6 @@ pyre::tensor::operator-(const tensorT & y) -> tensorT
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator-(tensorT && y) -> tensorT
-    requires(!scalar_c<tensorT>)
 {
     // write the result on the temporary
     y = -std::as_const(y);
@@ -359,7 +353,7 @@ pyre::tensor::operator-(tensorT && y) -> tensorT
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator-(const tensorT1 & y1, const tensorT2 & y2) -> auto
-    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
+    requires(tensor_same_shape_c<tensorT1, tensorT2>)
 {
     // std::cout << "operator- & &" << std::endl;
     return y1 + (-y2);
@@ -369,7 +363,7 @@ pyre::tensor::operator-(const tensorT1 & y1, const tensorT2 & y2) -> auto
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator-(tensorT1 && y1, const tensorT2 & y2) -> auto
-    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
+    requires(tensor_same_shape_c<tensorT1, tensorT2>)
 {
     // std::cout << "operator- && &" << std::endl;
     return std::move(y1) + (-y2);
@@ -379,7 +373,7 @@ pyre::tensor::operator-(tensorT1 && y1, const tensorT2 & y2) -> auto
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator-(const tensorT1 & y1, tensorT2 && y2) -> auto
-    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
+    requires(tensor_same_shape_c<tensorT1, tensorT2>)
 {
     // std::cout << "operator- & &&" << std::endl;
     return y1 + (-std::move(y2));
@@ -389,7 +383,7 @@ pyre::tensor::operator-(const tensorT1 & y1, tensorT2 && y2) -> auto
 template <pyre::tensor::tensor_c tensorT1, pyre::tensor::tensor_c tensorT2>
 constexpr auto
 pyre::tensor::operator-(tensorT1 && y1, tensorT2 && y2) -> auto
-    requires(tensor_same_shape_c<tensorT1, tensorT2> and !scalar_c<tensorT1>)
+    requires(tensor_same_shape_c<tensorT1, tensorT2>)
 {
     // std::cout << "operator- && &&" << std::endl;
     return std::move(y1) + std::move(-std::move(y2));
@@ -417,7 +411,6 @@ pyre::tensor::operator-=(tensorT & lhs, TENSOR && rhs) -> tensorT &
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator/(const tensorT & y, typename tensorT::scalar_type a) -> tensorT
-    requires(!scalar_c<tensorT>)
 {
     return (1.0 / a) * y;
 }
@@ -426,7 +419,6 @@ pyre::tensor::operator/(const tensorT & y, typename tensorT::scalar_type a) -> t
 template <pyre::tensor::tensor_c tensorT>
 constexpr auto
 pyre::tensor::operator/(tensorT && y, typename tensorT::scalar_type a) -> tensorT
-    requires(!scalar_c<tensorT>)
 {
     return (1.0 / a) * std::move(y);
 }
@@ -950,7 +942,7 @@ constexpr auto
 pyre::tensor::determinant(const matrixT & A) -> typename matrixT::scalar_type
     requires(matrixT::dims[0] == 1) // 1x1 matrix
 {
-    return A;
+    return A[0];
 }
 
 template <pyre::tensor::square_matrix_c matrixT>
@@ -1022,7 +1014,7 @@ constexpr auto
 pyre::tensor::inverse(const matrixT & A) -> matrixT
     requires(matrixT::dims[0] == 1 && !diagonal_matrix_c<matrixT>) // 1x1 matrix
 {
-    return matrixT { 1.0 / A };
+    return matrixT { 1.0 / A[0] };
 }
 
 

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -496,7 +496,7 @@ pyre::tensor::matrix_column(const vectorT & v)
 
 // builds a matrix with prescribed rows
 template <class packingT, pyre::tensor::vector_c vectorT, pyre::tensor::vector_c... vectorTs>
-    requires(pyre::tensor::tensor_same_shape_c<vectorT, vectorTs...>)
+    requires(pyre::tensor::tensor_same_shape_c<vectorT, vectorTs...> && sizeof...(vectorTs) > 0)
 constexpr auto
 pyre::tensor::rows(const vectorT & v, const vectorTs &... vs)
 {
@@ -536,7 +536,7 @@ pyre::tensor::rows(const vectorT & v, const vectorTs &... vs)
 
 // builds a matrix with prescribed columns
 template <class packingT, pyre::tensor::vector_c vectorT, pyre::tensor::vector_c... vectorTs>
-    requires(pyre::tensor::tensor_same_shape_c<vectorT, vectorTs...>)
+    requires(pyre::tensor::tensor_same_shape_c<vectorT, vectorTs...> && sizeof...(vectorTs) > 0)
 constexpr auto
 pyre::tensor::columns(const vectorT & v, const vectorTs &... vs)
 {

--- a/lib/pyre/tensor/algebra.icc
+++ b/lib/pyre/tensor/algebra.icc
@@ -987,6 +987,9 @@ template <pyre::tensor::square_matrix_c matrixT>
 constexpr auto
 pyre::tensor::symmetric(const matrixT & A) -> typename matrixT::symmetric_tensor_t
 {
+    if constexpr (symmetric_matrix_c<matrixT>)
+        return A;
+
     // the type of matrix for the result
     using matrix_result_t = typename matrixT::symmetric_tensor_t;
 
@@ -1009,8 +1012,8 @@ pyre::tensor::symmetric(const matrixT & A) -> typename matrixT::symmetric_tensor
             // all done
             return;
         };
-        // fill all rows in column K
-        (_fill_row.template operator()<K>(make_integer_sequence<D> {}), ...);
+        // fill all (lower diagonal, diagonal included) rows in column K
+        (_fill_row.template operator()<K>(make_integer_sequence<K+1> {}), ...);
     };
 
     // fill all columns
@@ -1024,12 +1027,8 @@ template <pyre::tensor::square_matrix_c matrixT>
 constexpr auto
 pyre::tensor::skew(const matrixT & A) -> auto
 {
-    constexpr int D = matrixT::dims[0];
-    using packing_type = typename matrixT::pack_t;
-    using scalar_type = typename matrixT::scalar_type;
-
-    if constexpr (matrixT::symmetric)
-        return zero<symmetric_matrix_t<D, scalar_type>>;
+    if constexpr (symmetric_matrix_c<matrixT>)
+        return zero<matrixT>;
     else
         return 0.5 * (A - transpose(A));
 }

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -45,9 +45,10 @@ namespace pyre::tensor {
     template <class F>
     concept symmetric_matrix_c = square_matrix_c<F> and F::symmetric;
 
-    // concept of two tensors having the same shape
-    template <class F1, class F2>
-    concept tensor_same_shape_c = tensor_c<F1> and tensor_c<F2> and F1::dims == F2::dims;
+    // concept of tensors having the same shape
+    template <class F0, class... Fs>
+    concept tensor_same_shape_c =
+        tensor_c<F0> && (tensor_c<Fs> && ...) && ((F0::dims == Fs::dims) && ...);
 
     // concept of a fourth-order tensor
     template <class F>

--- a/lib/pyre/tensor/concepts.h
+++ b/lib/pyre/tensor/concepts.h
@@ -21,10 +21,6 @@ namespace pyre::tensor {
         }(c);
     };
 
-    // concept of a scalar
-    template <class F>
-    concept scalar_c = tensor_c<F> and F::size == 1;
-
     // concept of a vector
     template <class F>
     concept vector_c = tensor_c<F> and F::rank == 1;

--- a/lib/pyre/tensor/public.h
+++ b/lib/pyre/tensor/public.h
@@ -30,14 +30,14 @@
 #include "factories.h"
 // the tensor
 #include "Tensor.h"
-// useful functions for {Tensor}
-#include "utilities.h"
 // {constexpr} version of {for} loops
 #include "constexpr_for.h"
 // the algebra on tensors
 #include "algebra.h"
 // the quaternions
 #include "UnitQuaternion.h"
+// useful functions for {Tensor} and {UnitQuaternion}
+#include "utilities.h"
 
 
 #endif

--- a/lib/pyre/tensor/traits.h
+++ b/lib/pyre/tensor/traits.h
@@ -180,6 +180,21 @@ namespace pyre::tensor {
         using type = tensor_t<scalar_type, repacking_type, I...>;
     };
 
+    namespace traits {
+        // the matrix type resulting from transposing {matrixT}
+        template <matrix_c matrixT>
+        struct transpose {
+        private:
+            using scalar_type = typename matrixT::scalar_type;
+            static constexpr auto D1 = matrixT::dims[0];
+            static constexpr auto D2 = matrixT::dims[1];
+            using packingT = typename matrixT::pack_t;
+
+        public:
+            using type = matrix_t<D2, D1, scalar_type, packingT>;
+        };
+    } // namespace traits
+
 } // namespace pyre::tensor
 
 

--- a/lib/pyre/tensor/traits.h
+++ b/lib/pyre/tensor/traits.h
@@ -180,21 +180,6 @@ namespace pyre::tensor {
         using type = tensor_t<scalar_type, repacking_type, I...>;
     };
 
-    namespace traits {
-        // the matrix type resulting from transposing {matrixT}
-        template <matrix_c matrixT>
-        struct transpose {
-        private:
-            using scalar_type = typename matrixT::scalar_type;
-            static constexpr auto D1 = matrixT::dims[0];
-            static constexpr auto D2 = matrixT::dims[1];
-            using packingT = typename matrixT::pack_t;
-
-        public:
-            using type = matrix_t<D2, D1, scalar_type, packingT>;
-        };
-    } // namespace traits
-
 } // namespace pyre::tensor
 
 

--- a/lib/pyre/tensor/utilities.h
+++ b/lib/pyre/tensor/utilities.h
@@ -20,6 +20,10 @@ namespace pyre::tensor {
     template <int D1, int D2, typename T, class packingT>
     std::ostream & operator<<(std::ostream & os, const matrix_t<D1, D2, T, packingT> & tensor);
 
+    // overload operator<< for quaternions
+    template <typename T>
+    std::ostream & operator<<(std::ostream & os, const UnitQuaternion<T> & quaternion);
+
     template <typename T>
     constexpr bool is_equal(T lhs, T rhs);
 

--- a/lib/pyre/tensor/utilities.icc
+++ b/lib/pyre/tensor/utilities.icc
@@ -87,8 +87,9 @@ pyre::tensor::operator<<(
 }
 
 // print a quaternion's (r, i, j, k) components
+template <typename T>
 std::ostream &
-operator<<(std::ostream & os, const pyre::tensor::quaternion_t & quaternion)
+operator<<(std::ostream & os, const pyre::tensor::UnitQuaternion<T> & quaternion)
 {
     os << "[ ";
     os << quaternion.r() << ", " << quaternion.i() << ", " << quaternion.j() << ", "

--- a/lib/pyre/tensor/utilities.icc
+++ b/lib/pyre/tensor/utilities.icc
@@ -86,6 +86,17 @@ pyre::tensor::operator<<(
     return _print_matrix(os, tensor, pyre::grid::make_integer_sequence<D1 - 1> {});
 }
 
+// print a quaternion's (r, i, j, k) components
+std::ostream &
+operator<<(std::ostream & os, const pyre::tensor::quaternion_t & quaternion)
+{
+    os << "[ ";
+    os << quaternion.r() << ", " << quaternion.i() << ", " << quaternion.j() << ", "
+       << quaternion.k();
+    os << " ]";
+    return os;
+}
+
 template <typename T>
 constexpr bool
 pyre::tensor::is_equal(T lhs, T rhs)

--- a/lib/pyre/tensor/utilities.icc
+++ b/lib/pyre/tensor/utilities.icc
@@ -89,7 +89,7 @@ pyre::tensor::operator<<(
 // print a quaternion's (r, i, j, k) components
 template <typename T>
 std::ostream &
-operator<<(std::ostream & os, const pyre::tensor::UnitQuaternion<T> & quaternion)
+pyre::tensor::operator<<(std::ostream & os, const pyre::tensor::UnitQuaternion<T> & quaternion)
 {
     os << "[ ";
     os << quaternion.r() << ", " << quaternion.i() << ", " << quaternion.j() << ", "

--- a/tests/pyre.lib/tensor/quaternion_from_rotation_matrix.cc
+++ b/tests/pyre.lib/tensor/quaternion_from_rotation_matrix.cc
@@ -1,0 +1,53 @@
+// -*- coding: utf-8 -*-
+//
+// bianca giovanardi
+// (c) 1998-2025 all rights reserved
+//
+
+
+// support
+#include <cassert>
+#include <numbers>
+// get the tensor algebra
+#include <pyre/tensor.h>
+
+
+// use namespace for readability
+using namespace pyre::tensor;
+
+
+// main program
+int
+main(int argc, char * argv[])
+{
+    // pick an angle
+    auto angle = std::numbers::pi / 2.0;
+
+    // pick an axis
+    auto axis = normalize(vector_t<3> { 0.0, 0.0, 1.0 });
+
+    // create a quaternion
+    auto quaternion = quaternion_t(angle, axis);
+
+    // get the rotation matrix associated with this quaternion
+    auto R = quaternion.rotation();
+
+    // create another quaternion representing this rotation
+    auto quaternion_prime = quaternion_t(R);
+
+    // get the angle of rotation for this new quaternion
+    auto angle_prime = quaternion_prime.angle();
+
+    // get the axis of rotation for this new quaternion
+    auto axis_prime = quaternion_prime.axis();
+
+    // check that the two quaternions are equivalent up to a reasonable tolerance
+    assert(std::fabs(angle - angle_prime) < 1.e-15);
+    assert(axis == axis_prime);
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.lib/tensor/tensor_concepts.cc
+++ b/tests/pyre.lib/tensor/tensor_concepts.cc
@@ -24,9 +24,6 @@ main(int argc, char * argv[])
     // a 1x1 matrix is a (n improper) matrix
     static_assert(matrix_c<matrix_t<1, 1>> == true);
 
-    // a 1x1 matrix is a scalar
-    static_assert(scalar_c<matrix_t<1, 1>> == true);
-
     // a 1x1 matrix is not a vector
     static_assert(vector_c<matrix_t<1, 1>> == false);
 

--- a/tests/pyre.lib/tensor/tensor_eigenvalues.cc
+++ b/tests/pyre.lib/tensor/tensor_eigenvalues.cc
@@ -47,8 +47,8 @@ main(int argc, char * argv[])
         static_assert(lambda_A[0] + lambda_A[1] == trace(A));
 
         // definition of eigenvalues/vectors pair
-        static_assert(A * col<0>(eigenvectors_A) == lambda_A[0] * col<0>(eigenvectors_A));
-        static_assert(A * col<1>(eigenvectors_A) == lambda_A[1] * col<1>(eigenvectors_A));
+        static_assert(A * column<0>(eigenvectors_A) == lambda_A[0] * column<0>(eigenvectors_A));
+        static_assert(A * column<1>(eigenvectors_A) == lambda_A[1] * column<1>(eigenvectors_A));
 
         // spectral decomposition
         static_assert(A * eigenvectors_A == eigenvectors_A * eigenvalues_A);

--- a/tests/pyre.lib/tensor/tensor_matrix_build.cc
+++ b/tests/pyre.lib/tensor/tensor_matrix_build.cc
@@ -25,17 +25,31 @@ main(int argc, char * argv[])
 
     // use {v1} and {v2} to build {A_row} row-wise
     constexpr auto A_row = rows(v1, v2);
-    // expected result
-    constexpr auto A_exp_row = matrix_t<2, 3> { -2.0, 2.0, 10.0, 1.0, 2.0, 3.0 / 2.0 };
+
+    // extract the rows of {A}
+    constexpr auto A_rows = rows(A_row);
+    constexpr auto row1 = std::get<0>(A_rows);
+    constexpr auto row2 = std::get<1>(A_rows);
+
+    // rebuild the matrix with the extracted rows
+    constexpr auto A_row2 = rows(row1, row2);
+
     // verify result
-    static_assert(A_exp_row == A_row);
+    static_assert(A_row2 == A_row);
 
     // use {v1} and {v2} to build {A_col} column-wise
     constexpr auto A_col = columns(v1, v2);
-    // expected result
-    constexpr auto A_exp_col = pyre::tensor::transpose(A_exp_row);
+
+    // extract the columns of {A}
+    constexpr auto A_cols = columns(A_col);
+    constexpr auto col1 = std::get<0>(A_cols);
+    constexpr auto col2 = std::get<1>(A_cols);
+
+    // rebuild the matrix with the extracted rows
+    constexpr auto A_col2 = columns(col1, col2);
+
     // verify result
-    static_assert(A_exp_col == A_col);
+    static_assert(A_col2 == A_col);
 
     // all done
     return 0;

--- a/tests/pyre.lib/tensor/tensor_matrix_build.cc
+++ b/tests/pyre.lib/tensor/tensor_matrix_build.cc
@@ -1,0 +1,45 @@
+// -*- coding: utf-8 -*-
+//
+// bianca giovanardi
+// (c) 1998-2026 all rights reserved
+//
+
+
+// support
+#include <cassert>
+// get the tensor algebra
+#include <pyre/tensor.h>
+
+
+// use namespace for readability
+using namespace pyre::tensor;
+
+
+// main program
+int
+main(int argc, char * argv[])
+{
+    // two vectors in 3D
+    constexpr auto v1 = vector_t<3, int> { -2, 2, 10 };
+    constexpr auto v2 = vector_t<3> { 1.0, 2.0, 3.0 / 2.0 };
+
+    // use {v1} and {v2} to build {A_row} row-wise
+    constexpr auto A_row = rows(v1, v2);
+    // expected result
+    constexpr auto A_exp_row = matrix_t<2, 3> { -2.0, 2.0, 10.0, 1.0, 2.0, 3.0 / 2.0 };
+    // verify result
+    static_assert(A_exp_row == A_row);
+
+    // use {v1} and {v2} to build {A_col} column-wise
+    constexpr auto A_col = columns(v1, v2);
+    // expected result
+    constexpr auto A_exp_col = pyre::tensor::transpose(A_exp_row);
+    // verify result
+    static_assert(A_exp_col == A_col);
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.lib/tensor/tensor_matrix_vector_product.cc
+++ b/tests/pyre.lib/tensor/tensor_matrix_vector_product.cc
@@ -25,7 +25,7 @@ main(int argc, char * argv[])
     // a quadratic form
     constexpr auto q1 = transpose(a1) * C1 * a1;
     // check that the value is correct
-    static_assert(q1 == 5.0);
+    static_assert(q1 == matrix_t<1> { 5.0 });
 
     // a 2D vector
     constexpr auto a2 = vector_t<2> { 1.0, 1.0 };
@@ -35,9 +35,6 @@ main(int argc, char * argv[])
     constexpr auto q2 = transpose(a2) * C2 * a2;
     // check that the value is correct
     static_assert(q2 == 5.0);
-
-    // check that the values of the two quadratic forms can be subtracted
-    static_assert(q1 - q2 == 0.0);
 
     // all done
     return 0;

--- a/tests/pyre.lib/tensor/tensor_transpose.cc
+++ b/tests/pyre.lib/tensor/tensor_transpose.cc
@@ -34,6 +34,9 @@ main(int argc, char * argv[])
     // transpose preserves determinant
     static_assert(determinant(At) == determinant(A));
 
+    // check the shape of the transpose for a non square matrix
+    static_assert(std::is_same_v<traits::transpose<matrix_t<3, 2>>::type, matrix_t<2, 3>>);
+
     // all done
     return 0;
 }

--- a/tests/pyre.lib/tensor/tensor_transpose.cc
+++ b/tests/pyre.lib/tensor/tensor_transpose.cc
@@ -34,9 +34,6 @@ main(int argc, char * argv[])
     // transpose preserves determinant
     static_assert(determinant(At) == determinant(A));
 
-    // check the shape of the transpose for a non square matrix
-    static_assert(std::is_same_v<traits::transpose<matrix_t<3, 2>>::type, matrix_t<2, 3>>);
-
     // all done
     return 0;
 }

--- a/tests/pyre.lib/tensor/tensor_utilities.cc
+++ b/tests/pyre.lib/tensor/tensor_utilities.cc
@@ -20,8 +20,8 @@ int
 main(int argc, char * argv[])
 {
     // 2D matrix: the columns of the identity are the canonical basis
-    static_assert(col<0>(identity<matrix_t<2>>) == unit<vector_t<2>, 0>);
-    static_assert(col<1>(identity<matrix_t<2>>) == unit<vector_t<2>, 1>);
+    static_assert(column<0>(identity<matrix_t<2>>) == unit<vector_t<2>, 0>);
+    static_assert(column<1>(identity<matrix_t<2>>) == unit<vector_t<2>, 1>);
 
     // 2D matrix: the rows of the identity are the canonical basis
     static_assert(row<0>(identity<matrix_t<2>>) == unit<vector_t<2>, 0>);
@@ -31,14 +31,14 @@ main(int argc, char * argv[])
     constexpr auto matrix = matrix_t<2, 3> { 1.0, 2.0, 3.0, 1.0, 2.0, 3.0 };
     static_assert(row<0>(matrix) == vector_t<3> { 1.0, 2.0, 3.0 });
     static_assert(row<1>(matrix) == vector_t<3> { 1.0, 2.0, 3.0 });
-    static_assert(col<0>(matrix) == vector_t<2> { 1.0, 1.0 });
-    static_assert(col<1>(matrix) == vector_t<2> { 2.0, 2.0 });
-    static_assert(col<2>(matrix) == vector_t<2> { 3.0, 3.0 });
+    static_assert(column<0>(matrix) == vector_t<2> { 1.0, 1.0 });
+    static_assert(column<1>(matrix) == vector_t<2> { 2.0, 2.0 });
+    static_assert(column<2>(matrix) == vector_t<2> { 3.0, 3.0 });
 
     // 3D matrix: the columns of the identity are the canonical basis
-    static_assert(col<0>(identity<matrix_t<3>>) == unit<vector_t<3>, 0>);
-    static_assert(col<1>(identity<matrix_t<3>>) == unit<vector_t<3>, 1>);
-    static_assert(col<2>(identity<matrix_t<3>>) == unit<vector_t<3>, 2>);
+    static_assert(column<0>(identity<matrix_t<3>>) == unit<vector_t<3>, 0>);
+    static_assert(column<1>(identity<matrix_t<3>>) == unit<vector_t<3>, 1>);
+    static_assert(column<2>(identity<matrix_t<3>>) == unit<vector_t<3>, 2>);
 
     // 3D matrix: the rows of the identity are the canonical basis
     static_assert(row<0>(identity<matrix_t<3>>) == unit<vector_t<3>, 0>);


### PR DESCRIPTION
- Added construction of quaternions from rotation matrices.
- Implemented `operator<<` for printing quaternions.
- Added component-wise accessors for quaternion elements.
- Added additional constexpr math utilities.
- Added conversion from skew-symmetric matrices to their corresponding rotation axis.
- Added matrix construction from vectors as matrix of rows and matrix of columns.

### Related issues

Touches the same surface as, but does not by itself close, these issues (see per-issue notes):

- #102 — mm support for `pyre::tensor`: adds two more tensor tests to `.mm`; the tensor benchmarks remain unwired.
- #104 — tensor build under clang: extends the constexpr-math surface (`tan`/`asin`/`acos`); the new inverse-trig functions still need the domain edge cases (`acos(0)`, negative `x`, `|x| = 1`) fixed and covered by a test.
- #132 — CMake gating of tensor tests on C++20: new tests follow the existing `pyre_test_driver_cxx20` pattern; the opt-in-vs-auto gating is unchanged.
