### PR TITLE
Improve algorithm to detect Linux distribution. Add Fedora and Rocky distributions

### DIFF
--- a/packages/pyre/platforms/Fedora.py
+++ b/packages/pyre/platforms/Fedora.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# superclass
+from .Linux import Linux
+
+
+# declaration
+class Fedora(Linux, family="pyre.platforms.fedora"):
+    """
+    Encapsulation of a host running linux on the fedora distribution
+    """
+
+    # public data
+    distribution = "fedora"
+
+
+# end of file

--- a/packages/pyre/platforms/Rocky.py
+++ b/packages/pyre/platforms/Rocky.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# superclass
+from .Linux import Linux
+
+
+# declaration
+class CentOS(Linux, family="pyre.platforms.rocky"):
+    """
+    Encapsulation of a host running linux on the rocky distribution
+    """
+
+    # public data
+    distribution = "rocky"
+
+
+# end of file

--- a/packages/pyre/platforms/Rocky.py
+++ b/packages/pyre/platforms/Rocky.py
@@ -9,7 +9,7 @@ from .Linux import Linux
 
 
 # declaration
-class CentOS(Linux, family="pyre.platforms.rocky"):
+class Rocky(Linux, family="pyre.platforms.rocky"):
     """
     Encapsulation of a host running linux on the rocky distribution
     """

--- a/packages/pyre/platforms/__init__.py
+++ b/packages/pyre/platforms/__init__.py
@@ -89,6 +89,30 @@ def redhat():
 
 
 @foundry(implements=platform)
+def rocky():
+    """
+    Support for RockyLinux
+    """
+    # get the class record
+    from .Rocky import Rocky
+
+    # and return it
+    return Rocky
+
+
+@foundry(implements=platform)
+def fedora():
+    """
+    Support for Fedora
+    """
+    # get the class record
+    from .Fedora import Fedora
+
+    # and return it
+    return Fedora
+
+
+@foundry(implements=platform)
 def ubuntu():
     """
     Support for Ubuntu
@@ -98,6 +122,18 @@ def ubuntu():
 
     # and return it
     return Ubuntu
+
+
+@foundry(implements=platform)
+def debian():
+    """
+    Support for Debian
+    """
+    # get the class record
+    from .Debian import Debian
+
+    # and return it
+    return Debian
 
 
 # host aliases


### PR DESCRIPTION
- Use Python version to decide which technique to use to get Linux distribution information
- Use platform.freedesktop_os_release() for Python 3.10 and later
- Add Fedora and Rocky(Linux) distributions.

Note: Fedora and RockyLinux use the dnf package manager, but the interface to the dnf package manager is not implemented.

Closes #166 
