### PR TITLE
pyre.http: fix response crossing on kept-alive connections

### DIFF
--- a/packages/pyre/http/Server.py
+++ b/packages/pyre/http/Server.py
@@ -126,13 +126,14 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
             # stop listening
             return False
 
-        # well, there is data to process; if we have a pending request
-        try:
-            # get it
-            request = self.requests[channel]
-        # otherwise
-        except KeyError:
-            # make a new one
+        # well, there is data to process; pick up any request parked from an earlier read on this
+        # channel, unparking it as we take it. this {pop} is also the fix for response-crossing on a
+        # kept-alive connection: a completed request is never left behind for the NEXT request to
+        # inherit -- it is re-parked below, in the {if not complete} branch, only while still partial
+        request = self.requests.pop(channel, None)
+        # if nothing was parked for this channel
+        if request is None:
+            # this is a brand new request, so make one
             request = self.request()
 
         # attempt to


### PR DESCRIPTION
## Summary

This change corrects a defect in the HTTP server's handling of persistent ("keep-alive")
connections. Under HTTP/1.1 a single connection carries a sequence of requests. The server keeps a
table of partially received requests, keyed by the connection, but it removed an entry from that
table only when the connection closed, never when a request finished normally. As a result, the next
request on a reused connection could inherit the previous, already-completed request and receive its
response a second time. The fix removes a request from the table at the moment it is retrieved, and
stores it again only for as long as it remains incomplete.

## Symptom

The problem was first observed in the qed client running under Safari. Image tiles in the viewport
intermittently failed to load and were shown as broken images. Examination of the responses showed
that a tile request had received, with a 200 status, the JSON body of an earlier GraphQL version
query rather than the bitmap it expected. Safari could not decode the JSON as an image and therefore
displayed the broken-image placeholder. The failure was intermittent, and once a connection had
entered this state, every subsequent request on it received the same incorrect response; in the
application this appeared as the page failing to render at all after the first failure.

The same behavior reproduced under Playwright's WebKit engine, which shares Safari's connection-reuse
behavior. It did not appear under any of the Chromium-based browsers.

## Root cause

When a request arrives across more than one network read, `Server.process` stores the partially
assembled request in `self.requests`, keyed by the connection, so that assembly can resume when more
data arrive. When assembly completes, the server fulfills the request and writes the response, but it
does not remove the completed request from the table. The only removal occurs in the branch that
handles a closed connection.

On a persistent connection, the following request retrieves that same table entry. `Request.extractPayload`
begins with a guard that returns immediately when the stored request is already complete, so the new
bytes are not parsed as a fresh request. The server then fulfills the stored, completed request a
second time and writes its response in answer to the new request. The triggering condition is
therefore a request that spans at least two network reads followed by another request on the same
connection. Because the division of a request across reads depends on packet boundaries, the failure
is intermittent.

This code was introduced in January 2015 (commit `d931302cb`), when the server lived in
`pyre.nexus.http`. The completion path has removed the table entry only on connection close, and at no
other time, ever since.

## Why the defect appears now

The defect requires connection reuse, and connection reuse is governed by the announced protocol
version. Under HTTP/1.0 a client opens a new connection for each request and closes it once the
response arrives, so no request ever follows another on the same connection and the stale entry is
never consulted. Under HTTP/1.1 connections are persistent by default and are reused.

The server's announced version has changed several times:

- It was introduced as 1.0 in February 2015 (commit `2f001756a`).
- It was raised to 1.1 on 23 April 2022 (commit `8805af545`) and returned to 1.0 the following day
  (commit `ec14716cc`). The commit that reverted it records that exchanges with Safari became
  unstable when the server claimed to speak 1.1. The underlying defect was not identified at the
  time; the symptom was avoided by lowering the announced version.
- It was raised to 1.1 again on 9 June 2026 (commit `19ba4fa91`), because the server-sent-events work
  requires persistent connections for its event stream.

The 2026 protocol change re-enabled connection reuse and, with it, the dormant 2015 defect. As in
2022, Safari was the client that exposed it, because it reuses pooled connections more readily than
the Chromium-based browsers.

It should be stated plainly that the server-sent-events feature did not introduce this defect and
does not contain it. That feature is implicated only because it required HTTP/1.1. This was confirmed
in two ways: disabling the client's event-stream subscription entirely, so that no event stream is
ever opened, did not remove the failure; and the server-sent-events commit does not modify the
request-handling code in question.

## The fix

`Server.process` now retrieves a pending request with `self.requests.pop(channel, None)` and creates a
new request when none is stored. The entry is removed at the moment it is taken, and it is stored
again only in the branch that handles an incomplete request. A completed request is therefore never
left in the table for a later request to inherit.

The earlier retrieval read the table with a `try`/`except` around a dictionary lookup. Because most
requests arrive in a single read and so have no stored entry, that lookup raised and caught a
`KeyError` on the common path of every request. Retrieving with `pop` and a default removes that
exception from the hot path as well.

## Verification

The failure was reproduced with Safari and, for automation, with Playwright's WebKit engine. A
script drives the server and records, for each tile in the viewport, whether the response was the
expected bitmap or some other payload. Against the unfixed server, runs intermittently showed tiles
answered with the version query's JSON body; the first such failure typically occurred within the
first few page loads, after which every subsequent request on the affected connection received the
same incorrect response and the page no longer rendered at all.

Against a server built from this branch, the same script ran thirty consecutive page loads without a
single failure. Every viewport tile loaded, no response was answered with anything other than its
bitmap, and no connection entered the persistent-failure state. The Chromium-based browsers, which
reuse connections less aggressively, did not reproduce the failure either before or after the
change.

In both the reproduction and the verification the client's event-stream subscription was disabled,
so that no event stream was opened at any point. The observations therefore bear only on the
server's handling of ordinary requests on a persistent connection, and the correction is independent
of the server-sent-events feature.
