### PR TITLE
Server-sent events over pyre.http

### DIFF
--- a/doc/design/sse.md
+++ b/doc/design/sse.md
@@ -1,0 +1,283 @@
+# server-sent events over pyre.http
+
+A design for pushing server-originated events to connected HTTP clients, built as
+a general `pyre.http` capability (usable by any tool, not just `qed`) with a clear
+path toward GraphQL subscriptions.
+
+Branches: `sse` in both `pyre` and `qed`.
+
+Status: **implemented and verified end to end** (2026-06-08). The notes below describe the design
+as built; where the build diverged from the original plan, the divergence is called out inline.
+
+## Goal
+
+Let a `pyre.http` server push messages to clients over a long-lived connection,
+so that a state change made by one client (or by automation) is reflected in every
+other connected client without polling. The motivating case: drive `qed`'s
+`window.qed` automation surface and have a second browser, connected to the same
+server, update on its own.
+
+Two standing constraints:
+
+1. **The primitive is general.** It lives in `pyre.http` and knows nothing about
+   `qed`. Every tool built on `pyre.http` gets it for free.
+2. **Client-library assumptions are isolated.** `qed` is migrating off Relay onto
+   Houdini. The browser-side wiring must keep the GraphQL-client-specific atom down
+   to a single, clearly marked swap point.
+
+Transport decision: **Server-Sent Events (SSE)**, not WebSockets. The push is
+strictly server→client; the client→server direction is already served by GraphQL
+mutation POSTs. SSE rides plain HTTP, needs no handshake, and the browser
+`EventSource` gives reconnection for free. The same `Hub`/`EventStream` pair is the
+transport `graphql-sse` needs later (see "Toward GraphQL subscriptions").
+
+## The core insight
+
+For our use case the push needs **no threads, no async, and no out-of-band wakeup**
+of the selector loop.
+
+Trace the flow: automation drives `window.qed` → that client POSTs a mutation → the
+POST arrives as a read-ready event on *its* channel → `http/Server.py:process`
+handles it → the server-side state mutates. Right there, **synchronously inside that
+same handler**, we enqueue SSE frames onto the *other* clients' held-open channels.
+The broadcast is just more work performed while servicing an event we are already
+inside. The single-threaded `SelectorPSL` loop never has to be woken from outside,
+because every state change is itself triggered by an incoming request.
+
+This is why the change is a few hundred lines and not a reactor rewrite.
+
+Out-of-band pushes — a timer, a filesystem watcher, a background process reporting
+progress — would need a dispatcher alarm or a self-pipe to wake `select()`. That is
+a documented extension point (see "Extension points"), not part of this work.
+
+## Architecture
+
+Three additive pieces in `pyre.http`, plus a one-line correctness fix in the `pyre.ipc`
+dispatcher (`SelectorPSL`). No change to the socket channel was needed.
+
+### `EventStream(Response)` — the SSE response
+
+A new response type alongside the others in `pyre/http/`. It carries the SSE
+headers and owns the wire framing; it has zero application awareness.
+
+- Headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache`,
+  `Connection: keep-alive`, and **no `Content-Length`**.
+- `alive = True` (the connection is held open).
+- `streaming = True` — a new flag on `Response` (default `False`) that the server
+  checks to route this response down the streaming path instead of the normal
+  render-and-write-once path.
+- An optional `topic` (default a single global topic) used by the `Hub` to scope
+  delivery. Topics exist from day one because `graphql-sse` maps one subscription
+  operation to one topic; a flat global broadcast would have to be refit later.
+- `event(data, *, name=None, id=None, retry=None) -> bytes` — formats one SSE
+  frame: `id: …\nevent: …\ndata: …\n\n`. Pure transport.
+
+### `Hub` — the subscriber registry and outbound pump
+
+Owned by the server (`self.hub`), constructed with the dispatcher reference (the
+server already holds `self.dispatcher`, set in `nexus.Server.activate`). The `Hub`
+holds subscriber channels keyed by topic and pumps bytes to them without blocking
+the loop.
+
+State:
+
+- `_subscribers: dict[topic, set[channel]]`
+- `_queues: dict[channel, deque[bytes]]` — per-channel outbound byte queue
+- `_armed: set[channel]` — channels currently registered for write-readiness
+
+Interface:
+
+- `subscribe(channel, topic)` — record the channel under the topic, create its
+  queue.
+- `unsubscribe(channel)` — drop the channel from every topic, its queue, and its
+  armed flag. Called on disconnect.
+- `publish(event, topic)` — append `event` bytes to every subscribed channel's
+  queue and **arm each channel once** (see below).
+- `flush(channel)` — the `whenWriteReady` handler. Drains as much of the channel's
+  queue as the socket will take, returns `True` while bytes remain (so the
+  dispatcher reschedules it), `False` when the queue empties.
+
+### Write-buffered delivery (the "two functions")
+
+Splitting the synchronous write into *assemble + queue* and *flush when writable*
+is exactly the `whenWriteReady` split. The mechanics fall out of what
+`SelectorPSL` already does:
+
+- `whenWriteReady(channel, call)` (`ipc/SelectorPSL.py:65`) turns on `EVENT_WRITE`
+  for the channel's `outbound` fd and registers the handler.
+- The watch loop (`ipc/SelectorPSL.py:176-188`) invokes write handlers when the fd
+  is writable; a handler that returns truthy is rescheduled, a falsy one is removed
+  and the `EVENT_WRITE` bit is cleared — while `EVENT_READ` stays on for disconnect
+  detection.
+- `dispatch()` (`ipc/SelectorPSL.py:243-249`) already catches `BlockingIOError`
+  /`InterruptedError` (reschedule) and `OSError` (drop). So `flush` may attempt a
+  partial send naively: a full socket buffer raises `BlockingIOError` and the
+  dispatcher simply tries again next time the fd is writable; a broken connection
+  raises `OSError` and the handler is dropped.
+
+`flush(channel)`:
+
+1. Peek the head of the queue; attempt a **partial** send.
+2. Remove fully-sent bytes; if a frame was partially sent, put the remainder back
+   at the head.
+3. Return `True` if the queue still has bytes, else remove the channel from
+   `_armed` and return `False`.
+
+**Arm once.** `whenWriteReady` appends a *new* handler to the fd's write pile on
+every call (`SelectorPSL.py:93`). `publish` must therefore arm a channel only if it
+is not already in `_armed`, or duplicate `flush` handlers pile up on one queue. Add
+to `_armed` on arm; remove when `flush` drains to empty.
+
+### Partial write on the channel
+
+The original plan called for a new partial-send method on `SocketTCP`. **It turned out to be
+unnecessary:** `SocketTCP` derives from `socket.socket`, whose inherited `send(bytes) -> int`
+*already is* the non-blocking partial send we want — it writes what it can, returns the count,
+and raises `BlockingIOError`/`OSError` exactly as the dispatcher expects. (Contrast `read`/`write`,
+which earn their wrappers by transforming behavior — looping `recv`, wrapping `sendall`. `send`
+would add nothing.) So `SocketTCP` is untouched. The only requirement is that the connection be
+non-blocking on the streaming path, which `Server.stream` arranges with a single
+`channel.setblocking(False)`; the normal request path keeps using the blocking `write`.
+
+### Dispatcher fix — arming write from within read
+
+The core insight depends on a read handler (`process`) registering *write* interest on the **same**
+fd, synchronously, while it runs. This surfaced a latent bug in `ipc/SelectorPSL.py:watch()` that no
+prior client had hit, because none armed a new event on a live fd mid-dispatch.
+
+`watch()` snapshotted the fd's event mask into a local *before* dispatching its handlers, cleared
+bits for handler piles that drained, then wrote the local back with `selector.modify`. But when
+`process` called `whenWriteReady` during the read dispatch, it set `EVENT_WRITE` in the live mask
+table — and the stale local snapshot (read-only) then overwrote the registration, **wiping the
+WRITE bit just added**. The flush handler never fired, so the preamble (and every event) sat in the
+queue forever. The connection opened and then went silent.
+
+The fix recomputes the mask from the **live** table after dispatch rather than from a pre-dispatch
+snapshot: track the bits whose piles drained (`cleared`), then set
+`event = masks[fd] & ~cleared`, so interest a handler *added* during dispatch survives. The
+registration update is also wrapped to tolerate an fd a handler closed mid-dispatch (the
+streaming-channel disconnect path). All `pyre.pkg/ipc` tests still pass. This fix is general — any
+handler that arms new interest on its own fd now behaves correctly — not SSE-specific.
+
+### Server wiring
+
+Two touches in `pyre/http/Server.py`, plus an `activate` override:
+
+- `respond()` (line 166) gains a streaming branch: if `response.streaming`, render
+  **status line + headers only** (no body, no `Content-Length`), enqueue that
+  preamble via `self.hub` for the channel, `self.hub.subscribe(channel, topic)`,
+  arm the channel, and return `response.alive`. The preamble and every later event
+  go through the same queue+flush path, so nothing on a streaming channel is ever
+  written with the blocking `sendall`. This needs a body-less variant of
+  `weaver/HTTP.py:render` (its lines 57-59 compute the body and set
+  `Content-Length` — exactly what we skip).
+- The 0-byte disconnect branch (lines 78-92) gains one line:
+  `self.hub.unsubscribe(channel)`. Because an `EventSource` never sends more bytes,
+  `process()` fires on a streaming channel **only** at disconnect, so cleanup falls
+  out naturally with no extra bookkeeping. The streaming channel is never placed in
+  `self.requests` (its GET completed), so the existing `del self.requests[channel]`
+  harmlessly hits its `KeyError` guard.
+
+`self.hub` is constructed in an `activate` override: the base `nexus.Server.activate` is where the
+dispatcher first becomes available (`self.dispatcher`), so the override chains up and then builds
+`self.hub = self.Hub(dispatcher=self.dispatcher)`. `EventStream` and `Hub` are exposed as the class
+types `server.eventStream` and `server.Hub` (alongside the existing `server.request`/`server.response`),
+and the live instance as `server.hub`.
+
+## qed integration contract
+
+The only place that knows about `qed`. All of it on the `sse` branch of `qed`.
+
+- **`/events` route** in `pkg/ux/Dispatcher.py` → handler returns an `EventStream`,
+  which subscribes that browser.
+- **One broadcast choke point — `GraphQL.respond` (`pkg/ux/GraphQL.py`), not the Store.** The
+  original plan put `hub.publish(...)` at the `Store` mutators. In the code that turned out to be
+  the *scattered* option: the `Store` has ~30 mutators with no shared funnel and no hub reference,
+  so "publish at the Store mutators" would mean a `publish` call added to every one of them plus
+  threading the hub in. The genuinely single seam is `GraphQL.respond`: every state change arrives
+  as a GraphQL mutation POST, and they all funnel through that one method, which already holds
+  `server` (hence `server.hub`) in its execution context. So publish once there, right after
+  `schema.execute`, when the operation is a mutation (`graphql.parse` + `OperationType.MUTATION`)
+  and `not result.errors` — queries and failed mutations notify nothing. The payload is minimal —
+  a single `{"type": "change"}` frame on the global topic ("something changed, refetch"). Per-topic
+  scoping (e.g. one topic per viewport) is deferred to the graphql-sse layer below.
+- **Client `liveSync`** — split in two so the GraphQL-client coupling stays isolated:
+  `ux/client/automation/eventStream.js` is the portable DOM half (`subscribe(onChange)` opens
+  `new EventSource('events')`, calls `onChange` on each message, returns a teardown); it survives
+  the Houdini migration untouched. `ux/client/automation/LiveSync.js` is the React + Relay glue
+  that supplies the one client-specific atom (see below) and is mounted as `<LiveSync/>` next to the
+  existing `<Automation/>`. (The portable file is `eventStream.js`, not `liveSync.js`, because
+  `liveSync.js` and `LiveSync.js` collide on a case-insensitive filesystem.)
+
+### Isolating the GraphQL client (Relay → Houdini)
+
+Everything portable — opening the `EventSource`, reconnection, parsing frames,
+topic filtering — is plain DOM, lives in `eventStream.js`, and survives the Houdini migration
+untouched. The **only** Relay-specific atom is "given an event, re-pull the affected query into the
+store." `subscribe(onChange)` takes that as a single injected callback; `LiveSync.js` supplies it,
+marked:
+
+```js
+// RELAY-SPECIFIC — swap this body for the Houdini equivalent on migration
+const refetch = () => fetchQuery(
+    environment, stateQuery, {}, { fetchPolicy: "network-only" },
+).toPromise()
+```
+
+`stateQuery` is the top-level `useFetchQEDQuery` taggedNode, re-exported from
+`context/useFetchQED.js`. Refetching it `network-only` writes fresh records into the Relay store,
+and every component reading them through `useFragment` re-renders — so the whole UI reconciles from
+one refetch.
+
+Deliberately **avoid** Relay's `requestSubscription` / network `subscribe`: that
+path is deeply Relay-coupled and would be discarded in the move to Houdini. When
+migrating, you replace one function body, not the wiring.
+
+## Toward GraphQL subscriptions
+
+`Hub` + `EventStream` is precisely the transport layer `graphql-sse` expects. The
+later subscriptions layer becomes a thin adapter: each subscription operation maps
+to a `Hub` topic; values a subscription resolver yields are `publish`-ed as SSE
+events on that topic; the client carries them over the same `/events`-style stream.
+Keeping `Hub` topic-aware now is what makes that a layer rather than a refit.
+
+## Extension points (not in this work)
+
+- **Out-of-band pushes.** Events not triggered by an incoming request (timers,
+  watchers, external processes) need a dispatcher alarm or a self-pipe to wake
+  `select()`. `nexus` is the right home when that arrives — see the external
+  tile-fetch/prep process work, which is when `nexus` gets poked.
+- **Generalizing the queue.** Only streaming responses use the queue+flush path
+  here; normal responses keep the synchronous `write`. The same pump could back all
+  responses later if it proves worthwhile. Step back to this only if the streaming
+  split is clean and stable first.
+
+## Change map
+
+`pyre` (`sse` branch) — package root is `packages/pyre/`:
+
+- `http/EventStream.py` *(new)* — response type (framing, SSE headers, `streaming`, `topic`,
+  `event()`).
+- `http/Hub.py` *(new)* — subscriber registry + write pump (`subscribe`/`unsubscribe`/`publish`/
+  `send`/`flush`, arm-once).
+- `http/Server.py` — `activate` override builds `self.hub`; streaming branch + `stream()` in
+  `respond()`; `hub.unsubscribe` in the disconnect branch; `eventStream`/`Hub` exposed as types.
+- `http/Response.py` — `streaming = False`.
+- `weaver/HTTP.py` — body-less `preamble()` rendering.
+- `ipc/SelectorPSL.py` — `watch()` fix: recompute the fd mask from the live table after dispatch
+  (so write interest armed by a read handler survives) + tolerate an fd closed mid-dispatch.
+- No `ipc/SocketTCP.py` change — the inherited `socket.send` is already the partial non-blocking
+  send. No `http/__init__.py` change — the surface is reached through the `Server` class types, as
+  the existing http modules are.
+
+`qed` (`sse` branch):
+
+- `pkg/ux/Dispatcher.py` — `/events` route + `events` handler returning `server.eventStream(...)`.
+- `pkg/ux/GraphQL.py` — the single broadcast choke point: `_isMutation` gate + `_notify` →
+  `server.hub.publish` after a successful mutation (NOT `Store.py`).
+- `ux/client/context/useFetchQED.js` — export the `useFetchQEDQuery` taggedNode for the refetch.
+- `ux/client/automation/eventStream.js` *(new)* — portable `subscribe(onChange)`.
+- `ux/client/automation/LiveSync.js` *(new)* — React + Relay glue, the one `RELAY-SPECIFIC` refetch.
+- `ux/client/qed.js` — mount `<LiveSync/>` next to `<Automation/>`.
+
+Build with `mm` from the `qed` scope. Commit `pyre` and `qed` separately.

--- a/doc/design/sse.md
+++ b/doc/design/sse.md
@@ -72,6 +72,21 @@ headers and owns the wire framing; it has zero application awareness.
 - `event(data, *, name=None, id=None, retry=None) -> bytes` — formats one SSE
   frame: `id: …\nevent: …\ndata: …\n\n`. Pure transport.
 
+### Protocol version — HTTP/1.1
+
+The `weaver/HTTP.py` renderer negotiates `min(renderer.version, response.version)` for the status
+line, and the renderer was capped at `1.0` — so every response went out as `HTTP/1.0` even though
+`Response` already declares `1.1`. That cap is wrong for the streaming path: an event stream carries
+**no `Content-Length`** and never self-closes, and under HTTP/1.0 `Connection: keep-alive` without a
+length is self-contradictory — the only body delimiter 1.0 offers is connection close. HTTP/1.1
+makes persistent connections the default and cleanly frames an open-ended stream, so the renderer
+now prefers **`1.1`**. The render-once path is unaffected: it always sets `Content-Length`.
+
+`render` and `preamble` share this status-line + negotiation logic, so `render` delegates to
+`preamble` for the status line and headers, then appends the blank-line separator and body — the
+body is assembled *first* so `Content-Length` is set before the headers go out, leaving the wire
+bytes byte-identical to the original render-once output.
+
 ### `Hub` — the subscriber registry and outbound pump
 
 Owned by the server (`self.hub`), constructed with the dispatcher reference (the
@@ -263,7 +278,8 @@ Keeping `Hub` topic-aware now is what makes that a layer rather than a refit.
 - `http/Server.py` — `activate` override builds `self.hub`; streaming branch + `stream()` in
   `respond()`; `hub.unsubscribe` in the disconnect branch; `eventStream`/`Hub` exposed as types.
 - `http/Response.py` — `streaming = False`.
-- `weaver/HTTP.py` — body-less `preamble()` rendering.
+- `weaver/HTTP.py` — body-less `preamble()` rendering; `render()` reuses it for the status line and
+  headers; renderer prefers HTTP/1.1 (the SSE keep-alive stream needs 1.1 semantics).
 - `ipc/SelectorPSL.py` — `watch()` fix: recompute the fd mask from the live table after dispatch
   (so write interest armed by a read handler survives) + tolerate an fd closed mid-dispatch.
 - No `ipc/SocketTCP.py` change — the inherited `socket.send` is already the partial non-blocking

--- a/packages/pyre/http/EventStream.py
+++ b/packages/pyre/http/EventStream.py
@@ -56,6 +56,15 @@ class EventStream(Response):
         # nothing to render
         return b""
 
+    # the keep-alive frame the server's hub broadcasts on a timer to hold idle connections open
+    @classmethod
+    def keepalive(cls):
+        """
+        Frame an SSE comment that keeps the connection warm without dispatching a client event
+        """
+        # a colon-led line is a comment the client ignores; the blank line ends the frame
+        return b": keepalive\n\n"
+
     # meta-methods
     def __init__(self, topic="", **kwds):
         # chain up

--- a/packages/pyre/http/EventStream.py
+++ b/packages/pyre/http/EventStream.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the base class
+from .Response import Response
+
+
+# the server-sent event stream response
+class EventStream(Response):
+    """
+    An HTTP response that holds the connection open and pushes server-sent events (SSE)
+
+    {EventStream} is pure transport: it carries the SSE headers and frames the wire format,
+    knowing nothing about any application. The server routes it down its streaming path, where
+    a {Hub} delivers events to the held-open connection.
+    """
+
+    # public data
+    code = 200  # a successful response
+    status = "OK"  # its description
+    streaming = True  # route me down the server's streaming path
+    alive = True  # hold the connection open
+    topic = ""  # the hub topic that scopes delivery; empty is the global topic
+
+    # interface
+    def event(self, data, *, name=None, id=None, retry=None):
+        """
+        Format {data} as a single SSE frame and return the encoded bytes
+        """
+        # collect the frame lines
+        lines = []
+        # an optional event id lets a reconnecting client report where it left off
+        if id is not None:
+            lines.append(f"id: {id}")
+        # an optional event name lets listeners be type specific
+        if name is not None:
+            lines.append(f"event: {name}")
+        # an optional reconnection delay hint, in milliseconds
+        if retry is not None:
+            lines.append(f"retry: {retry}")
+        # the payload, split so that any embedded newline stays within this one frame
+        for line in data.splitlines() or [""]:
+            lines.append(f"data: {line}")
+        # join the lines and terminate the frame with a blank line
+        frame = "\n".join(lines) + "\n\n"
+        # encode and hand off
+        return frame.encode(self.encoding)
+
+    def render(self, **kwds):
+        """
+        A streaming response carries no rendered body; its payload arrives out of band
+        """
+        # nothing to render
+        return b""
+
+    # meta-methods
+    def __init__(self, topic="", **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # remember the topic that scopes my delivery
+        self.topic = topic
+        # decorate the headers for SSE
+        headers = self.headers
+        # mark the content type
+        headers["Content-Type"] = "text/event-stream"
+        # forbid caching of the stream
+        headers["Cache-Control"] = "no-cache"
+        # hold the connection open
+        headers["Connection"] = "keep-alive"
+        # all done
+        return
+
+
+# end of file

--- a/packages/pyre/http/EventStream.py
+++ b/packages/pyre/http/EventStream.py
@@ -70,6 +70,9 @@ class EventStream(Response):
         headers["Cache-Control"] = "no-cache"
         # hold the connection open
         headers["Connection"] = "keep-alive"
+        # tell reverse proxies (nginx and friends) not to buffer the stream, so events reach the
+        # client promptly instead of being held back until the connection closes
+        headers["X-Accel-Buffering"] = "no"
         # all done
         return
 

--- a/packages/pyre/http/Hub.py
+++ b/packages/pyre/http/Hub.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import collections
+
+
+# the streaming subscriber registry and outbound pump
+class Hub:
+    """
+    The registry of streaming subscribers and the pump that feeds them
+
+    A {Hub} is owned by an HTTP server. It tracks the connections subscribed to each topic,
+    buffers the bytes destined for each connection, and drains those buffers without blocking
+    the server's event loop, riding the dispatcher's write-readiness notifications.
+    """
+
+    # interface
+    def subscribe(self, channel, topic=""):
+        """
+        Record {channel} as a subscriber to {topic} and prepare its outbound queue
+        """
+        # add the channel to the topic's subscriber set
+        self._subscribers[topic].add(channel)
+        # make sure it has an outbound queue
+        self._queues.setdefault(channel, collections.deque())
+        # all done
+        return
+
+    def unsubscribe(self, channel):
+        """
+        Drop {channel} from every topic, discard its queue, and forget it is armed
+        """
+        # remove it from each topic's subscriber set
+        for subscribers in self._subscribers.values():
+            # quietly, whether or not it is present
+            subscribers.discard(channel)
+        # discard its outbound queue
+        self._queues.pop(channel, None)
+        # and its armed flag
+        self._armed.discard(channel)
+        # all done
+        return
+
+    def publish(self, event, topic=""):
+        """
+        Append the {event} bytes to the outbound queue of every subscriber to {topic}
+        """
+        # go through the subscribers of this topic
+        for channel in self._subscribers.get(topic, ()):
+            # and enqueue the event on each
+            self.send(channel=channel, data=event)
+        # all done
+        return
+
+    def send(self, channel, data):
+        """
+        Append the {data} bytes to {channel}'s outbound queue and arm it for delivery
+        """
+        # attempt to
+        try:
+            # find the channel's queue
+            queue = self._queues[channel]
+        # if it is not a subscriber
+        except KeyError:
+            # there is nothing to do
+            return
+        # append the data
+        queue.append(data)
+        # and arm the channel for writing
+        self._arm(channel)
+        # all done
+        return
+
+    def flush(self, channel, **kwds):
+        """
+        The write-readiness handler: drain as much of {channel}'s queue as the socket accepts
+
+        Returns {True} while bytes remain, so the dispatcher reschedules this handler, and
+        {False} once the queue empties, so the dispatcher releases the write registration.
+        """
+        # find the channel's queue
+        queue = self._queues.get(channel)
+        # if the channel is gone
+        if queue is None:
+            # forget it is armed
+            self._armed.discard(channel)
+            # and ask not to be rescheduled
+            return False
+        # while there are frames to deliver
+        while queue:
+            # peek at the head of the queue
+            frame = queue[0]
+            # attempt a partial, non-blocking send; a full send buffer raises {BlockingIOError}
+            # and a broken connection raises {OSError}, both of which propagate to the
+            # dispatcher, which reschedules or drops this handler accordingly
+            sent = channel.send(frame)
+            # if the socket did not take the whole frame
+            if sent < len(frame):
+                # put the unsent remainder back at the head
+                queue[0] = frame[sent:]
+                # and ask to be rescheduled when the socket is writable again
+                return True
+            # otherwise the frame is fully delivered; drop it
+            queue.popleft()
+        # the queue is empty; forget the channel is armed
+        self._armed.discard(channel)
+        # and release the write registration
+        return False
+
+    # meta-methods
+    def __init__(self, dispatcher, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save the dispatcher, my source of write-readiness notifications
+        self.dispatcher = dispatcher
+        # the topic -> set of subscribed channels map
+        self._subscribers = collections.defaultdict(set)
+        # the channel -> outbound byte queue map
+        self._queues = {}
+        # the set of channels currently registered for write-readiness
+        self._armed = set()
+        # all done
+        return
+
+    # implementation details
+    def _arm(self, channel):
+        """
+        Register {channel} for write-readiness exactly once
+        """
+        # if the channel is already armed
+        if channel in self._armed:
+            # {whenWriteReady} appends a fresh handler on every call, so arming again would
+            # pile a duplicate {flush} onto the same queue; do nothing
+            return
+        # mark it armed
+        self._armed.add(channel)
+        # and ask the dispatcher to call me back when the channel can accept bytes
+        self.dispatcher.whenWriteReady(channel=channel, call=self.flush)
+        # all done
+        return
+
+    # private data
+    dispatcher = None
+    _subscribers = None
+    _queues = None
+    _armed = None
+
+
+# end of file

--- a/packages/pyre/http/Hub.py
+++ b/packages/pyre/http/Hub.py
@@ -15,7 +15,9 @@ class Hub:
 
     A {Hub} is owned by an HTTP server. It tracks the connections subscribed to each topic,
     buffers the bytes destined for each connection, and drains those buffers without blocking
-    the server's event loop, riding the dispatcher's write-readiness notifications.
+    the server's event loop, riding the dispatcher's write-readiness notifications. It also
+    broadcasts a periodic keep-alive so idle connections are not reaped by intermediaries, and
+    it bounds each connection's buffer so a slow consumer cannot grow it without limit.
     """
 
     # interface
@@ -27,6 +29,8 @@ class Hub:
         self._subscribers[topic].add(channel)
         # make sure it has an outbound queue
         self._queues.setdefault(channel, collections.deque())
+        # make sure the keep-alive timer is running, now that there is someone to feed
+        self._beat()
         # all done
         return
 
@@ -45,20 +49,28 @@ class Hub:
         # all done
         return
 
-    def publish(self, event, topic=""):
+    def publish(self, event, topic="", coalesce=False):
         """
         Append the {event} bytes to the outbound queue of every subscriber to {topic}
+
+        When {coalesce} is set, an {event} identical to the one already pending at the tail of a
+        subscriber's queue is skipped, so a burst of identical notifications collapses to one.
         """
-        # go through the subscribers of this topic
-        for channel in self._subscribers.get(topic, ()):
-            # and enqueue the event on each
-            self.send(channel=channel, data=event)
+        # iterate a snapshot of the subscribers: a send may drop an overflowing subscriber, which
+        # mutates the set we would otherwise be iterating
+        for channel in tuple(self._subscribers.get(topic, ())):
+            # enqueue the event on each
+            self.send(channel=channel, data=event, coalesce=coalesce)
         # all done
         return
 
-    def send(self, channel, data):
+    def send(self, channel, data, coalesce=False):
         """
         Append the {data} bytes to {channel}'s outbound queue and arm it for delivery
+
+        When {coalesce} is set and {data} already sits at the tail of the queue, the append is
+        skipped. A subscriber whose queue is full is dropped, so it reconnects and resynchronizes
+        rather than growing the buffer without bound.
         """
         # attempt to
         try:
@@ -68,7 +80,17 @@ class Hub:
         except KeyError:
             # there is nothing to do
             return
-        # append the data
+        # if we are coalescing and this exact frame is already pending at the tail
+        if coalesce and queue and queue[-1] == data:
+            # there is no point queuing it twice
+            return
+        # if the queue is already full, this subscriber cannot keep up
+        if len(queue) >= self._capacity:
+            # drop it; its client will reconnect and pull fresh state
+            self._drop(channel)
+            # and there is nothing more to do
+            return
+        # otherwise, append the data
         queue.append(data)
         # and arm the channel for writing
         self._arm(channel)
@@ -80,7 +102,7 @@ class Hub:
         The write-readiness handler: drain as much of {channel}'s queue as the socket accepts
 
         Returns {True} while bytes remain, so the dispatcher reschedules this handler, and
-        {False} once the queue empties, so the dispatcher releases the write registration.
+        {False} once the queue empties (or the connection breaks), so it is released.
         """
         # find the channel's queue
         queue = self._queues.get(channel)
@@ -94,10 +116,21 @@ class Hub:
         while queue:
             # peek at the head of the queue
             frame = queue[0]
-            # attempt a partial, non-blocking send; a full send buffer raises {BlockingIOError}
-            # and a broken connection raises {OSError}, both of which propagate to the
-            # dispatcher, which reschedules or drops this handler accordingly
-            sent = channel.send(frame)
+            # attempt a partial, non-blocking send
+            try:
+                # hand as much as the socket will take
+                sent = channel.send(frame)
+            # if the socket buffer is full right now
+            except BlockingIOError:
+                # nothing went; try again when the socket is writable (this MUST come first, since
+                # {BlockingIOError} is itself an {OSError})
+                return True
+            # if the connection is broken
+            except OSError:
+                # forget this subscriber now, rather than waiting for the read side to notice
+                self.unsubscribe(channel)
+                # and ask not to be rescheduled
+                return False
             # if the socket did not take the whole frame
             if sent < len(frame):
                 # put the unsent remainder back at the head
@@ -112,17 +145,27 @@ class Hub:
         return False
 
     # meta-methods
-    def __init__(self, dispatcher, **kwds):
+    def __init__(
+        self, dispatcher, capacity=1024, interval=None, keepalive=None, **kwds
+    ):
         # chain up
         super().__init__(**kwds)
-        # save the dispatcher, my source of write-readiness notifications
+        # save the dispatcher, my source of write-readiness notifications and timers
         self.dispatcher = dispatcher
+        # the most frames a single subscriber may have queued before it is dropped
+        self._capacity = capacity
+        # the keep-alive interval (a {pyre.units} time quantity) and the bytes to send each tick;
+        # both must be set for the heartbeat to run
+        self._interval = interval
+        self._keepalive = keepalive
         # the topic -> set of subscribed channels map
         self._subscribers = collections.defaultdict(set)
         # the channel -> outbound byte queue map
         self._queues = {}
         # the set of channels currently registered for write-readiness
         self._armed = set()
+        # whether the keep-alive timer is currently scheduled
+        self._beating = False
         # all done
         return
 
@@ -143,11 +186,68 @@ class Hub:
         # all done
         return
 
+    def _drop(self, channel):
+        """
+        Forget and close a subscriber that has fallen too far behind to keep up
+        """
+        # remove it from my tables
+        self.unsubscribe(channel)
+        # and close its connection, so the client reconnects and pulls fresh state
+        try:
+            # let go of the socket
+            channel.close()
+        # if it is already gone
+        except OSError:
+            # there is nothing to do
+            pass
+        # all done
+        return
+
+    def _beat(self):
+        """
+        Make sure the keep-alive timer is scheduled, if a heartbeat is configured
+        """
+        # if a heartbeat is not configured, or one is already running
+        if self._keepalive is None or self._interval is None or self._beating:
+            # there is nothing to do
+            return
+        # mark the timer as running
+        self._beating = True
+        # and schedule the first tick; the handler reschedules itself by returning the interval
+        self.dispatcher.alarm(interval=self._interval, call=self._heartbeat)
+        # all done
+        return
+
+    def _heartbeat(self, timestamp):
+        """
+        Broadcast a keep-alive to every subscriber and ask to be rescheduled
+
+        Returns the interval so the dispatcher fires this again; returns {None} when there are no
+        subscribers left, which stops the timer until the next {subscribe} restarts it.
+        """
+        # if there is no one left to keep alive
+        if not self._queues:
+            # let the timer lapse
+            self._beating = False
+            # by declining to reschedule
+            return None
+        # otherwise, send the keep-alive to every subscriber; iterate a snapshot since a full
+        # queue would drop its channel and mutate the map
+        for channel in tuple(self._queues):
+            # enqueue the keep-alive frame
+            self.send(channel=channel, data=self._keepalive)
+        # ask the dispatcher to fire this again after the same interval
+        return self._interval
+
     # private data
     dispatcher = None
+    _capacity = None
+    _interval = None
+    _keepalive = None
     _subscribers = None
     _queues = None
     _armed = None
+    _beating = False
 
 
 # end of file

--- a/packages/pyre/http/Hub.py
+++ b/packages/pyre/http/Hub.py
@@ -27,6 +27,9 @@ class Hub:
         """
         # add the channel to the topic's subscriber set
         self._subscribers[topic].add(channel)
+        # and record the reverse edge, so we can find this channel's topics again in O(1) at
+        # unsubscribe time instead of scanning every topic
+        self._topics.setdefault(channel, set()).add(topic)
         # make sure it has an outbound queue
         self._queues.setdefault(channel, collections.deque())
         # make sure the keep-alive timer is running, now that there is someone to feed
@@ -36,12 +39,20 @@ class Hub:
 
     def unsubscribe(self, channel):
         """
-        Drop {channel} from every topic, discard its queue, and forget it is armed
+        Drop {channel} from every topic it joined, discard its queue, and forget it is armed
         """
-        # remove it from each topic's subscriber set
-        for subscribers in self._subscribers.values():
-            # quietly, whether or not it is present
-            subscribers.discard(channel)
+        # consult the reverse index for exactly the topics this channel joined, and forget them
+        for topic in self._topics.pop(channel, ()):
+            # find that topic's subscriber set
+            subscribers = self._subscribers.get(topic)
+            # if it is still around
+            if subscribers is not None:
+                # remove this channel from it
+                subscribers.discard(channel)
+                # and if that leaves the topic with no subscribers
+                if not subscribers:
+                    # prune it, so short-lived topics do not pile up empty sets forever
+                    del self._subscribers[topic]
         # discard its outbound queue
         self._queues.pop(channel, None)
         # and its armed flag
@@ -158,8 +169,11 @@ class Hub:
         # both must be set for the heartbeat to run
         self._interval = interval
         self._keepalive = keepalive
-        # the topic -> set of subscribed channels map
+        # the topic -> set of subscribed channels map, consulted by publish
         self._subscribers = collections.defaultdict(set)
+        # its reverse, the channel -> set of joined topics map, consulted by unsubscribe so a
+        # disconnect touches only the topics that channel actually joined
+        self._topics = {}
         # the channel -> outbound byte queue map
         self._queues = {}
         # the set of channels currently registered for write-readiness
@@ -245,6 +259,7 @@ class Hub:
     _interval = None
     _keepalive = None
     _subscribers = None
+    _topics = None
     _queues = None
     _armed = None
     _beating = False

--- a/packages/pyre/http/Response.py
+++ b/packages/pyre/http/Response.py
@@ -36,6 +36,7 @@ class Response(NexusError):
 
     alive = True  # keep the connection alive after serving this response
     abort = False  # terminate the process after serving this response
+    streaming = False  # route me down the server's streaming path instead of render-once
     code = 0  # the exit code to pass to the shell upon exiting
 
     # meta-methods

--- a/packages/pyre/http/Server.py
+++ b/packages/pyre/http/Server.py
@@ -18,6 +18,8 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
     # types
     from .Request import Request as request
     from .Response import Response as response
+    from .EventStream import EventStream as eventStream
+    from .Hub import Hub
 
     # exceptions
     from . import exceptions, responses, documents
@@ -44,6 +46,18 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
         return pyre.version()
 
     # protocol obligations
+    @pyre.export(tip="register this service with the nexus")
+    def activate(self, app, dispatcher):
+        """
+        Register with the nexus and build the event hub
+        """
+        # chain up to grab a port and register for connection requests
+        super().activate(app=app, dispatcher=dispatcher)
+        # now that the dispatcher is available, build my event hub
+        self.hub = self.Hub(dispatcher=self.dispatcher)
+        # all done
+        return
+
     @pyre.export(tip="respond to the peer request")
     def process(self, channel):
         """
@@ -80,6 +94,10 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
             application.debug.log(f"connection from {channel.peer} was closed")
             # close the connection
             channel.close()
+            # if this channel was a streaming subscriber, drop it from the hub
+            if self.hub is not None:
+                # so we stop buffering events for a connection that is gone
+                self.hub.unsubscribe(channel)
             # check whether we know this peer
             try:
                 # in which case, forget him
@@ -164,6 +182,11 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
         return self.application.pyre_respond(server=self, request=request)
 
     def respond(self, channel, request, response):
+        # if this is a streaming response
+        if response.streaming:
+            # hand the channel to the hub instead of rendering and writing it once
+            return self.stream(channel=channel, request=request, response=response)
+
         # attempt to
         try:
             # ask the renderer to put together the byte stream
@@ -203,6 +226,25 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
         # otherwise, let the response document decide whether we should keep the channel alive
         return response.alive
 
+    def stream(self, channel, request, response):
+        """
+        Begin a server-sent event stream on {channel} by handing it to the hub
+        """
+        # render the preamble: the status line and headers, with no body and no Content-Length,
+        # terminated by the blank line that separates the headers from the event stream
+        preamble = b"\r\n".join(self.renderer.preamble(document=response)) + b"\r\n\r\n"
+        # switch the channel to non-blocking so the hub can perform partial sends
+        channel.setblocking(False)
+        # get my hub
+        hub = self.hub
+        # subscribe this channel to the response's topic
+        hub.subscribe(channel=channel, topic=response.topic)
+        # queue the preamble; the hub arms the channel and delivers it on the same path as
+        # every later event, so a streaming channel is never touched by the blocking writer
+        hub.send(channel=channel, data=preamble)
+        # let the response decide whether the connection stays open
+        return response.alive
+
     # meta-methods
     def __init__(self, **kwds):
         # chain up
@@ -215,6 +257,7 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
     # implementation details
     # private data
     requests = None
+    hub = None
     # constants
     MAX_BYTES = 1024 * 1024
 

--- a/packages/pyre/http/Server.py
+++ b/packages/pyre/http/Server.py
@@ -8,6 +8,9 @@
 import journal
 import pyre
 
+# the unit of time for the keep-alive interval
+from pyre.units.SI import second
+
 
 # my declaration
 class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
@@ -27,6 +30,14 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
     # user configurable state
     renderer = pyre.weaver.language(default="http")
     renderer.doc = "the renderer of the server responses to client requests"
+
+    heartbeat = pyre.properties.dimensional(default=15 * second)
+    heartbeat.doc = "how often to send a keep-alive on held-open streaming connections"
+
+    streamCapacity = pyre.properties.int(default=1024)
+    streamCapacity.doc = (
+        "the most frames a streaming subscriber may queue before it is dropped"
+    )
 
     # public state
     @property
@@ -53,8 +64,14 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
         """
         # chain up to grab a port and register for connection requests
         super().activate(app=app, dispatcher=dispatcher)
-        # now that the dispatcher is available, build my event hub
-        self.hub = self.Hub(dispatcher=self.dispatcher)
+        # now that the dispatcher is available, build my event hub, wiring in the keep-alive
+        # broadcast and the per-subscriber buffer bound
+        self.hub = self.Hub(
+            dispatcher=self.dispatcher,
+            capacity=self.streamCapacity,
+            interval=self.heartbeat,
+            keepalive=self.eventStream.keepalive(),
+        )
         # all done
         return
 

--- a/packages/pyre/ipc/SelectorPSL.py
+++ b/packages/pyre/ipc/SelectorPSL.py
@@ -153,25 +153,25 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
             for key, mask in selection:
                 # get the corresponding file descriptor
                 fd = key.fileobj
-                # and the events we are watching
-                event = masks[fd]
+                # the bits whose handler piles drain to empty during this pass
+                cleared = 0
                 # N.B.:
                 #     a decision had to be made regarding the order that handlers are invoked
                 #     this implementation calls the {read} handlers before the {write} handlers
                 # if the {mask} indicates {fd} is ready for read
                 if mask & selectors.EVENT_READ:
-                    # invoke the write handlers
+                    # invoke the read handlers
                     reschedule = self.dispatch(index=read, key=fd)
                     # if there is something to reschedule
                     if reschedule:
-                        # update the {write} map
+                        # update the {read} map
                         read[fd] = reschedule
                     # otherwise
                     else:
                         # remove this file descriptor from the pile
                         read.pop(fd, 0)
-                        # clear the {write} bit from its mask
-                        event &= ~selectors.EVENT_READ
+                        # and mark the read bit for clearing
+                        cleared |= selectors.EVENT_READ
                 # if the {mask} indicates {fd} is ready for write
                 if mask & selectors.EVENT_WRITE:
                     # invoke the write handlers
@@ -184,22 +184,32 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
                     else:
                         # remove this file descriptor from the pile
                         write.pop(fd, 0)
-                        # clear the {write} bit from its mask
-                        event &= ~selectors.EVENT_WRITE
-                # if the {event} mask of this {fd} is now trivial
-                if event == 0:
-                    # unregister it
-                    selector.unregister(fileobj=fd)
-                    # and remove it from the mask table
-                    masks.pop(fd, 0)
-                # otherwise
-                else:
-                    # if the event has been modified
-                    if masks[fd] != event:
+                        # and mark the write bit for clearing
+                        cleared |= selectors.EVENT_WRITE
+                # recompute the mask from the live table, not a pre-dispatch snapshot: a handler
+                # may have registered fresh interest on this same {fd} while it ran (e.g. a read
+                # handler arming a write), and that addition must survive
+                event = masks[fd] & ~cleared
+                # carefully, because a handler may have closed {fd} during dispatch
+                try:
+                    # if the {event} mask of this {fd} is now trivial
+                    if event == 0:
+                        # unregister it
+                        selector.unregister(fileobj=fd)
+                        # and remove it from the mask table
+                        masks.pop(fd, 0)
+                    # otherwise, if the registration changed
+                    elif masks[fd] != event:
                         # modify the selector registration
                         selector.modify(fileobj=fd, events=event)
                         # and update the table
                         masks[fd] = event
+                # if {fd} was closed out from under us
+                except (KeyError, ValueError, OSError):
+                    # forget it entirely
+                    read.pop(fd, 0)
+                    write.pop(fd, 0)
+                    masks.pop(fd, 0)
 
             # raise any overdue alarms
             self.awaken()

--- a/packages/pyre/weaver/HTTP.py
+++ b/packages/pyre/weaver/HTTP.py
@@ -101,4 +101,28 @@ class HTTP(pyre.component, implements=Language):
         yield ''
 
 
+    # implementation details
+    def preamble(self, document):
+        """
+        Render the status line and headers of a streaming {document}, with no body and no
+        {Content-Length}
+        """
+        # unpack
+        code = document.code
+        status = document.status
+        version = document.version
+
+        # decide which protocol to use
+        protocol = self.version if self.version < version else version
+        # turn it into a string
+        protocol = "{}.{}".format(*protocol)
+        # start the response
+        yield f"HTTP/{protocol} {code} {status}".encode(self.encoding, 'strict')
+
+        # assemble the headers and send them off
+        yield from self.header(document=document)
+        # all done
+        return
+
+
 # end of file

--- a/packages/pyre/weaver/HTTP.py
+++ b/packages/pyre/weaver/HTTP.py
@@ -29,7 +29,7 @@ class HTTP(pyre.component, implements=Language):
 
 
     # public data
-    version = 1,0 # my preferred protocol version
+    version = 1, 1  # my preferred protocol version
 
 
     # mill obligations

--- a/packages/pyre/weaver/HTTP.py
+++ b/packages/pyre/weaver/HTTP.py
@@ -38,28 +38,13 @@ class HTTP(pyre.component, implements=Language):
         """
         Render the document
         """
-        # unpack
-        code = document.code
-        headers = document.headers
-        status = document.status
-        version = document.version
-
-        # decide which protocol to use
-        protocol = self.version if self.version < version else version
-        # turn it into a string
-        protocol = "{}.{}".format(*protocol)
-        # start the response
-        opening = f"HTTP/{protocol} {code} {status}".encode(self.encoding, 'strict')
-        # and send it off
-        yield opening
-
         # assemble the payload
         page = self.body(document=document, **kwds)
-        # inform the client about the size of the payload
-        headers['Content-Length'] = len(page)
+        # inform the client about the size of the payload, before the headers go out
+        document.headers['Content-Length'] = len(page)
 
-        # assemble the headers and send them off
-        yield from self.header(document=document)
+        # emit the status line and headers
+        yield from self.preamble(document=document)
         # mark the end of the headers
         yield b''
         # send the page

--- a/tests/pyre.pkg/http/eventstream.py
+++ b/tests/pyre.pkg/http/eventstream.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify the {EventStream} response frames SSE correctly and carries the SSE headers
+"""
+
+# the response under test
+from pyre.http.EventStream import EventStream
+
+
+# a stand-in for the server; the {Response} base only consults it for its {name}
+class Server:
+    """
+    The minimal server surface a response needs
+    """
+
+    # the identification string the response stamps into its headers
+    name = "pyre/test"
+
+
+def test():
+    # build a stream scoped to the {updates} topic
+    stream = EventStream(server=Server(), topic="updates")
+
+    # it routes down the server's streaming path
+    assert stream.streaming is True
+    # it holds the connection open
+    assert stream.alive is True
+    # it is a successful response
+    assert stream.code == 200
+    # it remembers the topic that scopes its delivery
+    assert stream.topic == "updates"
+
+    # it advertises the SSE content type
+    assert stream.headers["Content-Type"] == "text/event-stream"
+    # it forbids caching of the stream
+    assert stream.headers["Cache-Control"] == "no-cache"
+    # it asks intermediaries to keep the connection open
+    assert stream.headers["Connection"] == "keep-alive"
+    # and it opts out of reverse-proxy buffering, so events are not held back
+    assert stream.headers["X-Accel-Buffering"] == "no"
+
+    # a bare payload frames as a single {data} line terminated by a blank line
+    assert stream.event("hello") == b"data: hello\n\n"
+    # the optional fields render in order, and multi-line data splits across {data} lines so the
+    # embedded newline stays inside this one frame
+    assert stream.event("a\nb", name="change", id=7, retry=3000) == (
+        b"id: 7\nevent: change\nretry: 3000\ndata: a\ndata: b\n\n"
+    )
+    # a streaming response renders no body of its own
+    assert stream.render() == b""
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/http/hub.py
+++ b/tests/pyre.pkg/http/hub.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify the http {Hub} arms a channel exactly once, drains with partial sends, re-arms once its
+queue empties, and cleans up on unsubscribe
+"""
+
+# the registry under test
+from pyre.http.Hub import Hub
+
+
+# a stand-in dispatcher that records every channel armed for write-readiness
+class Dispatcher:
+    """
+    The slice of the dispatcher interface the hub uses
+    """
+
+    # meta-methods
+    def __init__(self):
+        # start with an empty record of armings
+        self.armed = []
+        # all done
+        return
+
+    # the only dispatcher method the hub calls
+    def whenWriteReady(self, channel, call):
+        """
+        Record that {channel} was armed with the {call} handler
+        """
+        # remember the arming so the test can count it
+        self.armed.append((channel, call))
+        # all done
+        return
+
+
+# a stand-in channel whose socket accepts at most {limit} bytes per send ({None} accepts all)
+class Channel:
+    """
+    A socket-like endpoint with a controllable per-send capacity
+    """
+
+    # meta-methods
+    def __init__(self, limit=None):
+        # the bytes delivered so far
+        self.buffer = b""
+        # how many bytes a single send will accept
+        self.limit = limit
+        # all done
+        return
+
+    # accept up to {limit} bytes, like a non-blocking socket with a nearly-full buffer
+    def send(self, data):
+        """
+        Accept up to {limit} bytes of {data} and report how many were taken
+        """
+        # decide how many bytes to take
+        n = len(data) if self.limit is None else min(self.limit, len(data))
+        # append exactly that many
+        self.buffer += data[:n]
+        # and report the count, as a real socket does
+        return n
+
+
+def test():
+    # arm exactly once across publishes, then drain fully
+    # a fresh dispatcher and hub
+    dispatcher = Dispatcher()
+    hub = Hub(dispatcher=dispatcher)
+    # a channel that accepts everything
+    channel = Channel()
+    # subscribe it to a topic
+    hub.subscribe(channel=channel, topic="t")
+    # publish two events to that topic
+    hub.publish(b"one", topic="t")
+    hub.publish(b"two", topic="t")
+    # the two publishes armed the channel exactly once
+    assert len(dispatcher.armed) == 1
+    # a flush delivers both frames and reports the queue is now empty
+    assert hub.flush(channel=channel) is False
+    # the channel received them concatenated, in order
+    assert channel.buffer == b"one" + b"two"
+    # and it is no longer armed
+    assert channel not in hub._armed
+
+    # a frame larger than one send is delivered across flushes
+    # a fresh dispatcher and hub
+    dispatcher = Dispatcher()
+    hub = Hub(dispatcher=dispatcher)
+    # a channel that takes only three bytes per send
+    channel = Channel(limit=3)
+    # subscribe it to the default topic
+    hub.subscribe(channel=channel)
+    # queue six bytes
+    hub.send(channel=channel, data=b"abcdef")
+    # the first flush takes what fits, keeps the rest, and asks to be rescheduled
+    assert hub.flush(channel=channel) is True
+    # three bytes made it through
+    assert channel.buffer == b"abc"
+    # and the channel is still armed for the remainder
+    assert channel in hub._armed
+    # the second flush delivers the rest and disarms
+    assert hub.flush(channel=channel) is False
+    # all six bytes are now through
+    assert channel.buffer == b"abcdef"
+    # and the channel is disarmed
+    assert channel not in hub._armed
+
+    # a publish after the queue empties arms the channel afresh
+    # remember how many armings we have seen
+    before = len(dispatcher.armed)
+    # publish once more
+    hub.publish(b"z")
+    # which arms the channel again
+    assert len(dispatcher.armed) == before + 1
+
+    # unsubscribe forgets the channel; a later send to it is a quiet no-op
+    # drop the channel
+    hub.unsubscribe(channel)
+    # its queue is gone
+    assert channel not in hub._queues
+    # its armed flag is gone
+    assert channel not in hub._armed
+    # and sending to it now does nothing, rather than raising
+    hub.send(channel=channel, data=b"x")
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/http/hub.py
+++ b/tests/pyre.pkg/http/hub.py
@@ -6,15 +6,16 @@
 
 
 """
-Verify the http {Hub} arms a channel exactly once, drains with partial sends, re-arms once its
-queue empties, and cleans up on unsubscribe
+Verify the http {Hub}: it arms a channel once, drains with partial sends, re-arms once empty,
+cleans up on unsubscribe, coalesces identical frames, drops a subscriber that overflows its queue,
+and broadcasts a recurring keep-alive while it has subscribers
 """
 
 # the registry under test
 from pyre.http.Hub import Hub
 
 
-# a stand-in dispatcher that records every channel armed for write-readiness
+# a stand-in dispatcher that records every channel armed for write-readiness and every alarm set
 class Dispatcher:
     """
     The slice of the dispatcher interface the hub uses
@@ -22,12 +23,14 @@ class Dispatcher:
 
     # meta-methods
     def __init__(self):
-        # start with an empty record of armings
+        # the channels armed for write-readiness
         self.armed = []
+        # the alarms scheduled, as (interval, handler) pairs
+        self.alarms = []
         # all done
         return
 
-    # the only dispatcher method the hub calls
+    # arm a channel for write-readiness
     def whenWriteReady(self, channel, call):
         """
         Record that {channel} was armed with the {call} handler
@@ -37,11 +40,21 @@ class Dispatcher:
         # all done
         return
 
+    # schedule a timer
+    def alarm(self, interval, call):
+        """
+        Record that an alarm was scheduled to fire {call} after {interval}
+        """
+        # remember the alarm so the test can drive it
+        self.alarms.append((interval, call))
+        # all done
+        return
+
 
 # a stand-in channel whose socket accepts at most {limit} bytes per send ({None} accepts all)
 class Channel:
     """
-    A socket-like endpoint with a controllable per-send capacity
+    A socket-like endpoint with a controllable per-send capacity that records when it is closed
     """
 
     # meta-methods
@@ -50,6 +63,8 @@ class Channel:
         self.buffer = b""
         # how many bytes a single send will accept
         self.limit = limit
+        # whether the channel has been closed
+        self.closed = False
         # all done
         return
 
@@ -64,6 +79,16 @@ class Channel:
         self.buffer += data[:n]
         # and report the count, as a real socket does
         return n
+
+    # close the connection
+    def close(self):
+        """
+        Mark the channel as closed
+        """
+        # note the closure
+        self.closed = True
+        # all done
+        return
 
 
 def test():
@@ -127,6 +152,72 @@ def test():
     assert channel not in hub._armed
     # and sending to it now does nothing, rather than raising
     hub.send(channel=channel, data=b"x")
+
+    # coalescing skips an identical frame already pending at the tail
+    # a fresh dispatcher and hub
+    dispatcher = Dispatcher()
+    hub = Hub(dispatcher=dispatcher)
+    # a channel
+    channel = Channel()
+    # subscribe it
+    hub.subscribe(channel=channel)
+    # publish the same frame twice, coalescing
+    hub.publish(b"same", coalesce=True)
+    hub.publish(b"same", coalesce=True)
+    # only one copy is pending
+    assert len(hub._queues[channel]) == 1
+    # a different frame is still queued
+    hub.publish(b"other", coalesce=True)
+    assert len(hub._queues[channel]) == 2
+
+    # a subscriber that overflows its queue is dropped and closed
+    # a hub that holds at most two frames per subscriber
+    dispatcher = Dispatcher()
+    hub = Hub(dispatcher=dispatcher, capacity=2)
+    # a channel that never drains (its socket is not flushed during this block)
+    channel = Channel()
+    # subscribe it
+    hub.subscribe(channel=channel)
+    # fill the queue to capacity
+    hub.send(channel=channel, data=b"a")
+    hub.send(channel=channel, data=b"b")
+    # the queue is full
+    assert len(hub._queues[channel]) == 2
+    # the next send overflows, so the subscriber is dropped and its connection closed
+    hub.send(channel=channel, data=b"c")
+    # it is gone from the hub
+    assert channel not in hub._queues
+    # and its connection was closed
+    assert channel.closed is True
+
+    # the keep-alive heartbeat runs while there are subscribers and lapses when there are none
+    # a hub configured with a keep-alive frame and an interval
+    dispatcher = Dispatcher()
+    hub = Hub(dispatcher=dispatcher, keepalive=b": keepalive\n\n", interval=1)
+    # before anyone subscribes, no timer is scheduled
+    assert len(dispatcher.alarms) == 0
+    # the first subscriber starts the timer
+    first = Channel()
+    hub.subscribe(channel=first)
+    assert len(dispatcher.alarms) == 1
+    # a second subscriber does not start a second timer
+    second = Channel()
+    hub.subscribe(channel=second)
+    assert len(dispatcher.alarms) == 1
+    # firing the timer broadcasts the keep-alive to every subscriber and asks to recur
+    interval, beat = dispatcher.alarms[0]
+    assert beat(timestamp=0) == 1
+    # each subscriber has the keep-alive queued
+    assert hub._queues[first][-1] == b": keepalive\n\n"
+    assert hub._queues[second][-1] == b": keepalive\n\n"
+    # with no subscribers left, the next tick declines to recur
+    hub.unsubscribe(first)
+    hub.unsubscribe(second)
+    assert beat(timestamp=0) is None
+    # and a fresh subscription restarts the timer
+    third = Channel()
+    hub.subscribe(channel=third)
+    assert len(dispatcher.alarms) == 2
 
     # all done
     return

--- a/tests/pyre.pkg/http/hub.py
+++ b/tests/pyre.pkg/http/hub.py
@@ -219,6 +219,42 @@ def test():
     hub.subscribe(channel=third)
     assert len(dispatcher.alarms) == 2
 
+    # unsubscribe touches only the leaving channel's topics and prunes the ones left empty
+    # a fresh dispatcher and hub
+    dispatcher = Dispatcher()
+    hub = Hub(dispatcher=dispatcher)
+    # one channel on topic "x", another on topic "y"
+    here = Channel()
+    there = Channel()
+    hub.subscribe(channel=here, topic="x")
+    hub.subscribe(channel=there, topic="y")
+    # drop the first
+    hub.unsubscribe(here)
+    # it is gone from the reverse index and its queue
+    assert here not in hub._topics
+    assert here not in hub._queues
+    # its now-empty topic is pruned entirely
+    assert "x" not in hub._subscribers
+    # the other channel and its topic are untouched
+    assert there in hub._subscribers["y"]
+    assert hub._topics[there] == {"y"}
+
+    # a channel on several topics is removed from all of them at once
+    # a fresh dispatcher and hub
+    dispatcher = Dispatcher()
+    hub = Hub(dispatcher=dispatcher)
+    # one channel joining two topics
+    both = Channel()
+    hub.subscribe(channel=both, topic="a")
+    hub.subscribe(channel=both, topic="b")
+    # the reverse index records both
+    assert hub._topics[both] == {"a", "b"}
+    # unsubscribe removes it from both and prunes both now-empty topics
+    hub.unsubscribe(both)
+    assert "a" not in hub._subscribers
+    assert "b" not in hub._subscribers
+    assert both not in hub._topics
+
     # all done
     return
 

--- a/tests/pyre.pkg/http/render.py
+++ b/tests/pyre.pkg/http/render.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify the {HTTP} renderer's {render} emits a complete response: a status line, a
+{Content-Length}, a blank line, and the body
+"""
+
+# the renderer under test
+from pyre.weaver.HTTP import HTTP
+# the document it renders
+from pyre.http.documents import OK
+
+
+# a stand-in for the server; the {Response} base only consults it for its {name}
+class Server:
+    """
+    The minimal server surface a response needs
+    """
+
+    # the identification string the response stamps into its headers
+    name = "pyre/test"
+
+
+# a document that carries a body, so {render} has something to size and ship
+class Page(OK):
+    """
+    An {OK} response with a fixed payload
+    """
+
+    # hand back a known body
+    def render(self, **kwds):
+        """
+        Generate the payload
+        """
+        # a fixed page
+        return b"<html>hi</html>"
+
+
+def test():
+    # build the renderer and a document with a body
+    renderer = HTTP(name="renderer")
+    page = Page(server=Server())
+
+    # join the rendered fragments the way the server does
+    wire = b"\r\n".join(renderer.render(document=page))
+
+    # the status line opens the response
+    assert wire.startswith(b"HTTP/1.0 200 OK\r\n")
+    # the renderer sizes the body and advertises it
+    assert b"Content-Length: 15\r\n" in wire
+    # a blank line separates the headers from the body, which arrives last
+    assert wire.endswith(b"\r\n\r\n<html>hi</html>")
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/http/render.py
+++ b/tests/pyre.pkg/http/render.py
@@ -50,7 +50,7 @@ def test():
     wire = b"\r\n".join(renderer.render(document=page))
 
     # the status line opens the response
-    assert wire.startswith(b"HTTP/1.0 200 OK\r\n")
+    assert wire.startswith(b"HTTP/1.1 200 OK\r\n")
     # the renderer sizes the body and advertises it
     assert b"Content-Length: 15\r\n" in wire
     # a blank line separates the headers from the body, which arrives last

--- a/tests/pyre.pkg/http/sanity.py
+++ b/tests/pyre.pkg/http/sanity.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Sanity check: verify that the {pyre.http} package is accessible
+"""
+
+
+def test():
+    # access the package
+    import pyre.http
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/http/sse_preamble.py
+++ b/tests/pyre.pkg/http/sse_preamble.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify the {HTTP} renderer's {preamble} emits the server-sent events preamble: the status line
+and the full set of SSE headers, with no {Content-Length} and no body
+"""
+
+# the renderer under test
+from pyre.weaver.HTTP import HTTP
+# the streaming response it renders
+from pyre.http.EventStream import EventStream
+
+
+# a stand-in for the server; the {Response} base only consults it for its {name}
+class Server:
+    """
+    The minimal server surface a response needs
+    """
+
+    # the identification string the response stamps into its headers
+    name = "pyre/test"
+
+
+def test():
+    # build the renderer and a streaming response
+    renderer = HTTP(name="renderer")
+    stream = EventStream(server=Server(), topic="updates")
+
+    # the server frames the preamble by joining the fragments and ending the header block itself
+    wire = b"\r\n".join(renderer.preamble(document=stream)) + b"\r\n\r\n"
+
+    # the status line opens the response
+    assert wire.startswith(b"HTTP/1.0 200 OK\r\n")
+    # the SSE content type rides along
+    assert b"Content-Type: text/event-stream\r\n" in wire
+    # the stream forbids caching
+    assert b"Cache-Control: no-cache\r\n" in wire
+    # it asks intermediaries to hold the connection open
+    assert b"Connection: keep-alive\r\n" in wire
+    # and it opts out of reverse-proxy buffering, so events are not held back
+    assert b"X-Accel-Buffering: no\r\n" in wire
+    # a streaming response has no body, so it carries no {Content-Length}
+    assert b"Content-Length" not in wire
+    # the preamble is exactly the status line and headers, terminated by a blank line
+    assert wire.endswith(b"\r\n\r\n")
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/http/sse_preamble.py
+++ b/tests/pyre.pkg/http/sse_preamble.py
@@ -35,7 +35,7 @@ def test():
     wire = b"\r\n".join(renderer.preamble(document=stream)) + b"\r\n\r\n"
 
     # the status line opens the response
-    assert wire.startswith(b"HTTP/1.0 200 OK\r\n")
+    assert wire.startswith(b"HTTP/1.1 200 OK\r\n")
     # the SSE content type rides along
     assert b"Content-Type: text/event-stream\r\n" in wire
     # the stream forbids caching

--- a/tests/pyre.pkg/ipc/selector_write_during_read.py
+++ b/tests/pyre.pkg/ipc/selector_write_during_read.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify the psl selector preserves write interest that a read handler arms on its own fd during its
+own dispatch -- the scenario the streaming server relies on, and the one that exposed the stale-mask
+bug in {watch}
+"""
+
+# externals
+import socket
+
+# the framework
+import pyre.ipc
+from pyre.units.SI import second
+
+
+# a minimal channel wrapping one end of a socket pair; the dispatcher reads the {inbound}/{outbound}
+# endpoints and the handlers use {recv}/{send}
+class Channel:
+    """
+    A socket-backed channel whose two endpoints are the same socket
+    """
+
+    # meta-methods
+    def __init__(self, sock):
+        # the socket both endpoints resolve to
+        self.sock = sock
+        # all done
+        return
+
+    # access to the endpoints
+    @property
+    def inbound(self):
+        """
+        The endpoint the dispatcher watches for read-readiness
+        """
+        # the socket itself
+        return self.sock
+
+    @property
+    def outbound(self):
+        """
+        The endpoint the dispatcher watches for write-readiness
+        """
+        # the socket itself
+        return self.sock
+
+    # input/output
+    def recv(self, n):
+        """
+        Consume up to {n} bytes from the socket
+        """
+        # delegate to the socket
+        return self.sock.recv(n)
+
+    def send(self, data):
+        """
+        Send {data}, returning the number of bytes accepted
+        """
+        # delegate to the socket
+        return self.sock.send(data)
+
+
+def test():
+    # a connected socket pair; we watch one end
+    a, b = socket.socketpair()
+    # the watched end must be non-blocking so the write handler can probe it safely
+    a.setblocking(False)
+    # wrap it as a channel
+    channel = Channel(a)
+
+    # the selector under test
+    selector = pyre.ipc.newPSL(name="pyre.selectors.psl")
+
+    # a record of which handlers ran
+    fired = {"read": False, "write": False}
+
+    # the write handler: it only needs to prove that it ran
+    def onWrite(channel, **kwds):
+        """
+        Mark that write-readiness fired and stop the loop
+        """
+        # note that write-readiness fired
+        fired["write"] = True
+        # we have what we came for, so end the watch loop promptly
+        selector.stop()
+        # release the write registration
+        return False
+
+    # the read handler: while it runs it arms WRITE interest on the SAME fd -- the case that, before
+    # the fix, had its freshly added interest clobbered by a stale pre-dispatch mask snapshot
+    def onRead(channel, **kwds):
+        """
+        Mark that read-readiness fired and arm write interest mid-dispatch
+        """
+        # note that read-readiness fired
+        fired["read"] = True
+        # drain the byte so the fd is no longer read-ready
+        channel.recv(64)
+        # arm write interest on this same fd, right now, inside the read dispatch
+        selector.whenWriteReady(channel=channel, call=onWrite)
+        # release the read registration
+        return False
+
+    # a safety alarm so the loop can never hang if the bug returns and write never fires
+    def giveup(timestamp):
+        """
+        Abandon the watch loop so the test fails cleanly instead of hanging
+        """
+        # stop watching
+        selector.stop()
+        # all done
+        return
+
+    # watch the read side
+    selector.whenReadReady(channel=channel, call=onRead)
+    # arm the safety alarm a couple of seconds out
+    selector.alarm(interval=2 * second, call=giveup)
+    # make the read side ready by sending it a byte
+    b.send(b"x")
+    # run the loop until the handlers settle, or the safety alarm trips
+    selector.watch()
+
+    # the read handler must have run
+    assert fired["read"]
+    # and the write interest it armed mid-dispatch must have survived to fire
+    assert fired["write"]
+
+    # clean up the sockets
+    a.close()
+    b.close()
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file


### PR DESCRIPTION
Adds a general server-sent events (SSE) capability to `pyre.http`, so a server can push messages to clients over a held-open connection. It lives entirely in the framework and knows nothing about any application; every tool built on `pyre.http` gets it for free. Design: `doc/design/sse.md`.

## What's here

- **`http/EventStream.py`** — a new `Response` subtype carrying the SSE headers (`text/event-stream`, no `Content-Length`) and the wire framing (`event()`), plus an optional `topic` for scoped delivery.
- **`http/Hub.py`** — a topic-keyed subscriber registry and write-buffered pump (`subscribe`/`unsubscribe`/`publish`/`flush`). Bytes are queued per channel and drained via `whenWriteReady`, with partial-send accounting and arm-once semantics.
- **`http/Server.py`** — an `activate` override builds the hub once the dispatcher exists; `respond()` gains a streaming branch (`stream()`) that renders a body-less preamble and hands the channel to the hub; the disconnect path unsubscribes.
- **`http/Response.py`** — a `streaming = False` default flag, the only consumer of which is the new branch in `respond()`, so existing responses are unaffected.
- **`weaver/HTTP.py`** — a body-less `preamble()` renderer for streaming responses.

## Why it's small

The broadcast runs synchronously inside the handler servicing the incoming request that caused the state change, so the single-threaded selector loop never needs an out-of-band wakeup. No threads, no async. Out-of-band pushes (timers/watchers) remain a documented extension point for `nexus`.

## Dispatcher fix (general, not SSE-specific)

The core design — a read handler arming *write* interest on its own fd mid-dispatch — exposed a latent bug in `ipc/SelectorPSL.watch()`: it snapshotted the fd's event mask *before* dispatch and wrote the stale value back afterward, wiping interest a handler added during dispatch. The flush handler never fired and the connection went silent. `watch()` now recomputes the mask from the live table after dispatch and tolerates an fd closed mid-dispatch. All `pyre.pkg/ipc` tests still pass.

## Notes

- No `SocketTCP` change: the inherited `socket.send` already is the partial non-blocking send; the streaming path just sets the channel non-blocking.
- Verified end to end against a live server (preamble delivery, per-mutation frames, multi-client broadcast, clean disconnect). The consumer is the qed `sse` branch (separate PR), which builds on this.
