### PR TITLE
Make pyre-boot.zip runnable via a Boot pyre application

### DIFF
--- a/.mm/projects.mm
+++ b/.mm/projects.mm
@@ -3,8 +3,9 @@
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved
 
-# establish the build order
-projects := pyre journal merlin pyre-mpi pyre-gsl pyre-cuda
+# establish the build order; {merlin} leads so it stages the {lib/mm} portinfo headers
+# into {include/mm} before any project with C++ sources compiles against them
+projects := merlin pyre journal pyre-mpi pyre-gsl pyre-cuda
 
 # end of file
 

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -6,8 +6,6 @@
 
 # pyre builds a python package
 pyre.packages := pyre.pkg
-# the pure-python packages that make up the bootstrap bundle
-pyre.boot.packages := pyre.pkg journal.pkg merlin.pkg
 # libraries
 pyre.libraries := pyre.lib
 # the mandatory extensions
@@ -25,6 +23,11 @@ pyre.tests := pyre.python.tests pyre.pkg.tests pyre.lib.tests pyre.ext.tests sql
 
 # we also some files that get moved verbatim
 pyre.verbatim := pyre.templates
+
+# the bootstrap bundle
+pyre.boot.packages := pyre.pkg journal.pkg merlin.pkg
+# the bootstrap zip file entry point
+pyre.boot.main := etc/boot/main.py
 
 
 # predicates that check the c++ standard in use

--- a/etc/boot/main.py
+++ b/etc/boot/main.py
@@ -1,0 +1,339 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# externals
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import typing
+import urllib.error
+import urllib.request
+
+# the framework, imported straight out of this archive via {zipimport}
+import journal
+import pyre
+import merlin
+
+# the build strategies understood by {mm}; mirrors the {mode} trait validator in {merlin.shells.MM}
+modes = ("dev", "release", "conda", "macports", "ubuntu")
+
+# optional features and the external package each one needs; the core framework needs none
+features = (
+    ("h5 extension", "hdf5", ("h5c++", "h5cc")),
+    ("postgres extension", "libpq", ("pg_config",)),
+    ("mpi support", "mpi", ("mpic++", "mpicxx")),
+    ("gsl support", "gsl", ("gsl-config",)),
+    ("cuda support", "cuda", ("nvcc",)),
+)
+
+
+# the app
+class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
+    """
+    Fetch the pyre source that matches this archive and build it with the embedded {mm}
+    """
+
+    # user configurable state
+    target = pyre.properties.path()
+    target.default = None
+    target.doc = "the directory to populate with the pyre source"
+
+    source = pyre.properties.str()
+    source.default = None
+    source.doc = "the release tag to pull, or {head} for the tip; defaults to this archive's own tag"
+
+    mode = pyre.properties.str(default="dev")
+    mode.validators = pyre.constraints.isMember(*modes)
+    mode.doc = "the strategy {mm} uses to lay out the build products"
+
+    repo = pyre.properties.str(default="https://github.com/pyre/pyre")
+    repo.doc = "the source repository to pull from"
+
+    interactive = pyre.properties.bool(default=True)
+    interactive.doc = "prompt for any choices left unset on the command line"
+
+    # application obligations
+    @pyre.export
+    def main(self, *args, **kwds) -> int:
+        """
+        Walk the user through fetching the matching source and building it with {mm}
+        """
+        # figure out which release this archive was cut from
+        tag, human = self.release()
+        self.info.log(f"pyre bootstrapper — release {human} ({tag})")
+
+        # settle which version to pull, defaulting to this archive's own tag
+        self.source = self.pick(default=tag)
+        # then where it should land and how to build it
+        self.target = self.ask(
+            question="where should I put the source",
+            default=str(
+                self.target or pyre.primitives.path.cwd() / f"pyre-{self.source}"
+            ),
+        )
+        self.mode = self.ask(question="which build mode", default=self.mode)
+
+        # resolve the destination once, now that it is final
+        target = pyre.primitives.path(self.target).resolve()
+
+        # explain what this machine can build before touching anything
+        self.audit()
+
+        # give the user a chance to back out
+        if self.ask(question="proceed", default="yes").lower() not in ("y", "yes"):
+            self.info.log("nothing done")
+            return 0
+
+        # stage the source, lend a hand with conda, then build
+        self.stage(target=target)
+        if self.mode == "conda":
+            self.conda(target=target)
+        self.build(target=target)
+
+        # done
+        self.info.log(f"pyre is built; the source lives in '{target}'")
+        return 0
+
+    # implementation details
+    def release(self) -> typing.Tuple[str, str]:
+        """
+        Report the version this archive was cut from, as a {(tag, human)} pair
+        """
+        # unpack the embedded version stamp
+        major, minor, micro, revision = pyre.meta.version
+        # the git tag, and a friendly rendering
+        return f"v{major}.{minor}.{micro}", f"{major}.{minor}.{micro} rev {revision}"
+
+    def pick(self, *, default: str) -> str:
+        """
+        Settle on the version to pull: honor an explicit choice, else offer what GitHub publishes
+        """
+        # a value supplied on the command line wins outright
+        if self.source:
+            return self.source
+        # in batch mode with nothing set, fall back to this archive's own tag
+        if not self.interactive:
+            return default
+        # otherwise show what is actually available, newest first
+        tags = self.catalog()
+        if tags:
+            shown = ", ".join(tags[:8])
+            self.info.log(f"available releases: {shown}{' …' if len(tags) > 8 else ''}")
+        # the development tip is always on offer alongside the published tags
+        self.info.log("use a tag from the list, or 'head' for the tip of development")
+        return self.ask(question="which version", default=default)
+
+    def catalog(self) -> typing.List[str]:
+        """
+        Query GitHub for the published release tags, newest first; empty on any failure
+        """
+        # derive the API endpoint from the repository url
+        slug = self.repo.rstrip("/").removeprefix("https://github.com/")
+        url = f"https://api.github.com/repos/{slug}/releases"
+        # ask politely, tolerating any network or rate-limit failure
+        try:
+            request = urllib.request.Request(
+                url, headers={"Accept": "application/vnd.github+json"}
+            )
+            with urllib.request.urlopen(request) as istream:
+                payload = json.load(istream)
+        except (urllib.error.URLError, json.JSONDecodeError) as error:
+            # a missing catalog is not fatal; the embedded tag still works
+            self.warning.log(f"could not reach GitHub for the release list ({error})")
+            return []
+        # pull out the tag names, preserving GitHub's newest-first ordering
+        return [release["tag_name"] for release in payload]
+
+    def ask(self, *, question: str, default: str) -> str:
+        """
+        Prompt for a value when running interactively; otherwise accept {default} silently
+        """
+        # in batch mode the configured value stands as is
+        if not self.interactive:
+            return default
+        # otherwise offer {default} and take whatever the user types
+        reply = input(f"{question} [{default}]: ").strip()
+        return reply or default
+
+    def audit(self) -> None:
+        """
+        Probe the host for a toolchain and optional dependencies, explaining what is buildable
+        """
+        # narrate through a channel dedicated to this concern
+        channel = journal.info("pyre.boot.audit")
+        channel.line("checking what this machine can build:")
+
+        # the core needs nothing but a C++ toolchain and the python development headers
+        cxx = self.compiler()
+        if cxx is None:
+            channel.line(
+                "  ✗ core framework — no C++ compiler found (set CXX or install one)"
+            )
+        else:
+            channel.line(
+                f"  ✓ core framework (pyre, journal, merlin + extensions) via {cxx}"
+            )
+
+        # every other feature is gated on an external package
+        for name, package, commands in features:
+            available = any(shutil.which(command) is not None for command in commands)
+            mark = "✓" if available else "✗"
+            note = "available" if available else f"needs {package}"
+            channel.line(f"  {mark} {name} — {note}")
+
+        # set expectations: a bare toolchain already yields a fully usable framework
+        channel.line("")
+        channel.line(
+            "  the core builds with no extra packages; optional features light up"
+        )
+        channel.line("  automatically once their dependency is on your PATH")
+        channel.log()
+
+    def compiler(self) -> typing.Optional[str]:
+        """
+        Locate a C++ compiler, honoring {CXX} before falling back to the usual suspects
+        """
+        # prefer an explicit choice from the environment, then the common driver names
+        for candidate in filter(None, (os.environ.get("CXX"), "c++", "g++", "clang++")):
+            found = shutil.which(candidate)
+            if found is not None:
+                return found
+        # nothing usable
+        return None
+
+    def stage(self, *, target: "pyre.primitives.path") -> None:
+        """
+        Populate {target} with the pyre source: a fresh checkout, or the chosen release tag
+        """
+        # refuse to clobber an existing, non-empty destination
+        if target.exists() and any(target.contents):
+            self.error.log(f"'{target}' already exists and is not empty")
+
+        # pulling the tip of development
+        if self.source == "head":
+            # which requires git
+            if shutil.which("git") is None:
+                self.error.log(
+                    "git is required to pull head; install it or choose a release"
+                )
+            self.info.log(f"cloning {self.repo} into '{target}'")
+            # a full clone, so the user can actually work in the tree they just pulled
+            outcome = subprocess.run(["git", "clone", self.repo, str(target)])
+            if outcome.returncode != 0:
+                self.error.log(f"git clone failed with status {outcome.returncode}")
+            return
+
+        # otherwise stage the tarball for the chosen tag
+        url = f"{self.repo}/archive/refs/tags/{self.source}.tar.gz"
+        self.info.log(f"downloading {url}")
+        self.untar(url=url, target=target)
+
+    def untar(self, *, url: str, target: "pyre.primitives.path") -> None:
+        """
+        Download the source tarball at {url} and unpack its single top-level tree into {target}
+        """
+        # work in a scratch directory that cleans itself up
+        with tempfile.TemporaryDirectory() as scratch:
+            archive = os.path.join(scratch, "source.tar.gz")
+            # grab the bytes, turning a bad tag or a network hiccup into a clean error
+            try:
+                with urllib.request.urlopen(url=url) as istream, open(
+                    archive, "wb"
+                ) as ostream:
+                    shutil.copyfileobj(istream, ostream)
+            except urllib.error.URLError as error:
+                self.error.log(f"failed to download {url}: {error}")
+            # unpack it; {filter} keeps modern python from warning, and is harmless data hygiene
+            with tarfile.open(archive) as tar:
+                try:
+                    tar.extractall(scratch, filter="data")
+                except TypeError:
+                    # {filter} predates this interpreter; fall back to the classic extraction
+                    tar.extractall(scratch)
+            # the github tarball wraps everything in a single {pyre-x.y.z} directory
+            roots = [entry for entry in os.listdir(scratch) if entry != "source.tar.gz"]
+            if len(roots) != 1:
+                self.error.log(f"unexpected tarball layout: {roots}")
+            # promote that directory to the destination the user picked
+            shutil.move(os.path.join(scratch, roots[0]), str(target))
+
+    def conda(self, *, target: "pyre.primitives.path") -> None:
+        """
+        Help the user line up a conda environment when building in conda mode
+        """
+        # conda has to be on the PATH for any of this to work
+        if shutil.which("conda") is None:
+            self.warning.log(
+                "conda mode selected, but no 'conda' on your PATH; install miniforge"
+            )
+            return
+
+        # an already-active environment is the happy path
+        active = os.environ.get("CONDA_PREFIX")
+        if active:
+            self.info.log(f"building into the active conda environment at '{active}'")
+            return
+
+        # otherwise point the user at the environment file the repo ships, if any
+        for relative in (
+            ".conda/environment.yml",
+            "etc/environment.yml",
+            "environment.yml",
+        ):
+            spec = target / relative
+            if spec.exists():
+                self.info.log(
+                    f"no environment active; create one with: conda env create -f {spec}"
+                )
+                return
+
+        # no shipped spec; give generic guidance rather than guessing package names
+        self.warning.log(
+            "no conda environment is active; create and activate one before building"
+        )
+
+    def build(self, *, target: "pyre.primitives.path") -> None:
+        """
+        Drive the embedded {mm} builder against the freshly staged tree
+        """
+        # in a source checkout, the engine and portinfo headers sit beside the {bin} driver
+        engine = target / "share" / "mm" / "make"
+        portinfo = target / "include" / "mm"
+
+        self.info.log(f"building pyre in '{self.mode}' mode from '{target}'")
+        # {mm} keys off the project's local {.mm} configuration, so run from the tree root
+        here = pyre.primitives.path.cwd()
+        os.chdir(str(target))
+        try:
+            # instantiate the embedded builder, pointed at the staged engine
+            app = merlin.shells.mm(
+                name="mm", engine=engine, portinfo=portinfo, mode=self.mode
+            )
+            # and let it build the default target
+            status = app.run()
+        finally:
+            # always return to where we started
+            os.chdir(str(here))
+
+        # surface a non-zero build status as a real failure
+        if status != 0:
+            self.error.log(f"the build exited with status {status}")
+
+
+# bootstrap: this module is staged as the archive's {__main__.py}, so it is the entry point
+if __name__ == "__main__":
+    # instantiate the app
+    app = Boot(name="pyre-boot")
+    # launch it
+    status = app.run()
+    # share the exit code with the shell
+    raise SystemExit(status)
+
+
+# end of file

--- a/etc/boot/main.py
+++ b/etc/boot/main.py
@@ -394,10 +394,14 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
         # announce the build so its mode and source are on the record
         self.info.log(f"building pyre in '{self.mode}' mode from '{target}'")
 
-        # the staged tree ships its own {mm}, which finds its engine and portinfo relative
-        # to itself; running it in a fresh process keeps it the sole {pyre.application} and
-        # sidesteps the one-application-per-process constraint that would otherwise bite
+        # the staged tree ships its own {mm} driver; running it in a fresh process keeps it
+        # the sole {pyre.application} and sidesteps the one-app-per-process constraint that
+        # would otherwise bite, since this bootstrapper is already the running application
         driver = target / "bin" / "mm"
+        # {mm} refuses to start unless its portinfo headers exist, and by default it looks
+        # for them under {include/mm} — an install artifact a fresh checkout does not have;
+        # the very same headers ship in-source under {lib/mm}, so point it there to pass
+        portinfo = target / "lib" / "mm"
 
         # start from a copy of our own environment so we only add to it
         environment = dict(os.environ)
@@ -411,9 +415,15 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
             os.pathsep.join((archive, existing)) if existing else archive
         )
 
-        # run the driver from the tree root, where {mm} finds the local {.mm} configuration
+        # run the driver from the tree root, where {mm} finds the local {.mm} configuration,
+        # overriding portinfo so the build compiles against the in-source headers
         outcome = subprocess.run(
-            [sys.executable, str(driver), f"--mode={self.mode}"],
+            [
+                sys.executable,
+                str(driver),
+                f"--mode={self.mode}",
+                f"--portinfo={portinfo}",
+            ],
             cwd=str(target),
             env=environment,
         )

--- a/etc/boot/main.py
+++ b/etc/boot/main.py
@@ -44,13 +44,17 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
     target.default = None
     target.doc = "the directory to populate with the pyre source"
 
-    source = pyre.properties.str()
-    source.default = None
-    source.doc = "the release tag to pull, or {head} for the tip; defaults to this archive's own tag"
+    channel = pyre.properties.str()
+    channel.default = None
+    channel.doc = "which stream to build: a published {release} or the bleeding {edge}; unset asks"
+
+    tag = pyre.properties.str()
+    tag.default = None
+    tag.doc = "a specific release tag to build, even one not shown on the menu"
 
     branch = pyre.properties.str()
     branch.default = None
-    branch.doc = "the branch to clone when building the bleeding edge; defaults to {main}"
+    branch.doc = "the branch to clone when building the edge; defaults to {main}"
 
     mode = pyre.properties.str(default="dev")
     mode.validators = pyre.constraints.isMember(*modes)
@@ -73,14 +77,14 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
         # and greet the user with that provenance
         self.info.log(f"pyre bootstrapper — release {human} ({tag})")
 
-        # settle what to build: a stable tag, or the tip of a development branch
-        self.source = self.pick(default=tag)
+        # settle the stream and the exact tag or branch to build
+        self.resolve(default_tag=tag)
         # decide where the source should land, defaulting to a sibling named for the choice
         self.target = self.ask(
             question="where should I put the source",
             default=str(
                 self.target
-                or pyre.primitives.path.cwd() / f"pyre-{self.branch or self.source}"
+                or pyre.primitives.path.cwd() / f"pyre-{self.branch or self.tag}"
             ),
         )
         # and settle on the layout strategy {mm} will use
@@ -107,8 +111,13 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
         # and drive the build to completion
         self.build(target=target)
 
-        # leave the user knowing where their freshly built tree lives
-        self.info.log(f"pyre is built; the source lives in '{target}'")
+        # leave the user knowing both where the source lives and where the products landed
+        self.info.log("pyre is built")
+        self.info.log(f"  source:   {target}")
+        # the install prefix comes straight from {mm}, when it is willing to tell us
+        prefix = self.installPrefix(target=target)
+        if prefix:
+            self.info.log(f"  products: {prefix}")
         # and report success
         return 0
 
@@ -122,42 +131,76 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
         # and hand back both the git tag and a reader-friendly rendering of it
         return f"v{major}.{minor}.{micro}", f"{major}.{minor}.{micro} rev {revision}"
 
-    def pick(self, *, default: str) -> str:
+    def resolve(self, *, default_tag: str) -> None:
         """
-        Settle on what to build: a published release, or the tip of a development branch
+        Settle the {channel} and the exact {tag} or {branch} to build, honoring explicit choices
         """
-        # an explicit choice on the command line ends the conversation before it starts
-        if self.source:
-            # so hand it straight back
-            return self.source
-        # with nothing chosen and no one to prompt, this archive's own release is the safe bet
-        if not self.interactive:
-            # so fall back to it
-            return default
-        # the first fork in the road: a stable release, or the bleeding edge?
-        edition = self.ask(
-            question="build a released version or the bleeding edge",
-            default="released",
-        )
-        # anything that leans toward the edge routes us to a live branch checkout
-        if edition.lower() in ("b", "bleeding", "bleeding-edge", "edge", "head", "dev"):
-            # so find out which branch to track, defaulting to the mainline
-            self.branch = self.ask(question="which branch", default=self.branch or "main")
-            # and flag the source as a checkout rather than a tag
-            return "head"
-        # otherwise we are on the release track, so show what GitHub actually publishes
+        # a tag and a branch at once are contradictory; refuse to guess which one wins
+        if self.tag and self.branch:
+            self.error.log("specify a release tag or a branch, not both")
+        # an explicit tag pins the release stream outright
+        if self.tag:
+            self.channel = "release"
+            return
+        # an explicit branch pins the edge stream outright
+        if self.branch:
+            self.channel = "edge"
+            return
+        # with neither pinned, decide the stream: a command-line choice, else a question, else default
+        if self.channel:
+            # normalize whatever arrived on the command line
+            self.channel = self.normalizeChannel(text=self.channel)
+        elif self.interactive:
+            # ask the one question that opens the whole flow
+            self.channel = self.normalizeChannel(
+                text=self.ask(
+                    question="build a released version or the bleeding edge",
+                    default="released",
+                )
+            )
+        else:
+            # batch mode with nothing set builds this archive's own release
+            self.channel = "release"
+        # now fill in the piece the chosen stream still needs
+        if self.channel == "edge":
+            # a branch to clone, defaulting to the mainline
+            self.branch = self.ask(question="which branch", default="main")
+        else:
+            # a release tag, offered from the menu interactively, else our own by default
+            self.tag = (
+                self.pickRelease(default=default_tag) if self.interactive else default_tag
+            )
+        # both {channel} and its reference are now settled
+        return
+
+    def normalizeChannel(self, *, text: str) -> str:
+        """
+        Map free-form text to a stream, leaning toward {release} unless the edge is clearly asked for
+        """
+        # treat any of the edge-flavored answers as a request for the bleeding edge
+        if text.lower() in ("e", "edge", "b", "bleeding", "bleeding-edge", "head", "dev"):
+            return "edge"
+        # everything else means a published release
+        return "release"
+
+    def pickRelease(self, *, default: str) -> str:
+        """
+        Offer the buildable releases newest-first and let the user settle on a tag
+        """
+        # ask GitHub for the releases this archive can actually build
         tags = self.catalog()
-        # and when the catalog came back, put the newest handful in front of the user
+        # and when any came back, put the newest few in front of the user as a hint
         if tags:
-            # a compact preview, trailing an ellipsis when there is more than we show
-            shown = ", ".join(tags[:8])
-            self.info.log(f"available releases: {shown}{' …' if len(tags) > 8 else ''}")
-        # then let them settle on the tag to pull
+            # a short preview, trailing an ellipsis when the list runs longer
+            shown = ", ".join(tags[:3])
+            self.info.log(f"available releases: {shown}{' …' if len(tags) > 3 else ''}")
+        # the prompt still accepts any tag, on the menu or not
         return self.ask(question="which release", default=default)
 
     def catalog(self) -> typing.List[str]:
         """
-        Query GitHub for the published release tags, newest first; empty on any failure
+        Query GitHub for the releases this archive can build — its own version or newer, newest
+        first — since older releases predate this bootstrapper's machinery; empty on any failure
         """
         # turn the repository url into the releases endpoint of the GitHub API
         slug = self.repo.rstrip("/").removeprefix("https://github.com/")
@@ -179,8 +222,33 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
             self.warning.log(f"could not reach GitHub for the release list ({error})")
             # and carry on with an empty catalog; the embedded tag still works
             return []
-        # otherwise surface just the tag names, keeping GitHub's newest-first ordering
-        return [release["tag_name"] for release in payload]
+        # this archive can only vouch for releases at least as new as itself
+        floor = tuple(pyre.meta.version[:3])
+        # keep the published tags that parse and clear that floor, in GitHub's newest-first order
+        buildable = []
+        for release in payload:
+            # parse the tag into a comparable version
+            version = self.parseTag(tag=release["tag_name"])
+            # and keep it only when it is well-formed and not older than us
+            if version is not None and version >= floor:
+                buildable.append(release["tag_name"])
+        # hand back just the buildable subset
+        return buildable
+
+    def parseTag(self, *, tag: str) -> typing.Optional[typing.Tuple[int, ...]]:
+        """
+        Parse a {vX.Y.Z} release tag into a comparable integer triple, or {None} if it doesn't fit
+        """
+        # drop an optional leading {v}
+        body = tag[1:] if tag.startswith("v") else tag
+        # split into its dotted fields
+        fields = body.split(".")
+        # a well-formed release tag is exactly three all-numeric fields
+        if len(fields) != 3 or not all(field.isdigit() for field in fields):
+            # anything else is not a release we can order, so decline it
+            return None
+        # hand back the numeric triple for comparison
+        return tuple(int(field) for field in fields)
 
     def ask(self, *, question: str, default: str) -> str:
         """
@@ -266,7 +334,7 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
             self.error.log(f"'{target}' already exists and is not empty")
 
         # the bleeding edge arrives as a git checkout the user can actually work in
-        if self.source == "head":
+        if self.channel == "edge":
             # and none of that is possible without git on hand
             if shutil.which("git") is None:
                 # so say so plainly and stop
@@ -293,7 +361,7 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
             return
 
         # every other choice is a published tag, delivered as a tarball
-        url = f"{self.repo}/archive/refs/tags/{self.source}.tar.gz"
+        url = f"{self.repo}/archive/refs/tags/{self.tag}.tar.gz"
         # announce the download so a slow network does not read as a hang
         self.info.log(f"downloading {url}")
         # then fetch and unpack it into place
@@ -391,48 +459,65 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
         """
         Drive the freshly staged tree's own {mm} driver in a subprocess
         """
-        # announce the build so its mode and source are on the record
+        # announce the build so its mode and target are on the record
         self.info.log(f"building pyre in '{self.mode}' mode from '{target}'")
-
-        # the staged tree ships its own {mm} driver; running it in a fresh process keeps it
-        # the sole {pyre.application} and sidesteps the one-app-per-process constraint that
-        # would otherwise bite, since this bootstrapper is already the running application
-        driver = target / "bin" / "mm"
-        # {mm} refuses to start unless its portinfo headers exist, and by default it looks
-        # for them under {include/mm} — an install artifact a fresh checkout does not have;
-        # the very same headers ship in-source under {lib/mm}, so point it there to pass
-        portinfo = target / "lib" / "mm"
-
-        # start from a copy of our own environment so we only add to it
-        environment = dict(os.environ)
-        # locate the archive we are running from, which is our copy of the framework
-        archive = os.path.dirname(__file__)
-        # note whatever PYTHONPATH the user already has
-        existing = environment.get("PYTHONPATH")
-        # then prepend our archive so the child's {import pyre} resolves against it
-        # instead of fetching a bootstrap zip of its own
-        environment["PYTHONPATH"] = (
-            os.pathsep.join((archive, existing)) if existing else archive
-        )
-
-        # run the driver from the tree root, where {mm} finds the local {.mm} configuration,
-        # overriding portinfo so the build compiles against the in-source headers
-        outcome = subprocess.run(
-            [
-                sys.executable,
-                str(driver),
-                f"--mode={self.mode}",
-                f"--portinfo={portinfo}",
-            ],
-            cwd=str(target),
-            env=environment,
-        )
-
+        # run the default build target and wait for it to finish
+        outcome = self.runMM(target=target, args=[])
         # a non-zero exit from the build is a real failure the user needs to hear about
         if outcome.returncode != 0:
             self.error.log(f"the build exited with status {outcome.returncode}")
         # otherwise the build stands on its own output; nothing to add
         return
+
+    def installPrefix(self, *, target: "pyre.primitives.path") -> typing.Optional[str]:
+        """
+        Ask the staged {mm} where it delivered the build products, or {None} if it will not say
+        """
+        # a quiet, capturing query for the install prefix
+        outcome = self.runMM(target=target, args=["builder.info.prefix"], capture=True)
+        # if the query failed, we simply do not know where things landed
+        if outcome.returncode != 0:
+            return None
+        # {mm} prints the prefix as a plain path, so take the last non-empty line
+        lines = [line.strip() for line in outcome.stdout.splitlines() if line.strip()]
+        return lines[-1] if lines else None
+
+    def runMM(
+        self, *, target: "pyre.primitives.path", args: typing.List[str], capture: bool = False
+    ) -> "subprocess.CompletedProcess":
+        """
+        Run the staged tree's {mm} driver with our common plumbing and hand back the completed process
+        """
+        # the driver ships with the staged tree; running it in a fresh process keeps it the sole
+        # {pyre.application} and sidesteps the one-app-per-process collision this bootstrapper
+        # would otherwise trigger by instantiating a second application inside itself
+        driver = target / "bin" / "mm"
+        # {mm} refuses to start unless its portinfo headers exist, and by default it looks for them
+        # under {include/mm} — an install artifact a fresh checkout does not have; the very same
+        # headers ship in-source under {lib/mm}, so point it there to clear the startup gate
+        portinfo = target / "lib" / "mm"
+        # lend the child our framework so its {import pyre} resolves against this archive rather
+        # than fetching a bootstrap zip of its own
+        environment = dict(os.environ)
+        # the archive we are running from is our copy of the framework
+        archive = os.path.dirname(__file__)
+        # respect whatever PYTHONPATH the user already has by prepending, not replacing
+        existing = environment.get("PYTHONPATH")
+        environment["PYTHONPATH"] = (
+            os.pathsep.join((archive, existing)) if existing else archive
+        )
+        # the driver, the mode and portinfo overrides, then whatever targets the caller wants
+        command = [
+            sys.executable,
+            str(driver),
+            f"--mode={self.mode}",
+            f"--portinfo={portinfo}",
+            *args,
+        ]
+        # run it from the tree root, where {mm} finds the local {.mm} configuration
+        return subprocess.run(
+            command, cwd=str(target), env=environment, capture_output=capture, text=capture
+        )
 
 
 # bootstrap: this module is staged as the archive's {__main__.py}, so it is the entry point

--- a/etc/boot/main.py
+++ b/etc/boot/main.py
@@ -9,6 +9,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 import typing
@@ -18,7 +19,6 @@ import urllib.request
 # the framework, imported straight out of this archive via {zipimport}
 import journal
 import pyre
-import merlin
 
 # the build strategies understood by {mm}; mirrors the {mode} trait validator in {merlin.shells.MM}
 modes = ("dev", "release", "conda", "macports", "ubuntu")
@@ -48,6 +48,10 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
     source.default = None
     source.doc = "the release tag to pull, or {head} for the tip; defaults to this archive's own tag"
 
+    branch = pyre.properties.str()
+    branch.default = None
+    branch.doc = "the branch to clone when building the bleeding edge; defaults to {main}"
+
     mode = pyre.properties.str(default="dev")
     mode.validators = pyre.constraints.isMember(*modes)
     mode.doc = "the strategy {mm} uses to lay out the build products"
@@ -64,40 +68,48 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
         """
         Walk the user through fetching the matching source and building it with {mm}
         """
-        # figure out which release this archive was cut from
+        # find out which release this archive was cut from, so we can offer it as the default
         tag, human = self.release()
+        # and greet the user with that provenance
         self.info.log(f"pyre bootstrapper — release {human} ({tag})")
 
-        # settle which version to pull, defaulting to this archive's own tag
+        # settle what to build: a stable tag, or the tip of a development branch
         self.source = self.pick(default=tag)
-        # then where it should land and how to build it
+        # decide where the source should land, defaulting to a sibling named for the choice
         self.target = self.ask(
             question="where should I put the source",
             default=str(
-                self.target or pyre.primitives.path.cwd() / f"pyre-{self.source}"
+                self.target
+                or pyre.primitives.path.cwd() / f"pyre-{self.branch or self.source}"
             ),
         )
+        # and settle on the layout strategy {mm} will use
         self.mode = self.ask(question="which build mode", default=self.mode)
 
-        # resolve the destination once, now that it is final
+        # nail down the destination now that the user has had their say
         target = pyre.primitives.path(self.target).resolve()
 
-        # explain what this machine can build before touching anything
+        # lay out what this machine can build before we touch anything on disk
         self.audit()
 
-        # give the user a chance to back out
+        # and give the user a last chance to walk away
         if self.ask(question="proceed", default="yes").lower() not in ("y", "yes"):
+            # honoring a decline by doing exactly nothing
             self.info.log("nothing done")
+            # and reporting a clean, uneventful exit
             return 0
 
-        # stage the source, lend a hand with conda, then build
+        # with consent in hand, put the source on disk
         self.stage(target=target)
+        # help line up an environment when the chosen mode needs one
         if self.mode == "conda":
             self.conda(target=target)
+        # and drive the build to completion
         self.build(target=target)
 
-        # done
+        # leave the user knowing where their freshly built tree lives
         self.info.log(f"pyre is built; the source lives in '{target}'")
+        # and report success
         return 0
 
     # implementation details
@@ -105,225 +117,312 @@ class Boot(pyre.application, family="pyre.applications.boot", namespace="boot"):
         """
         Report the version this archive was cut from, as a {(tag, human)} pair
         """
-        # unpack the embedded version stamp
+        # read the version stamp baked into the framework at build time
         major, minor, micro, revision = pyre.meta.version
-        # the git tag, and a friendly rendering
+        # and hand back both the git tag and a reader-friendly rendering of it
         return f"v{major}.{minor}.{micro}", f"{major}.{minor}.{micro} rev {revision}"
 
     def pick(self, *, default: str) -> str:
         """
-        Settle on the version to pull: honor an explicit choice, else offer what GitHub publishes
+        Settle on what to build: a published release, or the tip of a development branch
         """
-        # a value supplied on the command line wins outright
+        # an explicit choice on the command line ends the conversation before it starts
         if self.source:
+            # so hand it straight back
             return self.source
-        # in batch mode with nothing set, fall back to this archive's own tag
+        # with nothing chosen and no one to prompt, this archive's own release is the safe bet
         if not self.interactive:
+            # so fall back to it
             return default
-        # otherwise show what is actually available, newest first
+        # the first fork in the road: a stable release, or the bleeding edge?
+        edition = self.ask(
+            question="build a released version or the bleeding edge",
+            default="released",
+        )
+        # anything that leans toward the edge routes us to a live branch checkout
+        if edition.lower() in ("b", "bleeding", "bleeding-edge", "edge", "head", "dev"):
+            # so find out which branch to track, defaulting to the mainline
+            self.branch = self.ask(question="which branch", default=self.branch or "main")
+            # and flag the source as a checkout rather than a tag
+            return "head"
+        # otherwise we are on the release track, so show what GitHub actually publishes
         tags = self.catalog()
+        # and when the catalog came back, put the newest handful in front of the user
         if tags:
+            # a compact preview, trailing an ellipsis when there is more than we show
             shown = ", ".join(tags[:8])
             self.info.log(f"available releases: {shown}{' …' if len(tags) > 8 else ''}")
-        # the development tip is always on offer alongside the published tags
-        self.info.log("use a tag from the list, or 'head' for the tip of development")
-        return self.ask(question="which version", default=default)
+        # then let them settle on the tag to pull
+        return self.ask(question="which release", default=default)
 
     def catalog(self) -> typing.List[str]:
         """
         Query GitHub for the published release tags, newest first; empty on any failure
         """
-        # derive the API endpoint from the repository url
+        # turn the repository url into the releases endpoint of the GitHub API
         slug = self.repo.rstrip("/").removeprefix("https://github.com/")
+        # by splicing the slug into the api host
         url = f"https://api.github.com/repos/{slug}/releases"
-        # ask politely, tolerating any network or rate-limit failure
+        # then reach out, treating the network as something that is allowed to fail
         try:
+            # ask for the json rendering of the releases
             request = urllib.request.Request(
                 url, headers={"Accept": "application/vnd.github+json"}
             )
+            # open the connection and read the response
             with urllib.request.urlopen(request) as istream:
+                # parsing the payload into python data
                 payload = json.load(istream)
+        # a network hiccup or a garbled response is not fatal here
         except (urllib.error.URLError, json.JSONDecodeError) as error:
-            # a missing catalog is not fatal; the embedded tag still works
+            # so warn that the list is unavailable
             self.warning.log(f"could not reach GitHub for the release list ({error})")
+            # and carry on with an empty catalog; the embedded tag still works
             return []
-        # pull out the tag names, preserving GitHub's newest-first ordering
+        # otherwise surface just the tag names, keeping GitHub's newest-first ordering
         return [release["tag_name"] for release in payload]
 
     def ask(self, *, question: str, default: str) -> str:
         """
         Prompt for a value when running interactively; otherwise accept {default} silently
         """
-        # in batch mode the configured value stands as is
+        # in batch mode there is no one to answer, so the configured value stands
         if not self.interactive:
+            # returned untouched
             return default
-        # otherwise offer {default} and take whatever the user types
+        # otherwise put the question to the user, offering {default} in brackets
         reply = input(f"{question} [{default}]: ").strip()
+        # and take what they typed, falling back to {default} on an empty line
         return reply or default
 
     def audit(self) -> None:
         """
         Probe the host for a toolchain and optional dependencies, explaining what is buildable
         """
-        # narrate through a channel dedicated to this concern
+        # narrate the whole audit through a channel dedicated to this concern
         channel = journal.info("pyre.boot.audit")
+        # open with a heading so the checklist that follows reads as one thought
         channel.line("checking what this machine can build:")
 
-        # the core needs nothing but a C++ toolchain and the python development headers
+        # the core needs nothing more exotic than a working C++ compiler
         cxx = self.compiler()
+        # so if none turned up, mark the core as unbuildable and say how to fix it
         if cxx is None:
             channel.line(
                 "  ✗ core framework — no C++ compiler found (set CXX or install one)"
             )
+        # and when one is present, confirm the core is good to go and name the compiler
         else:
             channel.line(
                 f"  ✓ core framework (pyre, journal, merlin + extensions) via {cxx}"
             )
 
-        # every other feature is gated on an external package
+        # walk the optional features, each gated on its own external package
         for name, package, commands in features:
+            # a feature is buildable when any of its probe commands is on the PATH
             available = any(shutil.which(command) is not None for command in commands)
+            # pick the checkmark that matches
             mark = "✓" if available else "✗"
+            # and the note that either celebrates or names the missing dependency
             note = "available" if available else f"needs {package}"
+            # then record the verdict for this feature
             channel.line(f"  {mark} {name} — {note}")
 
-        # set expectations: a bare toolchain already yields a fully usable framework
+        # close by setting expectations: a bare toolchain already yields a usable framework
         channel.line("")
+        # spelling out that the core stands alone
         channel.line(
             "  the core builds with no extra packages; optional features light up"
         )
+        # and that the rest arrives for free as dependencies appear
         channel.line("  automatically once their dependency is on your PATH")
+        # flush the assembled checklist as a single entry
         channel.log()
+        # nothing to report back; the audit speaks through its channel
+        return
 
     def compiler(self) -> typing.Optional[str]:
         """
         Locate a C++ compiler, honoring {CXX} before falling back to the usual suspects
         """
-        # prefer an explicit choice from the environment, then the common driver names
+        # try an explicit choice from the environment first, then the common driver names
         for candidate in filter(None, (os.environ.get("CXX"), "c++", "g++", "clang++")):
+            # resolving each candidate against the PATH
             found = shutil.which(candidate)
+            # and settling on the first one that actually exists
             if found is not None:
+                # by handing back its full path
                 return found
-        # nothing usable
+        # nothing on the list was usable, so report the absence
         return None
 
     def stage(self, *, target: "pyre.primitives.path") -> None:
         """
-        Populate {target} with the pyre source: a fresh checkout, or the chosen release tag
+        Populate {target} with the pyre source: a live branch checkout, or a release tarball
         """
-        # refuse to clobber an existing, non-empty destination
+        # a destination that already holds something is not ours to overwrite
         if target.exists() and any(target.contents):
+            # so refuse rather than risk clobbering the user's work
             self.error.log(f"'{target}' already exists and is not empty")
 
-        # pulling the tip of development
+        # the bleeding edge arrives as a git checkout the user can actually work in
         if self.source == "head":
-            # which requires git
+            # and none of that is possible without git on hand
             if shutil.which("git") is None:
+                # so say so plainly and stop
                 self.error.log(
-                    "git is required to pull head; install it or choose a release"
+                    "git is required to pull the bleeding edge; install it or choose a release"
                 )
-            self.info.log(f"cloning {self.repo} into '{target}'")
-            # a full clone, so the user can actually work in the tree they just pulled
-            outcome = subprocess.run(["git", "clone", self.repo, str(target)])
+            # start assembling the clone command
+            command = ["git", "clone"]
+            # narrowing it to the requested branch when one was named
+            if self.branch:
+                command += ["--branch", self.branch]
+            # and landing the work in the destination the user picked
+            command += [self.repo, str(target)]
+            # narrate what is about to happen, branch and all
+            self.info.log(
+                f"cloning {self.repo}{f' ({self.branch})' if self.branch else ''} into '{target}'"
+            )
+            # run the clone and wait for it to finish
+            outcome = subprocess.run(command)
+            # a failed clone leaves nothing to build, so treat it as fatal
             if outcome.returncode != 0:
                 self.error.log(f"git clone failed with status {outcome.returncode}")
+            # the checkout is the whole job on this path
             return
 
-        # otherwise stage the tarball for the chosen tag
+        # every other choice is a published tag, delivered as a tarball
         url = f"{self.repo}/archive/refs/tags/{self.source}.tar.gz"
+        # announce the download so a slow network does not read as a hang
         self.info.log(f"downloading {url}")
+        # then fetch and unpack it into place
         self.untar(url=url, target=target)
+        # and that completes the staging
+        return
 
     def untar(self, *, url: str, target: "pyre.primitives.path") -> None:
         """
         Download the source tarball at {url} and unpack its single top-level tree into {target}
         """
-        # work in a scratch directory that cleans itself up
+        # work in a scratch directory that cleans itself up no matter how we leave
         with tempfile.TemporaryDirectory() as scratch:
+            # where the downloaded archive will live
             archive = os.path.join(scratch, "source.tar.gz")
-            # grab the bytes, turning a bad tag or a network hiccup into a clean error
+            # grab the bytes, treating a bad tag or a network stumble as recoverable
             try:
+                # stream the response straight to disk to keep memory flat
                 with urllib.request.urlopen(url=url) as istream, open(
                     archive, "wb"
                 ) as ostream:
+                    # copying the payload across in chunks
                     shutil.copyfileobj(istream, ostream)
+            # a download that never arrives is a clean, explainable failure
             except urllib.error.URLError as error:
+                # so report it and stop
                 self.error.log(f"failed to download {url}: {error}")
-            # unpack it; {filter} keeps modern python from warning, and is harmless data hygiene
+            # open the archive for extraction
             with tarfile.open(archive) as tar:
+                # unpack it, asking modern python to sanitize member paths
                 try:
                     tar.extractall(scratch, filter="data")
+                # the {filter} argument predates older interpreters
                 except TypeError:
-                    # {filter} predates this interpreter; fall back to the classic extraction
+                    # so fall back to the classic extraction when it is unavailable
                     tar.extractall(scratch)
-            # the github tarball wraps everything in a single {pyre-x.y.z} directory
+            # GitHub wraps the whole tree in a single {pyre-x.y.z} directory beside our archive
             roots = [entry for entry in os.listdir(scratch) if entry != "source.tar.gz"]
+            # anything other than exactly one wrapper means the layout is not what we assumed
             if len(roots) != 1:
+                # so refuse to guess and report the surprise
                 self.error.log(f"unexpected tarball layout: {roots}")
-            # promote that directory to the destination the user picked
+            # promote that lone directory to the destination the user picked
             shutil.move(os.path.join(scratch, roots[0]), str(target))
+        # the tree is in place; the scratch directory is already gone
+        return
 
     def conda(self, *, target: "pyre.primitives.path") -> None:
         """
         Help the user line up a conda environment when building in conda mode
         """
-        # conda has to be on the PATH for any of this to work
+        # none of this guidance is possible without conda on the PATH
         if shutil.which("conda") is None:
+            # so point the user at an installer and bow out
             self.warning.log(
                 "conda mode selected, but no 'conda' on your PATH; install miniforge"
             )
+            # nothing more we can usefully say
             return
 
         # an already-active environment is the happy path
         active = os.environ.get("CONDA_PREFIX")
+        # so when one is live, just confirm we will build into it
         if active:
+            # naming it so the user knows where products will land
             self.info.log(f"building into the active conda environment at '{active}'")
+            # and leave the environment untouched
             return
 
-        # otherwise point the user at the environment file the repo ships, if any
+        # with nothing active, look for a spec the repo ships, in order of preference
         for relative in (
             ".conda/environment.yml",
             "etc/environment.yml",
             "environment.yml",
         ):
+            # resolve each candidate against the staged tree
             spec = target / relative
+            # and on the first one that exists, hand the user the exact command to run
             if spec.exists():
+                # so they can create the environment themselves
                 self.info.log(
                     f"no environment active; create one with: conda env create -f {spec}"
                 )
+                # our job here is done
                 return
 
-        # no shipped spec; give generic guidance rather than guessing package names
+        # no active environment and no shipped spec leaves only generic advice
         self.warning.log(
             "no conda environment is active; create and activate one before building"
         )
+        # which is the most we can offer without guessing package names
+        return
 
     def build(self, *, target: "pyre.primitives.path") -> None:
         """
-        Drive the embedded {mm} builder against the freshly staged tree
+        Drive the freshly staged tree's own {mm} driver in a subprocess
         """
-        # in a source checkout, the engine and portinfo headers sit beside the {bin} driver
-        engine = target / "share" / "mm" / "make"
-        portinfo = target / "include" / "mm"
-
+        # announce the build so its mode and source are on the record
         self.info.log(f"building pyre in '{self.mode}' mode from '{target}'")
-        # {mm} keys off the project's local {.mm} configuration, so run from the tree root
-        here = pyre.primitives.path.cwd()
-        os.chdir(str(target))
-        try:
-            # instantiate the embedded builder, pointed at the staged engine
-            app = merlin.shells.mm(
-                name="mm", engine=engine, portinfo=portinfo, mode=self.mode
-            )
-            # and let it build the default target
-            status = app.run()
-        finally:
-            # always return to where we started
-            os.chdir(str(here))
 
-        # surface a non-zero build status as a real failure
-        if status != 0:
-            self.error.log(f"the build exited with status {status}")
+        # the staged tree ships its own {mm}, which finds its engine and portinfo relative
+        # to itself; running it in a fresh process keeps it the sole {pyre.application} and
+        # sidesteps the one-application-per-process constraint that would otherwise bite
+        driver = target / "bin" / "mm"
+
+        # start from a copy of our own environment so we only add to it
+        environment = dict(os.environ)
+        # locate the archive we are running from, which is our copy of the framework
+        archive = os.path.dirname(__file__)
+        # note whatever PYTHONPATH the user already has
+        existing = environment.get("PYTHONPATH")
+        # then prepend our archive so the child's {import pyre} resolves against it
+        # instead of fetching a bootstrap zip of its own
+        environment["PYTHONPATH"] = (
+            os.pathsep.join((archive, existing)) if existing else archive
+        )
+
+        # run the driver from the tree root, where {mm} finds the local {.mm} configuration
+        outcome = subprocess.run(
+            [sys.executable, str(driver), f"--mode={self.mode}"],
+            cwd=str(target),
+            env=environment,
+        )
+
+        # a non-zero exit from the build is a real failure the user needs to hear about
+        if outcome.returncode != 0:
+            self.error.log(f"the build exited with status {outcome.returncode}")
+        # otherwise the build stands on its own output; nothing to add
+        return
 
 
 # bootstrap: this module is staged as the archive's {__main__.py}, so it is the entry point

--- a/share/mm/make/projects/init.mm
+++ b/share/mm/make/projects/init.mm
@@ -58,6 +58,9 @@ define project.init =
     ${eval $(1).boot.contents ?= $($(1).boot.root)contents/}
     # the bundle archive itself
     ${eval $(1).boot.archive ?= $($(1).boot.root)$($(1).stem)-boot.zip}
+    # an optional entry-point script, staged as the archive's {__main__.py} so the bundle is
+    # directly runnable with {python bundle.zip}; empty unless the project provides one
+    ${eval $(1).boot.main ?=}
 
     # make
     # the directory from where {make} was invoked, i.e. the nearest parent with a local

--- a/share/mm/make/projects/rules.mm
+++ b/share/mm/make/projects/rules.mm
@@ -62,8 +62,12 @@ endef
 
 # zip the currently-staged contents into the archive, replacing any previous one
 #   usage: project.boot.zip {project}
+# when the project nominates an entry point, it is dropped in as {__main__.py} at the zip root
+# right before bundling, so the freshest copy always ships and {python bundle.zip} just works
 define project.boot.zip =
 	$(rm.force) $($(1).boot.archive)
+	$(mkdirp) $($(1).boot.contents)
+	${if $($(1).boot.main),${if $(wildcard $($(1).home)/$($(1).boot.main)),$(cp) $($(1).home)/$($(1).boot.main) $($(1).boot.contents)__main__.py}}
 	cd $($(1).boot.contents) && $(zip) $(zip.flags.bundle) $($(1).boot.archive) .
 	@${call log.asset,"boot",$($(1).boot.archive)}
 endef


### PR DESCRIPTION
## Make `pyre-boot.zip` a self-bootstrapping, buildable archive

Turns the `pyre-boot.zip` bundle into a directly runnable bootstrapper:

```
python pyre-boot.zip
```

fetches pyre source and builds it with the tree's own `mm`. The entry point is a real
`pyre.application` (`etc/boot/main.py`, `class Boot`), staged into the archive as `__main__.py` and
imported straight from the zip via `zipimport`. It walks the user through: choose what to build →
where to put it and how → an audit of the toolchain and optional dependencies → confirm → stage →
(conda guidance) → build → report where the source and products landed.

Depends on **aivazis/mm#46**, which adds the generic `boot.main` staging rule; `.mm/pyre.mm` opts
in with `pyre.boot.main := etc/boot/main.py`.

### End-to-end verified

`python pyre-boot.zip` → *edge* → `boot` → full clone + build completes (exit 0): the whole C++ tree
(pyre, journal, and the h5/postgres/mpi/gsl extensions) compiles, the packages stage, and the run
ends by printing both the source location and the install prefix. Reaching a working build required
three fixes, each reproduced before fixing:

1. **Build in a subprocess, not in-process.** The first cut instantiated `merlin.shells.mm`
   in-process, but `Boot` is *already* the running `pyre.application`, and pyre allows one
   application per process — the journal `Chronicler` collided (*"another app 'pyre-boot' is already
   registered"*) and crashed. `build()` now execs the staged tree's own `bin/mm` in a fresh process
   (factored through a `runMM()` helper), with the archive prepended to the child's `PYTHONPATH` so
   its `import pyre` resolves against this zip instead of re-downloading a bootstrap archive. This
   also uses the fetched tree's own builder, closing the embedded-merlin drift concern.

2. **Portinfo headers for a from-source build.** `mm` refuses to start unless its portinfo headers
   exist, and by default looks for them under `include/mm` — an install artifact a fresh checkout
   never has (a fatal startup gate in `merlin/shells/MM.py::verifyInstallation`, before make parses
   anything). The same headers ship in-source at `lib/mm`, so `runMM()` passes
   `--portinfo=<target>/lib/mm` to clear the gate and compile against them directly.

3. **Don't offer un-buildable sources.** Published releases predate this bootstrapper's `bin/mm` +
   portinfo work, so pulling an old tag can't succeed. See the selection model below.

### Source selection

The old cut overloaded a single `source` trait (a tag *or* the magic string `"head"`). It is now
three explicit traits with a clear precedence:

- **`channel`** — `release` | `edge`; default `None`, which triggers the *"released or bleeding
  edge"* question.
- **`tag`** — a specific release tag, even one not on the menu.
- **`branch`** — the branch to clone for the edge (default `main`).

Precedence in `resolve()`: `--tag` pins the release stream and skips the questions; `--branch` pins
the edge stream and skips them; both together → error (*"specify a release tag or a branch, not
both"*); otherwise a command-line `--channel` is honored, else the question is asked interactively,
else batch mode defaults to this archive's own release. (App traits bind via the `--name=value`
form.)

The released menu no longer misleads: `catalog()` filters to releases **≥ this archive's own
version** — releases at least as new as the archive are, by construction, guaranteed to contain this
machinery — and trims to the newest three. A specific older tag can still be forced with `--tag` (or
typed at the prompt), caveat emptor.

### Reporting

The completion message now lists both where the source lives *and* where the products were delivered
(`source:` / `products:`), the install prefix pulled from `mm` via `builder.info.prefix`.

### Build-order note

`.mm/projects.mm` parses `merlin` ahead of `pyre`. This is **parse order**, not build order — it
makes merlin's variables (including the `merlin.mm.lib` → `include/mm` staging) defined before pyre
is parsed. Confirmed it does not break a normal build. Kept for install-side `include/mm`
correctness in other modes; it is *not* what unblocks the boot build (the gate is pre-make).

`etc/boot/main.py` is written to the project house style (intent-first comments; every method ends
on a `return`).

### Known limitation

The **released-tag** path won't work end-to-end until a release is cut that contains this `bin/mm`
+ portinfo work; a tag pull today still resolves the old code (and the version-floor menu, whose
stamp currently lags the branch, reflects that). The **edge/branch** path is the one proven here.
This branch is release prep, so that gap closes when the next release is cut.

### Commits

- `9263a5f34` build: parse the `merlin` project ahead of `pyre`
- `7c7f62c81` boot: build via the staged tree's own `mm`; add released/bleeding-edge selection
- `19616b580` boot: point `mm` at the in-source `lib/mm` portinfo headers
- `f2a94673f` boot: add channel/tag/branch selection, floor the release menu, and report the install prefix
- (plus the original `Boot` app + opt-in commit)
