### PR TITLE
ci: build GNU make 4.4.1 from source before running mm

### DIFF
--- a/.github/workflows/mm.yaml
+++ b/.github/workflows/mm.yaml
@@ -61,6 +61,25 @@ jobs:
           echo " -- install our dependencies"
           sudo apt install -y make openssh-server libgsl-dev libopenmpi-dev libhdf5-dev
 
+      - name: GNU make 4.4.1
+        run: |
+          echo " -- the runner ships an older make"
+          make --version
+          echo " -- mm requires GNU make >= 4.4 for the {.WAIT} primitive"
+          echo " -- fetching the GNU make 4.4.1 sources"
+          curl -LO https://ftp.gnu.org/gnu/make/make-4.4.1.tar.gz
+          echo " -- unpacking"
+          tar xzf make-4.4.1.tar.gz
+          echo " -- building and installing into /usr/local"
+          cd make-4.4.1
+          ./configure --prefix=/usr/local
+          make -j2
+          sudo make install
+          echo " -- refreshing the shell command hash"
+          hash -r
+          echo " -- the make now on PATH"
+          make --version
+
       - name: python ${{matrix.python}} setup
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pr-mm.yaml
+++ b/.github/workflows/pr-mm.yaml
@@ -45,6 +45,25 @@ jobs:
           echo " -- install our dependencies"
           sudo apt install -y make openssh-server libgsl-dev libopenmpi-dev libhdf5-dev
 
+      - name: GNU make 4.4.1
+        run: |
+          echo " -- the runner ships an older make"
+          make --version
+          echo " -- mm requires GNU make >= 4.4 for the {.WAIT} primitive"
+          echo " -- fetching the GNU make 4.4.1 sources"
+          curl -LO https://ftp.gnu.org/gnu/make/make-4.4.1.tar.gz
+          echo " -- unpacking"
+          tar xzf make-4.4.1.tar.gz
+          echo " -- building and installing into /usr/local"
+          cd make-4.4.1
+          ./configure --prefix=/usr/local
+          make -j2
+          sudo make install
+          echo " -- refreshing the shell command hash"
+          hash -r
+          echo " -- the make now on PATH"
+          make --version
+
       - name: python ${{matrix.python}} setup
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

The GitHub-hosted Ubuntu runners ship a GNU make older than 4.4, which lacks the `.WAIT` primitive that `mm` depends on. This caused our CI builds to fail.

This PR adds a step to both CI workflows that builds and installs GNU make 4.4.1 from source into `/usr/local` before the `mm` build runs:

- `.github/workflows/mm.yaml` — the push workflow
- `.github/workflows/pr-mm.yaml` — the pull-request workflow

The new step:
1. Reports the runner's bundled make version
2. Fetches the GNU make 4.4.1 source tarball from ftp.gnu.org
3. Configures, builds (`-j2`), and installs into `/usr/local`
4. Refreshes the shell command hash and reports the make now on `PATH`

## Why

`mm` requires GNU make >= 4.4 for the `.WAIT` primitive. The runner-provided make is too old, so it must be replaced before any `mm` invocation.

## Verification

CI on this PR exercises the new step directly — a green `pr-mm` run confirms the build picks up make 4.4.1 and proceeds.