### PR TITLE
ci: conda-forge build/test workflow

### DIFF
--- a/.github/matrix/conda.yml
+++ b/.github/matrix/conda.yml
@@ -1,0 +1,24 @@
+# -*- yaml -*-
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# the conda-forge environment with the pyre build dependencies; the per-matrix
+# toolchain (gcc/clang) and the optional cuda toolkit are layered on top of this
+# base by the workflow, so they are deliberately absent here
+name: pyre
+channels:
+  - conda-forge
+dependencies:
+  # the build driver: conda-forge ships GNU make >= 4.4, which mm needs for {.WAIT}
+  - make
+  # the interpreter and its build-time helpers
+  - python
+  - numpy
+  - pybind11
+  - pyyaml
+  # the native external packages
+  - gsl
+  - hdf5
+  - openmpi
+#
+# end of file

--- a/.github/matrix/conda.yml
+++ b/.github/matrix/conda.yml
@@ -6,8 +6,12 @@
 # toolchain (gcc/clang) and the optional cuda toolkit are layered on top of this
 # base by the workflow, so they are deliberately absent here
 name: pyre
+
+# stick to conda-forge only
 channels:
   - conda-forge
+
+# packages
 dependencies:
   # the build driver: conda-forge ships GNU make >= 4.4, which mm needs for {.WAIT}
   - make
@@ -20,5 +24,5 @@ dependencies:
   - gsl
   - hdf5
   - openmpi
-#
+
 # end of file

--- a/.github/matrix/conda.yml
+++ b/.github/matrix/conda.yml
@@ -17,6 +17,9 @@ dependencies:
   - make
   # the interpreter and its build-time helpers
   - python
+  # pin the standard ABI; left to itself the solver prefers the free-threaded {cp314t} build,
+  # whose headers live in {include/python3.14t} rather than {include/python3.14}
+  - python-gil
   - numpy
   - pybind11
   - pyyaml

--- a/.github/matrix/conda.yml
+++ b/.github/matrix/conda.yml
@@ -31,6 +31,10 @@ dependencies:
   # the native external packages
   - gsl
   - hdf5
-  - openmpi
+  # openmpi is withheld: {pyre.platforms} has no conda package manager, so {pyre.externals}
+  # cannot register the conda-provided openmpi and the {mpi} test suites fail at runtime. its
+  # absence gates the whole {pyre-mpi} project out of the build; restore it once the packager
+  # lands. nothing else in this environment wants it -- hdf5 resolves to its {nompi} variant
+  # - openmpi
 
 # end of file

--- a/.github/matrix/conda.yml
+++ b/.github/matrix/conda.yml
@@ -5,7 +5,12 @@
 # the conda-forge environment with the pyre build dependencies; the per-matrix
 # toolchain (gcc/clang) and the optional cuda toolkit are layered on top of this
 # base by the workflow, so they are deliberately absent here
-name: pyre
+
+# the environment name must not collide with the name of any project in {.mm}: {mm} seeds its
+# configuration search with {$(user.environment).mm}, and the project config directory is on
+# make's include path, so an environment named {pyre} makes the engine read {.mm/pyre.mm} as a
+# user config file, long before {extern.available} exists
+name: conda-pr
 
 # stick to conda-forge only
 channels:

--- a/.github/matrix/mm-conda.yaml
+++ b/.github/matrix/mm-conda.yaml
@@ -1,0 +1,26 @@
+# -*- yaml -*-
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# configuration for the {mm} build of pyre against a conda-forge toolchain
+mm:
+    # targets
+    target: "{pyre.environ.target},shared"
+
+    # compilers
+    compilers: "{pyre.environ.suite}, python/python3"
+
+    # intermediate build products
+    bldroot: /home/runner/work/build
+
+    # the location of the adhoc configuration files
+    runcfg: .github/matrix
+
+    # the name of the make utility; conda-forge make satisfies the >= 4.4 requirement
+    make: make
+
+# the final products go straight into the active conda environment via {--mode=conda},
+# so {prefix} is deliberately left unset here
+
+# end of file

--- a/.github/matrix/mm-conda.yaml
+++ b/.github/matrix/mm-conda.yaml
@@ -2,25 +2,19 @@
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved
 
-
 # configuration for the {mm} build of pyre against a conda-forge toolchain
 mm:
-    # targets
-    target: "{pyre.environ.target},shared"
-
-    # compilers
-    compilers: "{pyre.environ.suite}, python/python3"
-
+    # use conda for package dependencies
+    pkgdb: conda
+    # build straight in to the conda environment
+    mode: conda
     # intermediate build products
     bldroot: /home/runner/work/build
-
-    # the location of the adhoc configuration files
-    runcfg: .github/matrix
-
+    # targets
+    target: "{pyre.environ.target},shared"
+    # compilers
+    compilers: "{pyre.environ.suite}, python/python3"
     # the name of the make utility; conda-forge make satisfies the >= 4.4 requirement
     make: make
-
-# the final products go straight into the active conda environment via {--mode=conda},
-# so {prefix} is deliberately left unset here
 
 # end of file

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -1,0 +1,133 @@
+# -*- yaml -*-
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+name: conda
+# invoke
+on:
+  # once a week: this workflow guards against drift in {conda-forge}, which moves without any
+  # commit to {pyre}, so a merge is the wrong thing to key on; mondays at 07:00 UTC
+  schedule:
+    - cron: "0 7 * * 1"
+  # and manually
+  workflow_dispatch:
+jobs:
+  # build and test the tip of the default branch against a conda-forge toolchain
+  build:
+    name: >-
+      ${{matrix.target}}
+      ${{matrix.compiler}}
+      on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    # a login shell so the micromamba environment is active in every step
+    defaults:
+      run:
+        shell: bash -el {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        # the point is to catch a moving toolchain, not to re-test every build variant, so the
+        # scheduled run carries {opt} only; {pr-conda} covers {debug}
+        target: [opt]
+        compiler: [gcc, clang]
+        # the conda-forge toolchain packages for each compiler
+        include:
+          - compiler: gcc
+            suite: gcc
+            toolchain: gcc gxx
+            cc: gcc
+            cxx: g++
+          - compiler: clang
+            suite: clang
+            toolchain: clang clangxx
+            cc: clang
+            cxx: clang++
+
+    env:
+      # mm discovers its settings from the {mm.yaml} we install into ~/.pyre below
+      mm: python3 ${{github.workspace}}/mm/mm
+      target: ${{matrix.target}}
+      suite: ${{matrix.suite}}
+
+    steps:
+      - name: checkout pyre
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: pyre
+
+      - name: clone mm
+        run: |
+          echo " -- cloning mm"
+          git clone https://github.com/aivazis/mm
+
+      - name: conda-forge environment
+        uses: mamba-org/setup-micromamba@v3
+        with:
+          micromamba-version: latest
+          environment-file: pyre/.github/matrix/conda.yml
+          # conda-forge only, with strict priority so nothing leaks in from defaults
+          condarc: |
+            channels:
+              - conda-forge
+            channel_priority: strict
+          # layer the per-matrix toolchain onto the base env
+          create-args: >-
+            ${{matrix.toolchain}}
+
+      - name: versions
+        run: |
+          echo " -- conda prefix"
+          echo "${CONDA_PREFIX}"
+          echo " -- make"
+          make --version
+          echo " -- C compiler"
+          ${{matrix.cc}} --version
+          echo " -- C++ compiler"
+          ${{matrix.cxx}} --version
+          echo " -- python"
+          python --version
+
+      - name: configure mm
+        run: |
+          echo " -- creating the mm configuration directory"
+          mkdir -p ~/.pyre
+          echo " -- installing the mm configuration as ~/.pyre/mm.yaml so mm auto-discovers it"
+          cp pyre/.github/matrix/mm-conda.yaml ~/.pyre/mm.yaml
+
+      - name: package database
+        run: |
+          echo " -- switching to the pyre source directory"
+          cd pyre
+          echo " -- discovering the conda packages"
+          ${mm} --setup
+          echo " -- where the build products will be deposited"
+          ${mm} builder.info
+          echo " -- the resulting package database"
+          ${mm} extern.db.info
+          echo " -- the externals, as the make engine reads them back"
+          ${mm} extern.info
+          # and each external that {pyre} actually builds against; a package that is not available
+          # is never loaded, so its {info} target does not exist and asking for it is a hard error
+          echo " -- the individual packages"
+          ${mm} extern.python.info
+          ${mm} extern.pybind11.info
+          ${mm} extern.gsl.info
+          ${mm} extern.hdf5.info
+
+      - name: build pyre
+        run: |
+          echo " -- switching to the pyre source directory"
+          cd pyre
+          echo " -- building pyre into the conda prefix"
+          ${mm} --jobs=2
+
+      - name: test pyre
+        run: |
+          echo " -- switching to the pyre source directory"
+          cd pyre
+          echo " -- testing pyre"
+          ${mm} --jobs=2 tests
+#
+# end of file

--- a/.github/workflows/pr-conda.yaml
+++ b/.github/workflows/pr-conda.yaml
@@ -1,0 +1,115 @@
+# -*- yaml -*-
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+name: pr-conda
+on:
+  pull_request:
+jobs:
+  # build and test the ref that launched this action against a conda-forge toolchain
+  build:
+    name: >-
+      ${{matrix.target}}
+      ${{matrix.compiler}}${{matrix.cuda == 'cuda' && '+cuda' || ''}}
+      on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    # a login shell so the micromamba environment is active in every step
+    defaults:
+      run:
+        shell: bash -el {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        target: [debug, opt]
+        compiler: [gcc, clang]
+        cuda: [nocuda, cuda]
+        # the conda-forge toolchain packages for each compiler
+        include:
+          - compiler: gcc
+            suite: gcc
+            toolchain: gcc gxx
+          - compiler: clang
+            suite: clang
+            toolchain: clang clangxx
+
+    env:
+      mm: python3 ${{github.workspace}}/mm/mm --config=.github/matrix/mm-conda.yaml
+      target: ${{matrix.target}}
+      suite: ${{matrix.suite}}
+
+    steps:
+      - name: checkout pyre
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: pyre
+
+      - name: clone mm
+        run: |
+          echo " -- cloning mm"
+          git clone https://github.com/aivazis/mm
+
+      - name: conda-forge environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          micromamba-version: latest
+          environment-file: pyre/.github/matrix/conda.yml
+          # conda-forge only, with strict priority so nothing leaks in from defaults
+          condarc: |
+            channels:
+              - conda-forge
+            channel_priority: strict
+          # layer the per-matrix toolchain and the optional cuda toolkit onto the base env
+          create-args: >-
+            ${{matrix.toolchain}}
+            ${{matrix.cuda == 'cuda' && 'cuda-toolkit' || ''}}
+
+      - name: versions
+        run: |
+          echo " -- conda prefix"
+          echo "${CONDA_PREFIX}"
+          echo " -- make"
+          make --version
+          echo " -- C compiler"
+          ${CC} --version
+          echo " -- C++ compiler"
+          ${CXX} --version
+          echo " -- python"
+          python --version
+          if [ "${{matrix.cuda}}" = "cuda" ]; then
+            echo " -- nvcc"
+            nvcc --version
+          fi
+
+      - name: configure mm
+        run: |
+          echo " -- creating ~/.pyre"
+          mkdir -p ~/.pyre
+          echo " -- copying the mm configuration file"
+          cp pyre/.github/matrix/mm-conda.yaml ~/.pyre/mm.yaml
+
+      - name: package database
+        run: |
+          echo " -- switching to the pyre source directory"
+          cd pyre
+          echo " -- discovering the conda packages"
+          ${mm} --pkgdb=conda --setup
+          echo " -- the resulting package database"
+          ${mm} --pkgdb=conda extern.db.info
+
+      - name: build pyre
+        run: |
+          echo " -- switching to the pyre source directory"
+          cd pyre
+          echo " -- building pyre into the conda prefix"
+          ${mm} --pkgdb=conda --mode=conda --jobs=2
+
+      - name: test pyre
+        run: |
+          echo " -- switching to the pyre source directory"
+          cd pyre
+          echo " -- testing pyre"
+          ${mm} --pkgdb=conda --mode=conda --jobs=2 tests
+#
+# end of file

--- a/.github/workflows/pr-conda.yaml
+++ b/.github/workflows/pr-conda.yaml
@@ -29,9 +29,13 @@ jobs:
           - compiler: gcc
             suite: gcc
             toolchain: gcc gxx
+            cc: gcc
+            cxx: g++
           - compiler: clang
             suite: clang
             toolchain: clang clangxx
+            cc: clang
+            cxx: clang++
 
     env:
       mm: python3 ${{github.workspace}}/mm/mm --config=.github/matrix/mm-conda.yaml
@@ -72,9 +76,9 @@ jobs:
           echo " -- make"
           make --version
           echo " -- C compiler"
-          ${CC} --version
+          ${{matrix.cc}} --version
           echo " -- C++ compiler"
-          ${CXX} --version
+          ${{matrix.cxx}} --version
           echo " -- python"
           python --version
           if [ "${{matrix.cuda}}" = "cuda" ]; then

--- a/.github/workflows/pr-conda.yaml
+++ b/.github/workflows/pr-conda.yaml
@@ -3,8 +3,12 @@
 # (c) 1998-2026 all rights reserved
 
 name: pr-conda
+# invoke
 on:
+  # when a commit to a PR is made
   pull_request:
+  # and manually
+  workflow_dispatch:
 jobs:
   # build and test the ref that launched this action against a conda-forge toolchain
   build:
@@ -38,7 +42,8 @@ jobs:
             cxx: clang++
 
     env:
-      mm: python3 ${{github.workspace}}/mm/mm --config=.github/matrix/mm-conda.yaml
+      # mm discovers its settings from the {mm.yaml} we install into ~/.pyre below
+      mm: python3 ${{github.workspace}}/mm/mm
       target: ${{matrix.target}}
       suite: ${{matrix.suite}}
 
@@ -88,9 +93,9 @@ jobs:
 
       - name: configure mm
         run: |
-          echo " -- creating ~/.pyre"
+          echo " -- creating the mm configuration directory"
           mkdir -p ~/.pyre
-          echo " -- copying the mm configuration file"
+          echo " -- installing the mm configuration as ~/.pyre/mm.yaml so mm auto-discovers it"
           cp pyre/.github/matrix/mm-conda.yaml ~/.pyre/mm.yaml
 
       - name: package database
@@ -98,22 +103,22 @@ jobs:
           echo " -- switching to the pyre source directory"
           cd pyre
           echo " -- discovering the conda packages"
-          ${mm} --pkgdb=conda --setup
+          ${mm} --setup
           echo " -- the resulting package database"
-          ${mm} --pkgdb=conda extern.db.info
+          ${mm} extern.db.info
 
       - name: build pyre
         run: |
           echo " -- switching to the pyre source directory"
           cd pyre
           echo " -- building pyre into the conda prefix"
-          ${mm} --pkgdb=conda --mode=conda --jobs=2
+          ${mm} --jobs=2
 
       - name: test pyre
         run: |
           echo " -- switching to the pyre source directory"
           cd pyre
           echo " -- testing pyre"
-          ${mm} --pkgdb=conda --mode=conda --jobs=2 tests
+          ${mm} --jobs=2 tests
 #
 # end of file

--- a/.github/workflows/pr-conda.yaml
+++ b/.github/workflows/pr-conda.yaml
@@ -28,6 +28,11 @@ jobs:
         target: [debug, opt]
         compiler: [gcc, clang]
         cuda: [nocuda, cuda]
+        # cuda rides the gcc legs only; {cuda-nvcc} always hands the {.cu} sources to the conda
+        # {gcc} named by {$CXX}, so a clang+cuda leg would compile the device code identically
+        exclude:
+          - compiler: clang
+            cuda: cuda
         # the conda-forge toolchain packages for each compiler
         include:
           - compiler: gcc
@@ -60,7 +65,7 @@ jobs:
           git clone https://github.com/aivazis/mm
 
       - name: conda-forge environment
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           micromamba-version: latest
           environment-file: pyre/.github/matrix/conda.yml
@@ -69,10 +74,13 @@ jobs:
             channels:
               - conda-forge
             channel_priority: strict
-          # layer the per-matrix toolchain and the optional cuda toolkit onto the base env
+          # layer the per-matrix toolchain and the optional cuda compiler onto the base env; the
+          # full {cuda-toolkit} metapackage would drag in cublas, cufft, cusolver and friends, but
+          # {pyre-cuda} needs only {nvcc}, {cuda_runtime.h} and {libcudart} — exactly what these
+          # two provide, and exactly what {mm} probes for when it configures {extern.cuda}
           create-args: >-
             ${{matrix.toolchain}}
-            ${{matrix.cuda == 'cuda' && 'cuda-toolkit' || ''}}
+            ${{matrix.cuda == 'cuda' && 'cuda-nvcc cuda-cudart-dev' || ''}}
 
       - name: versions
         run: |

--- a/.github/workflows/pr-conda.yaml
+++ b/.github/workflows/pr-conda.yaml
@@ -27,7 +27,8 @@ jobs:
         os: [ubuntu-latest]
         target: [debug, opt]
         compiler: [gcc, clang]
-        cuda: [nocuda, cuda]
+        # temporarily disabled while we shake out the workflow; restore by putting {cuda} back
+        cuda: [nocuda]
         # cuda rides the gcc legs only; {cuda-nvcc} always hands the {.cu} sources to the conda
         # {gcc} named by {$CXX}, so a clang+cuda leg would compile the device code identically
         exclude:

--- a/.github/workflows/pr-conda.yaml
+++ b/.github/workflows/pr-conda.yaml
@@ -112,8 +112,19 @@ jobs:
           cd pyre
           echo " -- discovering the conda packages"
           ${mm} --setup
+          echo " -- where the build products will be deposited"
+          ${mm} builder.info
           echo " -- the resulting package database"
           ${mm} extern.db.info
+          echo " -- the externals, as the make engine reads them back"
+          ${mm} extern.info
+          # and each external that {pyre} actually builds against
+          echo " -- the individual packages"
+          ${mm} extern.python.info
+          ${mm} extern.pybind11.info
+          ${mm} extern.gsl.info
+          ${mm} extern.hdf5.info
+          ${mm} extern.mpi.info
 
       - name: build pyre
         run: |

--- a/.github/workflows/pr-conda.yaml
+++ b/.github/workflows/pr-conda.yaml
@@ -119,13 +119,15 @@ jobs:
           ${mm} extern.db.info
           echo " -- the externals, as the make engine reads them back"
           ${mm} extern.info
-          # and each external that {pyre} actually builds against
+          # and each external that {pyre} actually builds against; a package that is not available
+          # is never loaded, so its {info} target does not exist and asking for it is a hard error
           echo " -- the individual packages"
           ${mm} extern.python.info
           ${mm} extern.pybind11.info
           ${mm} extern.gsl.info
           ${mm} extern.hdf5.info
-          ${mm} extern.mpi.info
+          # restore alongside {openmpi} in {conda.yml}
+          # ${mm} extern.mpi.info
 
       - name: build pyre
         run: |

--- a/.mm/pyre-cuda.mm
+++ b/.mm/pyre-cuda.mm
@@ -17,8 +17,18 @@ pyre-cuda.packages := pyre-cuda.pkg
 pyre-cuda.libraries := pyre-cuda.lib
 # the mandatory extensions
 pyre-cuda.extensions := pyre-cuda.ext
-# and test suites
+
+# building {pyre-cuda} needs only the cuda toolkit, but running its tests needs an actual
+# device to execute on; gate the test suites on the presence of a cuda runtime, not on the
+# build-time availability of the package; probe the driver with {nvidia-smi} — the canonical
+# check, since the {/dev/nvidia*} nodes can be absent on a capable host until the driver
+# initializes them — but let the user override
+pyre-cuda.cuda.runtime ?= ${if ${shell command -v nvidia-smi > /dev/null 2>&1 && nvidia-smi -L 2>/dev/null | grep -m1 '^GPU'},cuda,}
+ifeq ($(pyre-cuda.cuda.runtime), cuda)
 pyre-cuda.tests := pyre-cuda.pkg.tests pyre-cuda.lib.tests
+else
+pyre-cuda.tests :=
+endif
 
 
 # the package
@@ -54,8 +64,10 @@ pyre-cuda.ext.lib.prerequisites += journal.lib pyre.lib
 cuda.libraries += cudart
 
 
-# get the testsuites
+# get the testsuites, when a cuda runtime gated them in
+ifeq ($(pyre-cuda.cuda.runtime), cuda)
 include $(pyre-cuda.tests)
+endif
 
 
 endif

--- a/.mm/pyre-gsl.pkg.tests
+++ b/.mm/pyre-gsl.pkg.tests
@@ -19,8 +19,11 @@ ifeq ($(pyre-gsl.mpi.available), mpi)
 
 # set up a macro for the hostfile
 pyre-gsl.pkg.mpi.hostfile := --hostfile localhost
+# see the note in {pyre-mpi.lib.tests}: turn {openmpi} binding off so it will place more ranks
+# than the host has cores
+pyre-gsl.pkg.mpi.binding = ${if ${findstring openmpi,$(mpi.flavor)},--bind-to none,}
 # assemble the haness
-pyre-gsl.pkg.mpi.harness = $(mpi.executive) $(pyre-gsl.pkg.mpi.hostfile)
+pyre-gsl.pkg.mpi.harness = $(mpi.executive) $(pyre-gsl.pkg.mpi.binding) $(pyre-gsl.pkg.mpi.hostfile)
 
 # run the following tests both in serial and in parallel
 # matrix bcast

--- a/.mm/pyre-gsl.pkg.tests
+++ b/.mm/pyre-gsl.pkg.tests
@@ -20,32 +20,32 @@ ifeq ($(pyre-gsl.mpi.available), mpi)
 # set up a macro for the hostfile
 pyre-gsl.pkg.mpi.hostfile := --hostfile localhost
 # assemble the haness
-pyre-gsl.pkg.mpi.harness := $(mpi.executive) $(pyre-gsl.pkg.mpi.hostfile)
+pyre-gsl.pkg.mpi.harness = $(mpi.executive) $(pyre-gsl.pkg.mpi.hostfile)
 
 # run the following tests both in serial and in parallel
 # matrix bcast
 tests.gsl.pkg.matrix_bcast.cases := matrix_bcast.serial matrix_bcast.parallel
-matrix_bcast.parallel.harness := $(pyre-gsl.pkg.mpi.harness) -np 8
+matrix_bcast.parallel.harness = $(pyre-gsl.pkg.mpi.harness) -np 8
 
 # matrix collect
 tests.gsl.pkg.matrix_collect.cases := matrix_collect.serial matrix_collect.parallel
-matrix_collect.parallel.harness := $(pyre-gsl.pkg.mpi.harness) -np 8
+matrix_collect.parallel.harness = $(pyre-gsl.pkg.mpi.harness) -np 8
 
 # matrix partition
 tests.gsl.pkg.matrix_partition.cases := matrix_partition.serial matrix_partition.parallel
-matrix_partition.parallel.harness := $(pyre-gsl.pkg.mpi.harness) -np 8
+matrix_partition.parallel.harness = $(pyre-gsl.pkg.mpi.harness) -np 8
 
 # vector bcast
 tests.gsl.pkg.vector_bcast.cases := vector_bcast.serial vector_bcast.parallel
-vector_bcast.parallel.harness := $(pyre-gsl.pkg.mpi.harness) -np 8
+vector_bcast.parallel.harness = $(pyre-gsl.pkg.mpi.harness) -np 8
 
 # vector collect
 tests.gsl.pkg.vector_collect.cases := vector_collect.serial vector_collect.parallel
-vector_collect.parallel.harness := $(pyre-gsl.pkg.mpi.harness) -np 8
+vector_collect.parallel.harness = $(pyre-gsl.pkg.mpi.harness) -np 8
 
 # vector partition
 tests.gsl.pkg.vector_partition.cases := vector_partition.serial vector_partition.parallel
-vector_partition.parallel.harness := $(pyre-gsl.pkg.mpi.harness) -np 8
+vector_partition.parallel.harness = $(pyre-gsl.pkg.mpi.harness) -np 8
 
 #if not
 else

--- a/.mm/pyre-mpi.lib.tests
+++ b/.mm/pyre-mpi.lib.tests
@@ -15,16 +15,16 @@ pyre-mpi.lib.tests.c++.defines += $(pyre.lib.c++.defines)
 # set up a macro for the hostfile
 pyre-mpi.lib.hostfile := --hostfile localhost
 # assemble the haness
-pyre-mpi.lib.harness := $(mpi.executive) $(pyre-mpi.lib.hostfile)
+pyre-mpi.lib.harness = $(mpi.executive) $(pyre-mpi.lib.hostfile)
 
 # these tests need harnesses
-tests.mpi.lib.sanity.harness := $(pyre-mpi.lib.harness) -np 4
-tests.mpi.lib.world.harness := $(pyre-mpi.lib.harness) -np 4
-tests.mpi.lib.group.harness := $(pyre-mpi.lib.harness) -np 4
-tests.mpi.lib.group-include.harness := $(pyre-mpi.lib.harness) -np 7
-tests.mpi.lib.group-exclude.harness := $(pyre-mpi.lib.harness) -np 7
-tests.mpi.lib.group-setops.harness := $(pyre-mpi.lib.harness) -np 7
-tests.mpi.lib.communicator.harness := $(pyre-mpi.lib.harness) -np 8
+tests.mpi.lib.sanity.harness = $(pyre-mpi.lib.harness) -np 4
+tests.mpi.lib.world.harness = $(pyre-mpi.lib.harness) -np 4
+tests.mpi.lib.group.harness = $(pyre-mpi.lib.harness) -np 4
+tests.mpi.lib.group-include.harness = $(pyre-mpi.lib.harness) -np 7
+tests.mpi.lib.group-exclude.harness = $(pyre-mpi.lib.harness) -np 7
+tests.mpi.lib.group-setops.harness = $(pyre-mpi.lib.harness) -np 7
+tests.mpi.lib.communicator.harness = $(pyre-mpi.lib.harness) -np 8
 
 # on some machines, running multiple mpi tests at the same time causes trouble
 # serialize the test suite

--- a/.mm/pyre-mpi.lib.tests
+++ b/.mm/pyre-mpi.lib.tests
@@ -14,8 +14,13 @@ pyre-mpi.lib.tests.c++.defines += $(pyre.lib.c++.defines)
 
 # set up a macro for the hostfile
 pyre-mpi.lib.hostfile := --hostfile localhost
+# these suites ask for more ranks than a CI runner has cores; the hostfile grants the slots, but
+# {openmpi} still refuses to bind that many processes. the {overload-allowed} spelling it
+# recommends is rejected outright by builds without cpu binding support, e.g. on macos, so switch
+# binding off instead; no other flavor understands this option, so they get nothing
+pyre-mpi.lib.binding = ${if ${findstring openmpi,$(mpi.flavor)},--bind-to none,}
 # assemble the haness
-pyre-mpi.lib.harness = $(mpi.executive) $(pyre-mpi.lib.hostfile)
+pyre-mpi.lib.harness = $(mpi.executive) $(pyre-mpi.lib.binding) $(pyre-mpi.lib.hostfile)
 
 # these tests need harnesses
 tests.mpi.lib.sanity.harness = $(pyre-mpi.lib.harness) -np 4

--- a/.mm/pyre-mpi.pkg.tests
+++ b/.mm/pyre-mpi.pkg.tests
@@ -16,7 +16,7 @@ pyre-mpi.pkg.tests.drivers.exclude := ip.py
 # set up a macro for the hostfile
 pyre-mpi.pkg.hostfile := --hostfile localhost
 # assemble the haness
-pyre-mpi.pkg.harness := $(mpi.executive) $(pyre-mpi.pkg.hostfile)
+pyre-mpi.pkg.harness = $(mpi.executive) $(pyre-mpi.pkg.hostfile)
 
 
 # on some machines, running multiple mpi tests at the same time causes trouble
@@ -41,7 +41,7 @@ tests.mpi.pkg.extension.cases := \
     tests.pyre-mpi.pkg.extension.serial tests.pyre-mpi.pkg.extension.parallel
 # {serial} runs as is
 # {parallel} has a harness
-tests.pyre-mpi.pkg.extension.parallel.harness := $(pyre-mpi.pkg.harness) -np 8
+tests.pyre-mpi.pkg.extension.parallel.harness = $(pyre-mpi.pkg.harness) -np 8
 
 
 # {world} has cases
@@ -49,24 +49,24 @@ tests.mpi.pkg.world.cases := \
     tests.pyre-mpi.pkg.world.serial tests.pyre-mpi.pkg.world.parallel
 # {serial} runs as is
 # {parallel} has a harness
-tests.pyre-mpi.pkg.world.parallel.harness := $(pyre-mpi.pkg.harness) -np 8
+tests.pyre-mpi.pkg.world.parallel.harness = $(pyre-mpi.pkg.harness) -np 8
 
 
 # groups
-tests.pyre-mpi.pkg.group.harness := $(pyre-mpi.pkg.harness) -np 8
-tests.pyre-mpi.pkg.group_include.harness := $(pyre-mpi.pkg.harness) -np 7
-tests.pyre-mpi.pkg.group_exclude.harness := $(pyre-mpi.pkg.harness) -np 7
-tests.pyre-mpi.pkg.group_setops.harness := $(pyre-mpi.pkg.harness) -np 7
-tests.pyre-mpi.pkg.restric.harness := $(pyre-mpi.pkg.harness) -np 7
+tests.pyre-mpi.pkg.group.harness = $(pyre-mpi.pkg.harness) -np 8
+tests.pyre-mpi.pkg.group_include.harness = $(pyre-mpi.pkg.harness) -np 7
+tests.pyre-mpi.pkg.group_exclude.harness = $(pyre-mpi.pkg.harness) -np 7
+tests.pyre-mpi.pkg.group_setops.harness = $(pyre-mpi.pkg.harness) -np 7
+tests.pyre-mpi.pkg.restric.harness = $(pyre-mpi.pkg.harness) -np 7
 
 
 # communications
-tests.pyre-mpi.pkg.bcast.harness := $(pyre-mpi.pkg.harness) -np 8
-tests.pyre-mpi.pkg.sum.harness := $(pyre-mpi.pkg.harness) -np 8
-tests.pyre-mpi.pkg.product.harness := $(pyre-mpi.pkg.harness) -np 8
-tests.pyre-mpi.pkg.max.harness := $(pyre-mpi.pkg.harness) -np 8
-tests.pyre-mpi.pkg.min.harness := $(pyre-mpi.pkg.harness) -np 8
-tests.pyre-mpi.pkg.port.harness := $(pyre-mpi.pkg.harness) -np 7
+tests.pyre-mpi.pkg.bcast.harness = $(pyre-mpi.pkg.harness) -np 8
+tests.pyre-mpi.pkg.sum.harness = $(pyre-mpi.pkg.harness) -np 8
+tests.pyre-mpi.pkg.product.harness = $(pyre-mpi.pkg.harness) -np 8
+tests.pyre-mpi.pkg.max.harness = $(pyre-mpi.pkg.harness) -np 8
+tests.pyre-mpi.pkg.min.harness = $(pyre-mpi.pkg.harness) -np 8
+tests.pyre-mpi.pkg.port.harness = $(pyre-mpi.pkg.harness) -np 7
 
 
 # end of file

--- a/.mm/pyre-mpi.pkg.tests
+++ b/.mm/pyre-mpi.pkg.tests
@@ -15,8 +15,11 @@ pyre-mpi.pkg.tests.drivers.exclude := ip.py
 
 # set up a macro for the hostfile
 pyre-mpi.pkg.hostfile := --hostfile localhost
+# see the note in {pyre-mpi.lib.tests}: turn {openmpi} binding off so it will place more ranks
+# than the host has cores
+pyre-mpi.pkg.binding = ${if ${findstring openmpi,$(mpi.flavor)},--bind-to none,}
 # assemble the haness
-pyre-mpi.pkg.harness = $(mpi.executive) $(pyre-mpi.pkg.hostfile)
+pyre-mpi.pkg.harness = $(mpi.executive) $(pyre-mpi.pkg.binding) $(pyre-mpi.pkg.hostfile)
 
 
 # on some machines, running multiple mpi tests at the same time causes trouble

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![conda version](https://img.shields.io/conda/vn/conda-forge/pyre)](https://github.com/conda-forge/pyre-feedstock)
 [![mm](https://github.com/pyre/pyre/actions/workflows/mm.yaml/badge.svg)](https://github.com/pyre/pyre/actions/workflows/mm.yaml)
 [![cmake](https://github.com/pyre/pyre/actions/workflows/cmake.yaml/badge.svg)](https://github.com/pyre/pyre/actions/workflows/cmake.yaml)
+[![conda](https://github.com/pyre/pyre/actions/workflows/conda.yaml/badge.svg)](https://github.com/pyre/pyre/actions/workflows/conda.yaml)
 [![pypi source](https://github.com/pyre/pyre/actions/workflows/pypi-source.yaml/badge.svg)](https://github.com/pyre/pyre/actions/workflows/pypi-source.yaml)
 [![wheels](https://github.com/pyre/pyre/actions/workflows/pypi-wheels.yaml/badge.svg)](https://github.com/pyre/pyre/actions/workflows/pypi-wheels.yaml)
 


### PR DESCRIPTION
## Summary

Adds a pull-request workflow (`pr-conda`) that provisions the pyre build dependencies from **conda-forge** via **micromamba** and builds with mm's conda package database, installing straight into the active `CONDA_PREFIX` so the build is immediately importable. This gets us ahead of the upcoming conda-based build requirement.

## What's here

- **`.github/workflows/pr-conda.yaml`** — PR-triggered, conda-forge only (strict priority), login shell so the env is active in every step.
- **`.github/matrix/conda.yml`** — the conda-forge environment: `make` (≥ 4.4 from conda-forge, so no source build needed here), `python`, `numpy`, `pybind11`, `pyyaml`, `gsl`, `hdf5`, `openmpi`. The per-leg toolchain and the optional cuda toolkit are layered on top by the workflow.
- **`.github/matrix/mm-conda.yaml`** — minimal mm config (target/suite/bldroot/make). No package locations and no driver pinning — `--pkgdb=conda` autodiscovers them. `prefix` is left unset; `--mode=conda` installs into `CONDA_PREFIX`.
- **`.mm/pyre-cuda.mm`** — cuda test-gate fix (below).

## Matrix

`(gcc, clang) × (debug, opt) × (nocuda, cuda)` = 8 jobs. The compiler toolchain is installed from conda-forge per leg (`gcc gxx` / `clang clangxx`); the cuda leg adds `cuda-toolkit`. Build/test run `mm --pkgdb=conda --mode=conda`.

## cuda test gate

Building `pyre-cuda` needs only the toolkit, but **running** its tests needs a device. The test suites are now gated on a cuda *runtime* — probed with `nvidia-smi` (overridable via `pyre-cuda.cuda.runtime`) — instead of on build-time package availability. On GPU-less runners the library and extension still build, but the device test suites are skipped.

## Spots to watch on first CI

1. **clang + cuda** — nvcc's host compiler defaults to gcc; this is the cell most likely to need attention (easy to `exclude` if undesired).
2. **`--mode=conda` prefix** — trusted to install into `CONDA_PREFIX`; if not, I'll set `prefix` explicitly.
3. **hdf5 serial vs mpi** — conda-forge may pick the mpi-enabled hdf5 build since openmpi is in the env; the pkgdb is expected to detect parallel mode.

Independent of #184 (the make-4.4.1 fix) — this workflow brings its own make from conda-forge — so the two PRs can merge in either order.