### PR TITLE
Experimenting with CI and c++ 23

### DIFF
--- a/.github/matrix/config.mm
+++ b/.github/matrix/config.mm
@@ -30,8 +30,8 @@ python.version := $(pythonVersion)
 python.dir := $(pythonLocation)
 
 # numpy
-numpy.version := 1.26.4
-numpy.dir := $(python.dir)/lib/python$(python.version)/site-packages/numpy/core
+numpy.version := 2.x
+numpy.dir := $(python.dir)/lib/python$(python.version)/site-packages/numpy/_core
 
 # pybind11
 pybind11.version := 2.11.1

--- a/.github/workflows/mm.yaml
+++ b/.github/workflows/mm.yaml
@@ -8,58 +8,60 @@ on:
   push:
     branches:
       - main
+
 jobs:
   # build and test the ref that launched this action
   build:
     name: >-
       ${{matrix.target}}
       python-${{matrix.python}}+${{matrix.compiler}}
-      on ${{matrix.os}}
-    runs-on: ${{matrix.os}}
+      in ${{matrix.container}}
+
+    runs-on: ubuntu-24.04
+
+    container:
+      image: ${{ matrix.container }}
+
     strategy:
       fail-fast: false
+
       matrix:
-        os: [ubuntu-24.04]
         target: [debug, opt]
         python: ["3.12", "3.13", "3.14"]
-        compiler: [
-          "gcc-13", "gcc-14",
-           "clang-17", "clang-18"
-        ]
         # define the names of the compilers
         include:
-          - compiler: gcc-13
+          - compiler: gcc-15
             suite: gcc
-            suiteVersion: 13
-            cc: gcc-13
-            cxx: g++-13
+            suiteVersion: 15
+            cc: gcc-15
+            cxx: g++-15
+            container: gcc:15
           - compiler: gcc-14
             suite: gcc
             suiteVersion: 14
             cc: gcc-14
             cxx: g++-14
-          - compiler: clang-17
+            container: gcc:14
+          - compiler: clang-21
             suite: clang
-            suiteVersion: 17
-            cc: clang-17
-            cxx: clang++-17
+            suiteVersion: 21
+            cc: clang-21
+            cxx: clang++-21
+            container: llvmorg/llvm:21
           - compiler: clang-18
             suite: clang
             suiteVersion: 18
             cc: clang-18
             cxx: clang++-18
+            container: llvmorg/llvm:18
 
     steps:
-      - name: ${{matrix.os}} refresh
+      - name: install system dependencies
         run: |
           echo " -- update the package cache"
           sudo apt update
-          echo " -- upgradables"
-          sudo apt list --upgradable
-          echo " -- upgrade"
-          sudo apt dist-upgrade
           echo " -- install our dependencies"
-          sudo apt install -y make openssh-server libgsl-dev libopenmpi-dev libhdf5-dev
+          sudo apt install -y make git openssh-server libgsl-dev libopenmpi-dev libhdf5-dev
 
       - name: python ${{matrix.python}} setup
         uses: actions/setup-python@v5
@@ -69,7 +71,7 @@ jobs:
       - name: install dependencies
         run: |
           python${pythonVersion} -m pip install --upgrade pip
-          pip3 install distro graphene 'numpy<2.0' pybind11 PyYAML
+          pip-${pythonVersion} install distro graphene numpy pybind11 PyYAML
         env:
           pythonVersion: ${{matrix.python}}
 
@@ -112,19 +114,19 @@ jobs:
       - name: locations of python packages
         run: |
           echo " -- distro"
-          pip3 show distro
+          pip-${pythonVersion} show distro
           echo " -- graphene"
-          pip3 show graphene
+          pip-${pythonVersion} show graphene
           echo " -- numpy"
-          pip3 show numpy
+          pip-${pythonVersion} show numpy
           echo " -- its headers"
-          find ${pythonLocation}/lib/python${pythonVersion}/site-packages/numpy/core/include
+          find ${pythonLocation}/lib/python${pythonVersion}/site-packages/numpy/_core/include
           echo " -- pybind11"
-          pip3 show pybind11
+          pip-${pythonVersion} show pybind11
           echo " -- its headers"
           find ${pythonLocation}/lib/python${pythonVersion}/site-packages/pybind11
           echo " -- yaml"
-          pip3 show PyYAML
+          pip-${pythonVersion} show PyYAML
         env:
           pythonVersion: ${{matrix.python}}
 
@@ -175,7 +177,7 @@ jobs:
           echo " -- verifying the h5 extension"
           ${mm} h5.ext.info
         env:
-          mm: python3 ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           target: ${{matrix.target}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
@@ -188,7 +190,7 @@ jobs:
           echo " -- building pyre"
           ${mm}
         env:
-          mm: python3 ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           target: ${{matrix.target}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
@@ -203,7 +205,7 @@ jobs:
           echo " -- testing pyre"
           ${mm} tests
         env:
-          mm: python3 ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           target: ${{matrix.target}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: install clang
         if: matrix.suite == 'clang'
         run: |
-          apt get update
+          apt-get update
           apt-get install -y \
               wget \
               lsb-release \

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -96,8 +96,8 @@ jobs:
 
       - name: install python dependencies
         run: |
-          python${{pythonVersion}} -m pip install --upgrade pip
-          python${{pythonVersion}} -m pip install graphene numpy pybind11 PyYAML
+          python${pythonVersion} -m pip install --upgrade pip
+          python${pythonVersion} -m pip install graphene numpy pybind11 PyYAML
         env:
           pythonVersion: ${{matrix.python}}
 
@@ -112,7 +112,7 @@ jobs:
       # --- diagnostics ---
       - name: versions
         run: |
-          python${{pythonVersion}} --version
+          python${pythonVersion} --version
           ${{matrix.cc}} --version
           ${{matrix.cxx}} --version
           echo "CXXFLAGS=$CXXFLAGS"
@@ -145,7 +145,7 @@ jobs:
           ${mm} extern.pybind11.info
 
         env:
-          mm: python${{pythonVersion}} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
@@ -156,7 +156,7 @@ jobs:
           cd pyre
           ${mm}
         env:
-          mm: python${{pythonVersion}} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
@@ -167,7 +167,7 @@ jobs:
           cd pyre
           ${mm} tests
         env:
-          mm: python${{pythonVersion}} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -26,16 +26,16 @@ jobs:
       matrix:
         target: [debug, opt]
         python: ["3.14"]
-        compiler: [gcc-15, clang-21]
+        compiler: [gcc-14, clang-21]
         stdlib: [libstdc++, libc++]
 
         include:
           # gcc (libstdc++ only)
-          - compiler: gcc-15
+          - compiler: gcc-14
             suite: gcc
-            suiteVersion: 15
-            cc: gcc-15
-            cxx: g++-15
+            suiteVersion: 14
+            cc: gcc-14
+            cxx: g++-14
             stdlib: libstdc++
 
           # clang + libstdc++
@@ -55,7 +55,7 @@ jobs:
             stdlib: libc++
 
         exclude:
-          - compiler: gcc-15
+          - compiler: gcc-14
             stdlib: libc++
 
     steps:
@@ -73,7 +73,7 @@ jobs:
       - name: install gcc
         if: matrix.suite == 'gcc'
         run: |
-          apt-get install -y gcc-15 g++-15
+          apt-get install -y gcc-14 g++-14
 
       - name: install clang
         if: matrix.suite == 'clang'

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -3,6 +3,7 @@
 # (c) 1998-2026 all rights reserved
 
 name: pr-mm
+
 on:
   pull_request:
 
@@ -11,13 +12,13 @@ jobs:
   build:
     name: >-
       ${{matrix.target}}
-      python-${{matrix.python}}+${{matrix.compiler}}
-      in ${{matrix.container}}
+      python-${{matrix.python}}+
+      ${{matrix.compiler}}+${{matrix.stdlib}}
 
     runs-on: ubuntu-24.04
 
     container:
-      image: ${{ matrix.container }}
+      image: ubuntu:24.04
 
     strategy:
       fail-fast: false
@@ -25,99 +26,96 @@ jobs:
       matrix:
         target: [debug, opt]
         python: ["3.14"]
-        # define the names of the compilers
+
         include:
+          # gcc (libstdc++ only)
           - compiler: gcc-15
             suite: gcc
             suiteVersion: 15
             cc: gcc-15
             cxx: g++-15
-            container: gcc:15
+            stdlib: libstdc++
+
+          # clang + libstdc++
           - compiler: clang-21
             suite: clang
             suiteVersion: 21
             cc: clang-21
             cxx: clang++-21
-            container: llvmorg/llvm:21
+            stdlib: libstdc++
+
+          # clang + libc++
+          - compiler: clang-21
+            suite: clang
+            suiteVersion: 21
+            cc: clang-21
+            cxx: clang++-21
+            stdlib: libc++
 
     steps:
-      - name: install system dependencies
+      # --- base system ---
+      - name: install base dependencies
         run: |
-          echo " -- update the package cache"
-          sudo apt update
-          echo " -- install our dependencies"
-          sudo apt install -y make git openssh-server libgsl-dev libopenmpi-dev libhdf5-dev
+          apt-get update
+          apt-get install -y \
+            make git wget lsb-release \
+            openssh-server \
+            libgsl-dev libopenmpi-dev libhdf5-dev \
+            python3 python3-pip python3-dev
 
+      # --- install compilers ---
+      - name: install gcc
+        if: matrix.suite == 'gcc'
+        run: |
+          apt-get install -y gcc-15 g++-15
+
+      - name: install clang
+        if: matrix.suite == 'clang'
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          ./llvm.sh ${{matrix.suiteVersion}}
+
+      # --- install libc++ when requested ---
+      - name: install libc++
+        if: matrix.stdlib == 'libc++'
+        run: |
+          apt-get install -y libc++-dev libc++abi-dev
+
+      # --- python setup ---
       - name: python ${{matrix.python}} setup
         uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python}}
 
-      - name: install dependencies
+      - name: install python dependencies
         run: |
           python${pythonVersion} -m pip install --upgrade pip
-          pip-${pythonVersion} install distro graphene numpy pybind11 PyYAML
+          pip-${pythonVersion} install graphene numpy pybind11 PyYAML
         env:
           pythonVersion: ${{matrix.python}}
 
-      - name: list system packages
+      # --- stdlib flags ---
+      - name: configure stdlib flags
         run: |
-          dpkg -l
+          if [ "${{matrix.stdlib}}" = "libc++" ]; then
+            echo "CXXFLAGS=-stdlib=libc++" >> $GITHUB_ENV
+            echo "LDFLAGS=-stdlib=libc++" >> $GITHUB_ENV
+          fi
 
+      # --- diagnostics ---
       - name: versions
         run: |
-          echo " -- platform tag from python"
-          python${pythonVersion} -c "import sys; print(sys.platform)"
-          echo " -- distribution tag from python"
-          python${pythonVersion} -c "import distro; print(distro.linux_distribution(full_distribution_name=False))"
-          echo " -- make"
-          make --version
-          echo " -- python"
           python${pythonVersion} --version
-          echo "    -- prefix"
-          python${pythonVersion}-config --prefix
-          echo "    -- includes"
-          python${pythonVersion}-config --includes
-          echo "    -- libs"
-          python${pythonVersion}-config --libs
-          echo " -- ${{matrix.cc}}"
           ${{matrix.cc}} --version
-          echo " -- ${{matrix.cxx}}"
           ${{matrix.cxx}} --version
+          echo "CXXFLAGS=$CXXFLAGS"
         env:
           pythonVersion: ${{matrix.python}}
 
-      - name: external dependencies
-        run: |
-          echo " -- gsl"
-          sudo dpkg-query -L libgsl-dev
-          echo " -- openmpi"
-          sudo dpkg-query -L libopenmpi-dev
-          echo " -- hdf5"
-          sudo dpkg-query -L libhdf5-dev
-
-      - name: locations of python packages
-        run: |
-          echo " -- distro"
-          pip-${pythonVersion} show distro
-          echo " -- graphene"
-          pip-${pythonVersion} show graphene
-          echo " -- numpy"
-          pip-${pythonVersion} show numpy
-          echo " -- its headers"
-          find ${pythonLocation}/lib/python${pythonVersion}/site-packages/numpy/core/include
-          echo " -- pybind11"
-          pip-${pythonVersion} show pybind11
-          echo " -- its headers"
-          find ${pythonLocation}/lib/python${pythonVersion}/site-packages/pybind11
-          echo " -- yaml"
-          pip-${pythonVersion} show PyYAML
-        env:
-          pythonVersion: ${{matrix.python}}
-
+      # --- sources ---
       - name: clone mm
         run: |
-          echo " -- cloning mm"
           git clone https://github.com/aivazis/mm
 
       - name: checkout pyre
@@ -126,66 +124,47 @@ jobs:
           fetch-depth: 0
           path: 'pyre'
 
+      # --- mm setup ---
       - name: mm diagnostics
         run: |
-          echo " -- runner home"
-          pwd
-          echo " -- switching to the pyre home directory"
           cd pyre
-          echo " -- pyre source directory"
-          pwd
-          echo " -- creating ~/.pyre"
-          mkdir ~/.pyre
-          echo " -- copying the mm configuration file"
+
+          mkdir -p ~/.pyre ~/.mm
           cp .github/matrix/mm.pfg ~/.pyre
-          echo " -- creating ~/.mm"
-          mkdir ~/.mm
-          echo " -- copying the package configuration file there"
           cp .github/matrix/config.mm ~/.mm
-          echo " -- checking whether mm can run from here"
-          echo now at: ${PWD}
-          echo mm: ${mm}
-          ${mm} --help
+
           ${mm} host.info
           ${mm} builder.info
-          ${mm} make.info
-          echo " -- verifying external packages"
-          ${mm} extern.gsl.info
-          ${mm} extern.mpi.info
-          ${mm} extern.hdf5.info
           ${mm} extern.numpy.info
           ${mm} extern.pybind11.info
+
         env:
           mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
-          target: ${{matrix.target}}
+          pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
-          pythonVersion: ${{matrix.python}}
 
+      # --- build ---
       - name: build pyre
         run: |
-          echo " -- switching to the pyre home directory"
           cd pyre
-          echo " -- building pyre"
           ${mm}
         env:
           mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
-          target: ${{matrix.target}}
+          pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
-          pythonVersion: ${{matrix.python}}
 
+      # --- test ---
       - name: test pyre
         run: |
-          echo " -- switching to the pyre home directory"
           cd pyre
-          echo " -- testing pyre"
           ${mm} tests
         env:
           mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
-          target: ${{matrix.target}}
+          pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
-          pythonVersion: ${{matrix.python}}
+
 #
 # end of file

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -96,8 +96,8 @@ jobs:
 
       - name: install python dependencies
         run: |
-          python${pythonVersion} -m pip install --upgrade pip
-          python${pythonVersion} -m pip install graphene numpy pybind11 PyYAML
+          python${{pythonVersion}} -m pip install --upgrade pip
+          python${{pythonVersion}} -m pip install graphene numpy pybind11 PyYAML
         env:
           pythonVersion: ${{matrix.python}}
 
@@ -112,7 +112,7 @@ jobs:
       # --- diagnostics ---
       - name: versions
         run: |
-          python${pythonVersion} --version
+          python${{pythonVersion}} --version
           ${{matrix.cc}} --version
           ${{matrix.cxx}} --version
           echo "CXXFLAGS=$CXXFLAGS"
@@ -145,7 +145,7 @@ jobs:
           ${mm} extern.pybind11.info
 
         env:
-          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${{pythonVersion}} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
@@ -156,7 +156,7 @@ jobs:
           cd pyre
           ${mm}
         env:
-          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${{pythonVersion}} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
@@ -167,7 +167,7 @@ jobs:
           cd pyre
           ${mm} tests
         env:
-          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${{pythonVersion}} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -26,6 +26,8 @@ jobs:
       matrix:
         target: [debug, opt]
         python: ["3.14"]
+        compiler: [gcc-15, clang-21]
+        stdlib: [libstdc++, libc++]
 
         include:
           # gcc (libstdc++ only)
@@ -72,6 +74,12 @@ jobs:
       - name: install clang
         if: matrix.suite == 'clang'
         run: |
+          apt get update
+          apt-get install -y \
+              wget \
+              lsb-release \
+              software-properties-common \
+              gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           ./llvm.sh ${{matrix.suiteVersion}}

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -54,6 +54,10 @@ jobs:
             cxx: clang++-21
             stdlib: libc++
 
+        exclude:
+          - compiler: gcc-15
+            stdlib: libc++
+
     steps:
       # --- base system ---
       - name: install base dependencies

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -5,45 +5,48 @@
 name: pr-mm
 on:
   pull_request:
+
 jobs:
   # build and test the ref that launched this action
   build:
     name: >-
       ${{matrix.target}}
       python-${{matrix.python}}+${{matrix.compiler}}
-      on ${{matrix.os}}
-    runs-on: ${{matrix.os}}
+      in ${{matrix.container}}
+
+    runs-on: ubuntu-24.04
+
+    container:
+      image: ${{ matrix.container }}
+
     strategy:
       fail-fast: false
+
       matrix:
-        os: [ubuntu-24.04]
         target: [debug, opt]
         python: ["3.14"]
-        compiler: ["gcc-13", "clang-18"]
         # define the names of the compilers
         include:
-          - compiler: gcc-13
+          - compiler: gcc-15
             suite: gcc
-            suiteVersion: 13
-            cc: gcc-13
-            cxx: g++-13
-          - compiler: clang-18
+            suiteVersion: 15
+            cc: gcc-15
+            cxx: g++-15
+            container: gcc:15
+          - compiler: clang-21
             suite: clang
-            suiteVersion: 18
-            cc: clang-18
-            cxx: clang++-18
+            suiteVersion: 21
+            cc: clang-21
+            cxx: clang++-21
+            container: llvmorg/llvm:21
 
     steps:
-      - name: ${{matrix.os}} refresh
+      - name: install system dependencies
         run: |
           echo " -- update the package cache"
           sudo apt update
-          echo " -- upgradables"
-          sudo apt list --upgradable
-          echo " -- upgrade"
-          sudo apt dist-upgrade
           echo " -- install our dependencies"
-          sudo apt install -y make openssh-server libgsl-dev libopenmpi-dev libhdf5-dev
+          sudo apt install -y make git openssh-server libgsl-dev libopenmpi-dev libhdf5-dev
 
       - name: python ${{matrix.python}} setup
         uses: actions/setup-python@v5
@@ -53,7 +56,7 @@ jobs:
       - name: install dependencies
         run: |
           python${pythonVersion} -m pip install --upgrade pip
-          pip3 install distro graphene 'numpy<2.0' pybind11 PyYAML
+          pip-${pythonVersion} install distro graphene numpy pybind11 PyYAML
         env:
           pythonVersion: ${{matrix.python}}
 
@@ -96,19 +99,19 @@ jobs:
       - name: locations of python packages
         run: |
           echo " -- distro"
-          pip3 show distro
+          pip-${pythonVersion} show distro
           echo " -- graphene"
-          pip3 show graphene
+          pip-${pythonVersion} show graphene
           echo " -- numpy"
-          pip3 show numpy
+          pip-${pythonVersion} show numpy
           echo " -- its headers"
           find ${pythonLocation}/lib/python${pythonVersion}/site-packages/numpy/core/include
           echo " -- pybind11"
-          pip3 show pybind11
+          pip-${pythonVersion} show pybind11
           echo " -- its headers"
           find ${pythonLocation}/lib/python${pythonVersion}/site-packages/pybind11
           echo " -- yaml"
-          pip3 show PyYAML
+          pip-${pythonVersion} show PyYAML
         env:
           pythonVersion: ${{matrix.python}}
 
@@ -153,7 +156,7 @@ jobs:
           ${mm} extern.numpy.info
           ${mm} extern.pybind11.info
         env:
-          mm: python3 ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           target: ${{matrix.target}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
@@ -166,7 +169,7 @@ jobs:
           echo " -- building pyre"
           ${mm}
         env:
-          mm: python3 ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           target: ${{matrix.target}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
@@ -179,7 +182,7 @@ jobs:
           echo " -- testing pyre"
           ${mm} tests
         env:
-          mm: python3 ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           target: ${{matrix.target}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -134,16 +134,13 @@ jobs:
       - name: mm diagnostics
         run: |
           cd pyre
-
           mkdir -p ~/.pyre ~/.mm
           cp .github/matrix/mm.pfg ~/.pyre
           cp .github/matrix/config.mm ~/.mm
-
           ${mm} host.info
           ${mm} builder.info
           ${mm} extern.numpy.info
           ${mm} extern.pybind11.info
-
         env:
           mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -142,10 +142,10 @@ jobs:
           ${mm} extern.numpy.info
           ${mm} extern.pybind11.info
         env:
-          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
 
       # --- build ---
       - name: build pyre
@@ -153,10 +153,10 @@ jobs:
           cd pyre
           ${mm}
         env:
-          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
 
       # --- test ---
       - name: test pyre
@@ -164,10 +164,10 @@ jobs:
           cd pyre
           ${mm} tests
         env:
-          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
           pythonVersion: ${{matrix.python}}
           suite: ${{matrix.suite}}
           suiteVersion: ${{matrix.suiteVersion}}
+          mm: python${pythonVersion} ${{github.workspace}}/mm/mm.py --config=.github/matrix/mm.pfg
 
 #
 # end of file

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -64,7 +64,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y \
-            make git wget lsb-release \
+            make git wget lsb-release software-properties-common gnupg \
             openssh-server \
             libgsl-dev libopenmpi-dev libhdf5-dev \
             python3 python3-pip python3-dev
@@ -78,12 +78,6 @@ jobs:
       - name: install clang
         if: matrix.suite == 'clang'
         run: |
-          apt-get update
-          apt-get install -y \
-              wget \
-              lsb-release \
-              software-properties-common \
-              gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           ./llvm.sh ${{matrix.suiteVersion}}
@@ -103,7 +97,7 @@ jobs:
       - name: install python dependencies
         run: |
           python${pythonVersion} -m pip install --upgrade pip
-          pip-${pythonVersion} install graphene numpy pybind11 PyYAML
+          python${pythonVersion} -m pip install graphene numpy pybind11 PyYAML
         env:
           pythonVersion: ${{matrix.python}}
 

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -27,11 +27,7 @@ pyre.verbatim := pyre.templates
 
 # predicates that check the c++ standard in use
 # these are low resolution tests and may not be good enough
-pyre.c++20 = \
-  ${findstring \
-    $($(compiler.c++).std.c++20), \
-    $(pyre.lib.c++.flags) \
-  }
+pyre.c++20 = ${call languages.c++.has_c++20,pyre.lib}
 
 
 # if we have {hdf5}, build the {h5} extension

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -56,7 +56,7 @@ pyre.lib.root := lib/pyre/
 pyre.lib.stem := pyre
 pyre.lib.prerequisites += journal.lib
 pyre.lib.c++.defines += PYRE_CORE
-pyre.lib.c++.flags += -Wall $($(compiler.c++).std.c++23)
+pyre.lib.c++.flags += -Wall $($(compiler.c++).std.c++20)
 
 # additional macros that enable features sensitive to the c++ standard version
 pyre.lib.c++.defines += \


### PR DESCRIPTION
A recent commit switched `c++23` on in the `pyre.lib` flags, a setting that is inherited by practically every library in this project. Unfortunately, this caused all the `mm` tests to fail, whereas the `cmake` build succeeds completely with the same source code but with `c++20` as the target standard.

The suspicion is that there is something wrong with the GitHub CI runners that causes these failures, since the `c++23}` build with `mm` is known to be good on a wide range of `conda` environments.