### PR TITLE
conda: derive the python ABI suffix from the package manifest; repair the mm driver's layout probe

### DIFF
--- a/bin/mm
+++ b/bin/mm
@@ -54,29 +54,24 @@ import merlin
 
 # bootstrap
 if __name__ == "__main__":
-    # find out where i live
-    _mm_home = pyre.primitives.path(__file__).resolve().parent
-    # check whether i'm running from my source directory
-    _mm_insitu = (_mm_home / "make" / "merlin.mm").exists()
+    # find out where i live; the driver sits in {bin}, so my home is one level up
+    _mm_home = pyre.primitives.path(__file__).resolve().parent.parent
+    # check whether i'm running from my source directory; only the source tree keeps the
+    # {portinfo} headers under {lib/mm} -- the install stages them into {include/mm}, so
+    # their location is what tells the two layouts apart
+    _mm_insitu = (_mm_home / "lib" / "mm" / "portinfo.h").exists()
 
-    # if i'm running in-place
+    # if i'm running in place, the headers are where the sources left them
     if _mm_insitu:
-        # this is the layout i expect to see:
-        # the {portinfo} headers
-        _mm_incdir = _mm_home / "include" / "mm"
-        # the share area
-        _mm_shrdir = _mm_home
-        # my makefiles
-        _mm_mkdir = _mm_shrdir / "make"
+        # so mark against the source directory
+        _mm_incdir = _mm_home / "lib" / "mm"
     # otherwise
     else:
-        # assume i am installed in a u*ixy environment:
-        # the {portinfo} headers
-        _mm_incdir = (_mm_home / ".." / "include" / "mm").resolve()
-        # my share area
-        _mm_shrdir = (_mm_home / ".." / "share" / "mm").resolve()
-        # my makefiles
-        _mm_mkdir = (_mm_shrdir / "make").resolve()
+        # they were staged into the include area of the install prefix
+        _mm_incdir = _mm_home / "include" / "mm"
+
+    # either way, the make engine sits in the share area
+    _mm_mkdir = _mm_home / "share" / "mm" / "make"
 
     # instantiate the app
     app = merlin.shells.mm(name="mm", engine=_mm_mkdir, portinfo=_mm_incdir)

--- a/packages/merlin/shells/MM.py
+++ b/packages/merlin/shells/MM.py
@@ -1692,7 +1692,7 @@ class MM(pyre.application, family="pyre.applications.mm", namespace="mm"):
                 "module": "pybind11",
             },
             "pyre": {"candidates": ["pyre"]},
-            "python": {"candidates": ["python"], "trim": True},
+            "python": {"candidates": ["python"], "handler": "_emitCondaPython", "trim": True},
             "slepc": {"candidates": ["slepc"]},
             "sundials": {"candidates": ["sundials"]},
             "vtk": {"candidates": ["vtk"]},
@@ -1892,6 +1892,34 @@ class MM(pyre.application, family="pyre.applications.mm", namespace="mm"):
         except ValueError:
             # record where it actually is
             entry["lines"].append(f"{target}.dir ?= {root}")
+
+    def _emitCondaPython(self, entry, recipe, candidate, record, prefix):
+        """
+        Emit the configuration for the python interpreter; conda ships free-threading builds
+        whose headers sit in {include/python3.14t}, so read the ABI suffix off the directory
+        that owns {Python.h} instead of rebuilding the name from the version alone
+        """
+        # the interpreter is installed at the root of the environment
+        entry["lines"].append("python.dir ?= $(conda.prefix)")
+        # find the directory that owns the main header
+        incdir = self._condaManifestDir(record, lambda path: path.name == "Python.h")
+        # if the manifest doesn't mention it, leave {model} at its {init.mm} default and let the
+        # {markers.headers} check downstream complain about the missing header
+        if incdir is None:
+            # nothing more we can say
+            return
+        # the stem that {init.mm} builds the interpreter name from, e.g. {python3.14}
+        stem = f"python{entry['version']}"
+        # whatever the directory appends to that stem is the ABI model: {t} for free-threading,
+        # {d} for a debug build, empty for the standard one
+        model = incdir.name[len(stem) :] if incdir.name.startswith(stem) else ""
+        # the standard build needs nothing; {init.mm} already defaults {model} to empty
+        if not model:
+            # so leave it alone
+            return
+        # otherwise hand the suffix to the build, so that the interpreter name, the configurator,
+        # the include path and the library name all pick it up together
+        entry["lines"].append(f"python.model ?= {model}")
 
     def _emitCondaCuda(self, index, prefix):
         """

--- a/share/mm/make/extern/petsc/rules.mm
+++ b/share/mm/make/extern/petsc/rules.mm
@@ -1,9 +1,8 @@
 # -*- Makefile -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
+
 
 # show me
 # ${info -- petsc.info}

--- a/share/mm/make/extern/python/init.mm
+++ b/share/mm/make/extern/python/init.mm
@@ -18,8 +18,9 @@ python.model ?= $(empty)
 python.interpreter ?= python$(python.version)$(python.model)
 # the configurator
 python.configurator ?= $(python.interpreter)-config
-# the interpreter tag, used to form pathnames
-python.tag ?= $(python.interpreter)$(python.model)
+# the interpreter tag, used to form pathnames; {interpreter} already carries the {model},
+# so appending it again would double the ABI suffix for free-threading and debug builds
+python.tag ?= $(python.interpreter)
 
 # compiler flags
 python.flags ?=

--- a/share/mm/make/mm/rules.mm
+++ b/share/mm/make/mm/rules.mm
@@ -7,7 +7,7 @@
 # administrivia
 mm.banner:
 	@$(log)
-	@$(log) $(palette.banner)"    mm $(mm.version)"$(palette.normal)
+	@$(log) $(palette.banner)"    merlin mm $(mm.version)"$(palette.normal)
 	@$(log) "    Michael Aïvázis <michael.aivazis@para-sim.com>"
 	@$(log) "    copyright 1998-2026 all rights reserved"
 	@$(log)


### PR DESCRIPTION
Four related changes to the embedded `merlin` builder. The first is the pyre-side twin of
[aivazis/mm#47](https://github.com/aivazis/mm/pull/47); the rest are repairs it surfaced.

## 1. the python ABI suffix

`pyre`'s conda-forge CI dies at the first pybind11 binding:

```
.../pybind11/include/pybind11/conduit/wrap_include_python_h.h:44:10: fatal error: Python.h: No such file or directory
```

The environment is active and `mode=conda` resolves the prefix correctly. The problem is
narrower. Leaving `python` unpinned lets the solver take the free-threading build, because the
`cp314t` build string outranks `cp314`:

```
+ python      3.14.6  hf9ea5aa_0_cp314t
+ python_abi  3.14    8_cp314t
```

whose headers live in `include/python3.14t`. `_condaRecipes` trims python's version to
`major.minor`, so the database records `python.version ?= 3.14`, and `extern/python/init.mm`
*reconstructs* the include path from that string, arriving at `include/python3.14` — a directory
that does not exist.

The tell is in the error itself: pybind11's own headers resolve fine, under
`lib/python3.14t/site-packages/...`, because `_emitCondaSitePackage` asks the module where it
lives. Python's include directory is the one place we rebuild a path from a version string
instead of reading the manifest, and that is where the suffix is lost.

`_emitCondaPython` now locates the directory owning `Python.h` in the package's `conda-meta`
record and reports whatever it appends to `python{major.minor}` as `python.model` — the same
manifest-driven technique `_emitCondaCuda` uses via `commonRoot`. One emitted line corrects
`interpreter`, `configurator`, `incpath` and `libraries` together, since `init.mm` derives all
four from `model`. Nothing is emitted for the standard build, so its behaviour is unchanged.

Note that `_condaResolve` skips the generic `{name}.dir ?= $(conda.prefix)` line once a recipe
names a handler, so `_emitCondaPython` emits it itself.

## 2. `python.tag`

`model` is the interpreter's *memory model* — historically the `m` of `python3.6m`, which
appeared in the include directory and library name but not in the interpreter binary. The
free-threading `t` is different: it appears in the binary name too, and `python.interpreter`
already carries it. So

```make
python.tag ?= $(python.interpreter)$(python.model)
```

now doubles the suffix. `tag` is consumed only by `extern.python.info`'s logging, so this is
cosmetic, but it becomes visible the moment `model` is non-empty. It is now
`python.tag ?= $(python.interpreter)`, identical to today's value whenever `model` is empty.

`share/mm/make/extern/python/init.mm` is a verbatim copy of `~/dv/mm/make/...`; the two remain
byte-identical.

## 3. the driver's layout probe

`bin/mm` computed `_mm_home` as the directory holding the driver — `<root>/bin` — and then
probed `<root>/bin/make/merlin.mm` to decide whether it was running in place. That marker never
exists, so a run from the pyre source tree always took the installed branch and looked for the
`portinfo` headers in `include/mm`, which the source tree does not have; they live in `lib/mm`.

`_mm_home` is now the project root, and the probe keys off the thing that actually differs
between the two layouts — where the headers are:

| | `lib/mm/portinfo.h` | `include/mm/portinfo.h` | `share/mm/make/merlin.mm` |
|---|---|---|---|
| source tree | yes | no | yes |
| install prefix | no | yes | yes |

Probing `share/mm/make/merlin.mm` cannot discriminate, because `.mm/merlin.mm` declares
`merlin.mm.make.root := share/mm/` as `verbatim`, so an installed prefix has it too. Probing
`lib/mm/portinfo.h` does. Verified against a real install prefix
(`.../pyre/conda/opt-shared-darwin-arm64`), which has `include/mm/portinfo.h` and
`share/mm/make/merlin.mm` but no `lib/mm/portinfo.h`.

Since the make engine sits at `share/mm/make` in *both* layouts, `_mm_mkdir` no longer needs a
branch.

## 4. banner

The embedded builder now announces itself as `merlin mm` rather than `mm`, so it is
distinguishable from the standalone driver at a glance. This is the one intentional divergence
of `share/mm/make/` from `aivazis/mm`.

## 5. preamble cosmetics

`extern/petsc/rules.mm` carried a non-conforming preamble — a stray `# parasim` line and a
trailing `#` — in both copies. It now matches every other file in the engine. The corresponding
repairs on the standalone side (two `mmichael.aivazis` typos, one stale `1998-2025`, and the
missing email on this same file) are in a separate `preamble` branch of `aivazis/mm`.

With that, `~/dv/mm/make` and `share/mm/make/` differ in exactly one file: `mm/rules.mm`, the
banner divergence of §4. The verbatim-copy invariant holds.

## verification

- `_emitCondaPython` exercised against synthetic `conda-meta` records for the free-threading,
  debug, standard and missing-`Python.h` cases.
- The `init.mm` expansion checked with `make` for both `model=t` and `model=`, confirming the
  standard build is bit-for-bit unchanged.
- The driver's probe checked against the real source tree and a real install prefix.
- `black` clean at the project's `line-length = 100`.

## note

`pr-conda.yaml` pins `python-gil` in its environment file, so the free-threading path is not what
unblocks CI. This change is about not silently mis-deriving the include path when a non-standard
ABI *is* selected. Also, `pr-conda` clones `aivazis/mm` from GitHub, so the CI legs pick up the
handler only once aivazis/mm#47 lands; the copy here serves the embedded merlin build.
