### PR TITLE
pyre.http: split Response.code into HTTP status and shell exitCode

### DIFF
--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -164,7 +164,7 @@ jobs:
           echo " -- switching to the pyre home directory"
           cd pyre
           echo " -- building pyre"
-          ${mm}
+          ${mm} --jobs=2
         env:
           mm: python3 ${{github.workspace}}/mm/mm --config=.github/matrix/mm.pfg
           target: ${{matrix.target}}

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -177,7 +177,7 @@ jobs:
           echo " -- switching to the pyre home directory"
           cd pyre
           echo " -- testing pyre"
-          ${mm} tests
+          ${mm} --jobs=2 tests
         env:
           mm: python3 ${{github.workspace}}/mm/mm --config=.github/matrix/mm.pfg
           target: ${{matrix.target}}

--- a/packages/pyre/http/Response.py
+++ b/packages/pyre/http/Response.py
@@ -9,6 +9,7 @@ import time  # to generate timestamps
 
 # my superclass
 from ..nexus.exceptions import NexusError
+
 # the case insensitive header mapping
 from .Headers import Headers
 
@@ -27,17 +28,28 @@ class Response(NexusError):
     # the work...
 
     # public data
-    code = None  # a numeric code indicating the type of HTTP response
-    status = ""  # a very short description of the type of HTTP response
-    server = None  # the server that accepted the client request
-    headers = None  # meta data about the response
-    encoding = "utf-8"  # the default encoding for the response payload
-    version = (1, 1)  # the HTTP version spoken here
+    # a numeric code indicating the type of HTTP response
+    code = None
+    # a very short description of the type of HTTP response
+    status = ""
+    # the server that accepted the client request
+    server = None
+    # meta data about the response
+    headers = None
+    # the default encoding for the response payload
+    encoding = "utf-8"
+    # the HTTP version spoken here
+    version = (1, 1)
 
-    alive = True  # keep the connection alive after serving this response
-    abort = False  # terminate the process after serving this response
-    streaming = False  # route me down the server's streaming path instead of render-once
-    code = 0  # the exit code to pass to the shell upon exiting
+    # keep the connection alive after serving this response
+    alive = True
+    # route me down the server's streaming path instead of render-once
+    streaming = False
+
+    # terminate the process after serving this response
+    abort = False
+    # the code to pass to the shell upon exiting
+    exitCode = 0
 
     # meta-methods
     def __init__(self, server, version=version, encoding=encoding, **kwds):

--- a/packages/pyre/http/Server.py
+++ b/packages/pyre/http/Server.py
@@ -238,7 +238,7 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
         # if the application wants to terminate
         if response.abort:
             # do it
-            raise SystemExit(response.code)
+            raise SystemExit(response.exitCode)
 
         # otherwise, let the response document decide whether we should keep the channel alive
         return response.alive

--- a/packages/pyre/http/documents.py
+++ b/packages/pyre/http/documents.py
@@ -67,11 +67,11 @@ class Exit(OK):
     abort = True
 
     # metamethods
-    def __init__(self, code=OK.code, **kwds):
+    def __init__(self, exitCode=0, **kwds):
         # chain up
         super().__init__(**kwds)
         # set my exit code
-        self.code = code
+        self.exitCode = exitCode
         # all done
         return
 

--- a/tests/pyre.pkg/http/abort_derives_from_exit.py
+++ b/tests/pyre.pkg/http/abort_derives_from_exit.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify the design invariant that holds {exitCode} together: every document in {pyre.http.documents}
+that aborts the process derives from {Exit}, so the abort flag and its exit code come from one place
+"""
+
+# the document types
+from pyre.http import documents
+
+
+def test():
+    # the single carrier of the abort behavior
+    exit = documents.Exit
+
+    # go through every name the documents module exposes
+    for entity in vars(documents).values():
+        # skip anything that is not a class
+        if not isinstance(entity, type):
+            # move on
+            continue
+        # skip names imported from elsewhere; only audit classes declared in this module
+        if entity.__module__ != documents.__name__:
+            # move on
+            continue
+        # a document that aborts the process must derive from {Exit}, or it sidesteps the one place
+        # that carries an {exitCode}
+        if getattr(entity, "abort", False):
+            # enforce the invariant
+            assert issubclass(entity, exit)
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/http/exit_code.py
+++ b/tests/pyre.pkg/http/exit_code.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify {code} (the HTTP status) and {exitCode} (the shell exit code) are distinct: {Exit} renders
+a 200 status yet terminates the process with its own {exitCode}, while every other document type
+leaves {exitCode} at the default 0
+"""
+
+# the server that drives the response path
+from pyre.http.Server import Server
+# the document types under test
+from pyre.http import documents
+
+
+# a stand-in client connection that records whatever the server writes
+class Channel:
+    """
+    A write sink that captures the bytes the server sends
+    """
+
+    # meta-methods
+    def __init__(self):
+        # the bytes written so far
+        self.data = b""
+        # all done
+        return
+
+    # accept and record a write
+    def write(self, data):
+        """
+        Record {data} and report all of it as accepted
+        """
+        # capture it
+        self.data += data
+        # and report the whole write went through
+        return len(data)
+
+
+def test():
+    # a server to render and serve the response
+    server = Server(name="exit-code-test")
+
+    # an Exit carrying a non-default shell exit code
+    response = documents.Exit(server=server, exitCode=42)
+    # a channel to capture the rendered preamble
+    channel = Channel()
+    # serving an aborting response renders it and then terminates the process
+    try:
+        # which raises {SystemExit}
+        server.respond(channel=channel, request=None, response=response)
+    # catch it
+    except SystemExit as error:
+        # the shell exit code is the response's {exitCode}, not its HTTP status
+        assert error.code == 42
+    # if it did not raise
+    else:
+        # the abort path is broken
+        assert False
+    # and what reached the client is a well-formed 200 status line: the HTTP {code} is untouched
+    assert channel.data.startswith(b"HTTP/1.1 200 OK\r\n")
+
+    # the exit code defaults to a clean 0 when none is requested
+    assert documents.Exit(server=server).exitCode == 0
+
+    # every other document type leaves {exitCode} at the default 0; only {Exit} overrides it
+    for entity in vars(documents).values():
+        # skip non-classes and names imported from elsewhere
+        if not isinstance(entity, type) or entity.__module__ != documents.__name__:
+            # not one of ours
+            continue
+        # Exit is the one type that carries a custom exit code
+        if entity is documents.Exit:
+            # so it is exempt
+            continue
+        # all the others inherit the default
+        assert entity.exitCode == 0
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file


### PR DESCRIPTION
Closes #178.

## The bug

`pyre.http.Response` declared the class attribute `code` **twice**, and the two declarations meant two unrelated things:

```python
code = None  # a numeric code indicating the type of HTTP response   # HTTP status
...
code = 0     # the exit code to pass to the shell upon exiting        # shell exit code
```

The second declaration silently shadowed the first, so a single attribute was forced to carry two incompatible meanings:

- the **HTTP status code** (200, 404, …) that the renderer writes into the status line (`weaver/HTTP.py`) and the header log reads (`Server.py`), and
- the **shell exit code** that `Server.respond` passes to `raise SystemExit(response.code)` when `response.abort` is set.

`documents.Exit` is the one class that lives in both senses at once — it is an `OK` response (rendered, so its `code` must be `200`) *and* the abort carrier (its `code` is handed to `SystemExit`). Its constructor defaulted the field to the HTTP code (`code=OK.code`, i.e. `200`), so a clean, client-requested shutdown rendered `HTTP/1.1 200 OK` and then ran `SystemExit(200)` — **terminating the server process with shell status 200 instead of 0.** Any supervisor, CI job, or shell inspecting the exit status saw a failure.

## The fix

Split the two concepts into two attributes:

- `Response.code` is now the **HTTP status only** — the duplicate `code = 0` declaration is gone.
- `Response.exitCode = 0` is the **shell exit code**; `Server.respond` raises `SystemExit(response.exitCode)`, and `Exit.__init__(self, exitCode=0, ...)` sets it independently of the HTTP `code`, which `Exit` now inherits as `200` from `OK`.

Net effect: `Exit()` serves a `200` page and exits the process `0`; `Exit(exitCode=N)` exits `N`.

## ⚠️ Breaking change

The `Exit` constructor keyword changed: **`Exit(code=…)` → `Exit(exitCode=…)`**. Every project with a web-based UI on `pyre.http` is exposed — both at runtime (their server currently exits non-zero on a normal shutdown) and at the API level (any `Exit(code=…)` call site must be updated). Downstream projects such as `qed` should audit their shutdown/exit handling when they pick this up.

## Tests (`tests/pyre.pkg/http/`)

- `exit_code.py` — drives the real `Server.respond` abort path with a capturing channel: `Exit(exitCode=42)` renders `HTTP/1.1 200 OK` yet raises `SystemExit(42)`; the default is `0`; and every other document type leaves `exitCode` at `0`.
- `abort_derives_from_exit.py` — enforces the design invariant by sweeping every class declared in `pyre.http.documents`: any class with `abort = True` must derive from `Exit`, so the abort flag and its exit code always come from one place.

Full `pyre.pkg/http` suite passes under `mm`.
