### PR TITLE
Added support for specifying multiple configuration files with a single --config command line argument

### DIFF
--- a/packages/pyre/framework/Executive.py
+++ b/packages/pyre/framework/Executive.py
@@ -665,10 +665,12 @@ class Executive:
             journal.warning("pyre.framework").log(f"{name}: no uri")
             # and go no further
             return
-        # load the configuration
-        self.loadConfiguration(
-            uri=value, locator=locator, priority=self.priority.command
-        )
+        # go through the specified files
+        for source in value.split(","):
+            # load the configuration
+            self.loadConfiguration(
+                uri=source.strip(), locator=locator, priority=self.priority.command
+            )
         # and return
         return
 


### PR DESCRIPTION
Added support for

```
myapp --config=FILENAME1.yaml,FILENAME2.yaml
```

Incidentally, the following shortcut also works in some shells, such as bash and zsh, in case it is more convenient:

```
myapp --config={FILENAME1,FILENAME2}.yaml
```

