### PR TITLE
Add a mpi.ext binding-layer test suite

### DIFF
--- a/.mm/pyre-mpi.ext.tests
+++ b/.mm/pyre-mpi.ext.tests
@@ -1,0 +1,103 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the mpi extension testsuite
+pyre-mpi.ext.tests.stem := mpi.ext
+pyre-mpi.ext.tests.prerequisites := pyre-mpi.pkg pyre-mpi.ext pyre.pkg
+
+
+# set up a macro for the hostfile
+pyre-mpi.ext.hostfile := --hostfile localhost
+# see the note in {pyre-mpi.lib.tests}: turn {openmpi} binding off so it will place more ranks
+# than the host has cores
+pyre-mpi.ext.binding = ${if ${findstring openmpi,$(mpi.flavor)},--bind-to none,}
+# assemble the harness
+pyre-mpi.ext.harness = $(mpi.executive) $(pyre-mpi.ext.binding) $(pyre-mpi.ext.hostfile)
+
+
+# on some machines, running multiple mpi tests at the same time causes trouble
+# serialize the test suite; the introspection tests come first, since they touch no runtime
+tests.mpi.ext.libmpi_sanity.pre := tests.mpi.ext.sanity
+tests.mpi.ext.libmpi_enums.pre := tests.mpi.ext.libmpi_sanity
+tests.mpi.ext.libmpi_exceptions.pre := tests.mpi.ext.libmpi_enums
+tests.mpi.ext.libmpi_runtime.pre := tests.mpi.ext.libmpi_exceptions
+tests.mpi.ext.libmpi_communicator.pre := tests.mpi.ext.libmpi_runtime
+tests.mpi.ext.libmpi_group.pre := tests.mpi.ext.libmpi_communicator
+tests.mpi.ext.libmpi_reductions.pre := tests.mpi.ext.libmpi_group
+tests.mpi.ext.libmpi_collectives.pre := tests.mpi.ext.libmpi_reductions
+tests.mpi.ext.libmpi_port.pre := tests.mpi.ext.libmpi_collectives
+tests.mpi.ext.libmpi_nonblocking.pre := tests.mpi.ext.libmpi_port
+tests.mpi.ext.libmpi_cartesian.pre := tests.mpi.ext.libmpi_nonblocking
+
+
+# the behavioral tests each run twice: once serially against a lone process, so the bindings are
+# known to work with no mpi machine at all, and once under the launcher against a real one
+
+# {libmpi_exceptions} has cases
+tests.mpi.ext.libmpi_exceptions.cases := \
+    tests.pyre-mpi.ext.libmpi_exceptions.serial tests.pyre-mpi.ext.libmpi_exceptions.parallel
+# {serial} runs as is
+# {parallel} has a harness
+tests.pyre-mpi.ext.libmpi_exceptions.parallel.harness = $(pyre-mpi.ext.harness) -np 8
+
+# {libmpi_runtime} has cases
+tests.mpi.ext.libmpi_runtime.cases := \
+    tests.pyre-mpi.ext.libmpi_runtime.serial tests.pyre-mpi.ext.libmpi_runtime.parallel
+# {serial} runs as is
+# {parallel} has a harness
+tests.pyre-mpi.ext.libmpi_runtime.parallel.harness = $(pyre-mpi.ext.harness) -np 8
+
+# {libmpi_communicator} has cases
+tests.mpi.ext.libmpi_communicator.cases := \
+    tests.pyre-mpi.ext.libmpi_communicator.serial tests.pyre-mpi.ext.libmpi_communicator.parallel
+# {serial} runs as is
+# {parallel} has a harness
+tests.pyre-mpi.ext.libmpi_communicator.parallel.harness = $(pyre-mpi.ext.harness) -np 8
+
+# {libmpi_group} has cases
+tests.mpi.ext.libmpi_group.cases := \
+    tests.pyre-mpi.ext.libmpi_group.serial tests.pyre-mpi.ext.libmpi_group.parallel
+# {serial} runs as is
+# {parallel} has a harness
+tests.pyre-mpi.ext.libmpi_group.parallel.harness = $(pyre-mpi.ext.harness) -np 7
+
+# {libmpi_reductions} has cases
+tests.mpi.ext.libmpi_reductions.cases := \
+    tests.pyre-mpi.ext.libmpi_reductions.serial tests.pyre-mpi.ext.libmpi_reductions.parallel
+# {serial} runs as is
+# {parallel} has a harness
+tests.pyre-mpi.ext.libmpi_reductions.parallel.harness = $(pyre-mpi.ext.harness) -np 8
+
+# {libmpi_collectives} has cases
+tests.mpi.ext.libmpi_collectives.cases := \
+    tests.pyre-mpi.ext.libmpi_collectives.serial tests.pyre-mpi.ext.libmpi_collectives.parallel
+# {serial} runs as is
+# {parallel} has a harness
+tests.pyre-mpi.ext.libmpi_collectives.parallel.harness = $(pyre-mpi.ext.harness) -np 8
+
+# {libmpi_port} has cases
+tests.mpi.ext.libmpi_port.cases := \
+    tests.pyre-mpi.ext.libmpi_port.serial tests.pyre-mpi.ext.libmpi_port.parallel
+# {serial} runs as is
+# {parallel} has a harness
+tests.pyre-mpi.ext.libmpi_port.parallel.harness = $(pyre-mpi.ext.harness) -np 4
+
+# {libmpi_nonblocking} has cases
+tests.mpi.ext.libmpi_nonblocking.cases := \
+    tests.pyre-mpi.ext.libmpi_nonblocking.serial tests.pyre-mpi.ext.libmpi_nonblocking.parallel
+# {serial} runs as is
+# {parallel} has a harness
+tests.pyre-mpi.ext.libmpi_nonblocking.parallel.harness = $(pyre-mpi.ext.harness) -np 4
+
+# {libmpi_cartesian} has cases
+tests.mpi.ext.libmpi_cartesian.cases := \
+    tests.pyre-mpi.ext.libmpi_cartesian.serial tests.pyre-mpi.ext.libmpi_cartesian.parallel
+# {serial} runs as is
+# {parallel} has a harness
+tests.pyre-mpi.ext.libmpi_cartesian.parallel.harness = $(pyre-mpi.ext.harness) -np 8
+
+
+# end of file

--- a/.mm/pyre-mpi.mm
+++ b/.mm/pyre-mpi.mm
@@ -18,7 +18,7 @@ pyre-mpi.libraries := pyre-mpi.lib
 # a python extension
 pyre-mpi.extensions := pyre-mpi.ext
 # and test suites
-pyre-mpi.tests := pyre-mpi.pkg.tests pyre-mpi.lib.tests
+pyre-mpi.tests := pyre-mpi.pkg.tests pyre-mpi.ext.tests pyre-mpi.lib.tests
 
 
 # the mpi package meta-data
@@ -52,7 +52,7 @@ pyre-mpi.ext.lib.c++.defines += $(pyre-mpi.lib.c++.defines)
 
 
 # get the testsuites
-include pyre-mpi.pkg.tests pyre-mpi.lib.tests
+include pyre-mpi.pkg.tests pyre-mpi.ext.tests pyre-mpi.lib.tests
 
 
 endif

--- a/tests/mpi.ext/libmpi_cartesian.py
+++ b/tests/mpi.ext/libmpi_cartesian.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the cartesian communicator bindings: arrange the processes on a grid and walk it by
+coordinates, by rank, and by stepping along an axis
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # bring mpi up, arranging for the shutdown
+    mpi.init()
+    # get the world communicator straight from the bindings
+    libmpi = mpi.libmpi
+    world = libmpi.world()
+    # and its size
+    size = world.size
+
+    # lay every process out on a single, non-wrapping axis; hold the numbering fixed so that a
+    # process keeps the rank it had in the world, and its coordinate is exactly that rank
+    line = world.cartesian(axes=[size], periods=[0], reorder=0)
+    # my rank within the grid
+    rank = line.rank
+
+    # the grid has one axis
+    assert line.dimensions == 1
+    # whose extent is the process count
+    assert line.axes == [size]
+    # which does not wrap
+    assert line.periods == [0]
+
+    # with the numbering fixed, i sit at the coordinate that matches my rank
+    assert line.coordinates() == [rank]
+    # asking about a named rank agrees
+    assert line.coordinates(rank) == [rank]
+    # and the inverse recovers the rank that sits at a coordinate
+    assert line.rankAt([rank]) == rank
+
+    # stepping one place along the axis names my two neighbors: the one that would send to me,
+    # and the one i would send to
+    behind, ahead = line.shift(direction=0, displacement=1)
+    # at the low end nobody precedes me, so the axis does not wrap and the walk falls off
+    if rank == 0:
+        assert behind == libmpi.procNull
+    # everywhere else my predecessor is one step back
+    else:
+        assert behind == rank - 1
+    # at the high end nobody follows me
+    if rank == size - 1:
+        assert ahead == libmpi.procNull
+    # everywhere else my successor is one step on
+    else:
+        assert ahead == rank + 1
+
+    # keeping the only axis spans the whole grid again
+    whole = line.sub(keep=[1])
+    assert isinstance(whole, libmpi.Cartesian)
+    assert whole.size == size
+
+    # dropping it leaves each process alone on a grid of one
+    alone = line.sub(keep=[0])
+    assert isinstance(alone, libmpi.Cartesian)
+    assert alone.size == 1
+
+    # when the process count is an even number greater than one, a two by half grid exercises the
+    # multi-axis paths the single axis above cannot reach
+    if size > 1 and size % 2 == 0:
+        # arrange the processes on two rows, wrapping the second axis, numbering held fixed
+        grid = world.cartesian(axes=[2, size // 2], periods=[1, 1], reorder=0)
+        # the grid has two axes
+        assert grid.dimensions == 2
+        # of the shape we asked for
+        assert grid.axes == [2, size // 2]
+        # where my coordinate and my rank name the same spot both ways
+        here = grid.coordinates()
+        assert grid.rankAt(here) == grid.rank
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_collectives.py
+++ b/tests/mpi.ext/libmpi_collectives.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the collectives that move data rather than combine it: the number versions, which cross
+the binding as lists, and the object versions, which pickle whatever they are handed
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # bring mpi up, arranging for the shutdown
+    mpi.init()
+    # get the world communicator straight from the bindings
+    libmpi = mpi.libmpi
+    world = libmpi.world()
+    # and its structure
+    size = world.size
+    rank = world.rank
+
+    # gather every rank at the root, where a c++ vector of cells crosses the binding as a list
+    gathered = world.gather(rank, 0)
+    # only the root collects
+    if rank == 0:
+        assert gathered == list(range(size))
+    # and everybody else is told so
+    else:
+        assert gathered is None
+
+    # the same, delivered to everybody
+    assert world.allgather(rank) == list(range(size))
+
+    # scatter one cell per process from the root; only the root's list matters
+    parcels = [2 * slot for slot in range(size)] if rank == 0 else []
+    # each process receives the cell addressed to it
+    assert world.scatter(parcels, 0) == 2 * rank
+
+    # every process hands one cell to every process, each carrying its own rank
+    assert world.alltoall([rank] * size) == list(range(size))
+
+    # broadcast an object from rank zero; only the source supplies one, and everybody rebuilds it
+    word = world.bcast({"greeting": "hello", "from": 0} if rank == 0 else None, 0)
+    assert word == {"greeting": "hello", "from": 0}
+
+    # the object collectives carry whatever pickle can flatten, so each process brings a value of
+    # a different type and a different size
+    mine = {"rank": rank, "payload": "x" * (rank + 1)}
+
+    # collect them all at the root
+    collected = world.gatherObject(mine, 0)
+    # only the root collects
+    if rank == 0:
+        assert collected == [{"rank": slot, "payload": "x" * (slot + 1)} for slot in range(size)]
+    # and everybody else is told so
+    else:
+        assert collected is None
+
+    # the same, delivered to everybody
+    everyone = world.allgatherObject(mine)
+    # one object per process
+    assert len(everyone) == size
+    # the last of which carries the longest payload
+    assert everyone[size - 1] == {"rank": size - 1, "payload": "x" * size}
+
+    # hand an object of a different type and size to each process; only the root's matter
+    bundles = [("rank", slot) * (slot + 1) for slot in range(size)] if rank == 0 else None
+    # each process receives the one addressed to it
+    assert world.scatterObject(bundles, 0) == ("rank", rank) * (rank + 1)
+
+    # every process hands one object to every process, sized as its sender decided
+    deliveries = [{"from": rank, "pad": "y" * (2 * rank + peer)} for peer in range(size)]
+    # exchange
+    received = world.alltoallObject(deliveries)
+    # so i receive one object from each process, in rank order
+    assert received == [{"from": peer, "pad": "y" * (2 * peer + rank)} for peer in range(size)]
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_communicator.py
+++ b/tests/mpi.ext/libmpi_communicator.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the communicator bindings: its structure, its comparisons, and the factories that carve
+new communicators, groups, ports, and grids out of it
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # bring mpi up, arranging for the shutdown
+    mpi.init()
+    # get the world communicator straight from the bindings
+    libmpi = mpi.libmpi
+    world = libmpi.world()
+    # and its structure
+    size = world.size
+    rank = world.rank
+
+    # a real communicator is true and not null
+    assert bool(world) is True
+    assert world.isNull() is False
+
+    # the set of processes it holds is a group of the same size, in which i have the same rank
+    group = world.group()
+    assert group.size == size
+    assert group.rank == rank
+
+    # a communicator is identical to itself
+    assert world.compare(world) == libmpi.Comparison.identical
+
+    # a duplicate has my membership but a fresh context, so it is a genuine communicator
+    twin = world.duplicate()
+    assert isinstance(twin, libmpi.Communicator)
+    # with the same members in the same order, but a handle of its own: congruent, not identical
+    assert world.compare(twin) == libmpi.Comparison.congruent
+
+    # splitting by parity lands me in the communicator of my color
+    mine = world.split(rank % 2)
+    # which is a real communicator, since every color here is valid
+    assert isinstance(mine, libmpi.Communicator)
+    # and it holds every process of my parity
+    assert mine.size == len([peer for peer in range(size) if peer % 2 == rank % 2])
+
+    # including a single rank builds a communicator only that rank belongs to
+    lone = world.include([0])
+    # so rank zero gets a communicator of one
+    if rank == 0:
+        assert lone is not None
+        assert lone.size == 1
+    # and everybody else is left out, and told so
+    else:
+        assert lone is None
+
+    # excluding rank zero builds the complement
+    rest = world.exclude([0])
+    # which rank zero is not part of
+    if rank == 0:
+        assert rest is None
+    # while everybody else lands in a communicator one smaller than the world
+    else:
+        assert rest is not None
+        assert rest.size == size - 1
+
+    # restricting to my whole group hands everybody a communicator congruent to me
+    full = world.restrict(world.group())
+    assert full is not None
+    assert full.size == size
+
+    # a port to a peer is a genuine conduit
+    conduit = world.port(peer=rank, tag=3)
+    assert isinstance(conduit, libmpi.Port)
+    # that remembers the peer and the label
+    assert conduit.peer == rank
+    assert conduit.tag == 3
+
+    # laying my processes out on a one dimensional grid hands back a cartesian communicator
+    grid = world.cartesian(axes=[size], periods=[0])
+    assert isinstance(grid, libmpi.Cartesian)
+    # which, being a communicator, still knows how many processes it holds
+    assert grid.size == size
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_enums.py
+++ b/tests/mpi.ext/libmpi_enums.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that every enumeration the bindings publish carries the members the collectives and the
+comparisons name, and that the members of each are distinct
+"""
+
+
+def test():
+    # access the bindings directly, without bringing mpi up
+    from mpi import libmpi
+
+    # the reduction operators, grouped as the c++ layer groups them
+    ops = [
+        # arithmetic
+        libmpi.Op.sum,
+        libmpi.Op.product,
+        libmpi.Op.maximum,
+        libmpi.Op.minimum,
+        # logical
+        libmpi.Op.logicalAnd,
+        libmpi.Op.logicalOr,
+        libmpi.Op.logicalXor,
+        # bitwise
+        libmpi.Op.bitwiseAnd,
+        libmpi.Op.bitwiseOr,
+        libmpi.Op.bitwiseXor,
+        # the extrema paired with the rank that supplied them
+        libmpi.Op.maxloc,
+        libmpi.Op.minloc,
+        # last one wins
+        libmpi.Op.replace,
+    ]
+    # no two operators may share a value, or a reduction would silently do the wrong thing
+    assert len(set(ops)) == len(ops)
+
+    # the outcomes of a comparison
+    comparisons = [
+        libmpi.Comparison.identical,
+        libmpi.Comparison.congruent,
+        libmpi.Comparison.similar,
+        libmpi.Comparison.unequal,
+    ]
+    # likewise distinct
+    assert len(set(comparisons)) == len(comparisons)
+
+    # the levels of thread support
+    threads = [
+        libmpi.Thread.single,
+        libmpi.Thread.funneled,
+        libmpi.Thread.serialized,
+        libmpi.Thread.multiple,
+    ]
+    # and these too
+    assert len(set(threads)) == len(threads)
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_exceptions.py
+++ b/tests/mpi.ext/libmpi_exceptions.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that the exception hierarchy the bindings register has the right shape, and that a failed
+call arrives in python under its own name rather than its parent's
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # and the bindings themselves
+    libmpi = mpi.libmpi
+
+    # the base of everything the package raises derives from python's own {Exception}, so a
+    # caller who knows nothing of mpi can still catch it
+    assert issubclass(libmpi.Error, Exception)
+    # a failed mpi call is an {Error}
+    assert issubclass(libmpi.MPIError, libmpi.Error)
+    # and so is an argument whose shape does not fit
+    assert issubclass(libmpi.ShapeError, libmpi.Error)
+    # but a shape error is not an mpi failure, and neither derives from the other
+    assert not issubclass(libmpi.ShapeError, libmpi.MPIError)
+    assert not issubclass(libmpi.MPIError, libmpi.ShapeError)
+
+    # bring mpi up, arranging for the shutdown
+    mpi.init()
+    # get the world communicator straight from the bindings
+    world = libmpi.world()
+    # and its size
+    size = world.size
+    # and my rank
+    rank = world.rank
+
+    # a scatter whose root offers the wrong number of cells is refused; this needs a peer to
+    # scatter to, so only attempt it when there is more than one process
+    if size > 1 and rank == 0:
+        # plant a flag
+        refused = False
+        # ask for the impossible
+        try:
+            # one cell too few for the processes waiting on it
+            world.scatter([0] * (size - 1), 0)
+        # the mismatch must arrive under its own name, not as the base {Error}
+        except libmpi.ShapeError:
+            refused = True
+        # check that it did
+        assert refused
+
+        # and the very same failure must still be caught when the handler asks only for the base
+        refused = False
+        # ask again
+        try:
+            world.scatter([0] * (size - 1), 0)
+        # a {ShapeError} is an {Error}, so this must catch it too
+        except libmpi.Error:
+            refused = True
+        # check
+        assert refused
+
+    # the processes that did not raise must not wait for the one that did
+    world.barrier()
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_group.py
+++ b/tests/mpi.ext/libmpi_group.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the group bindings: membership, the set operations python spells as methods, the
+comparisons, and the translation of ranks from one group to another
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # bring mpi up, arranging for the shutdown
+    mpi.init()
+    # get the world communicator straight from the bindings
+    libmpi = mpi.libmpi
+    world = libmpi.world()
+    # and its structure
+    size = world.size
+    rank = world.rank
+
+    # the group of every process in the world
+    everyone = world.group()
+    # holds them all
+    assert everyone.size == size
+    # in which i have my usual rank
+    assert everyone.rank == rank
+    # it has members, so it is not empty
+    assert everyone.isEmpty() is False
+    # and it names a real group, so it is not null
+    assert everyone.isNull() is False
+    # which makes it true in a boolean test
+    assert bool(everyone) is True
+
+    # the group of the even ranks
+    evens = everyone.include([peer for peer in range(size) if peer % 2 == 0])
+    # holds exactly half of them, rounding up
+    assert evens.size == (size + 1) // 2
+
+    # the group with rank zero left out
+    others = everyone.exclude([0])
+    # is one smaller than the world
+    assert others.size == size - 1
+
+    # the union of the two covers everybody the world holds, since between them they leave
+    # nobody out
+    union = evens.union(others)
+    assert union.size == size
+
+    # the intersection holds the even ranks other than zero
+    intersection = evens.intersection(others)
+    assert intersection.size == len([peer for peer in range(size) if peer % 2 == 0 and peer != 0])
+
+    # the difference holds only what {evens} has and {others} does not, which is rank zero alone
+    difference = evens.difference(others)
+    assert difference.size == (1 if size > 0 else 0)
+
+    # a group is identical to itself
+    assert everyone.compare(everyone) == libmpi.Comparison.identical
+    # a freshly built group with the same members in the same order shares its membership, so it
+    # compares equal one way or the other: congruent in general, or identical when mpi hands back
+    # the very same handle, as it does for a lone process
+    twin = everyone.include(list(range(size)))
+    assert everyone.compare(twin) in (libmpi.Comparison.identical, libmpi.Comparison.congruent)
+
+    # the members of the even group carry ranks of their own inside it, from zero on up
+    local = list(range(evens.size))
+    # translating those back to the world recovers the even ranks, in order
+    world_ranks = evens.translateRanks(local, everyone)
+    assert world_ranks == [peer for peer in range(size) if peer % 2 == 0]
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_nonblocking.py
+++ b/tests/mpi.ext/libmpi_nonblocking.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the transfers that hand back a receipt instead of blocking, the receipt itself, the
+report it completes into, and the collective waits the module publishes
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # bring mpi up, arranging for the shutdown
+    mpi.init()
+    # get the world communicator straight from the bindings
+    libmpi = mpi.libmpi
+    world = libmpi.world()
+    # and its structure
+    size = world.size
+    rank = world.rank
+
+    # place the processes on a ring: the one i send to, and the one i hear from
+    following = (rank + 1) % size
+    preceding = (rank - 1) % size
+
+    # the payload i ship says who sent it
+    payload = bytes([rank, 0xAB])
+
+    # post the receive first, so the message has somewhere to land, then the send; neither call
+    # blocks, so the ring needs no parity split
+    inbox = bytearray(2)
+    pending = [
+        world.irecvBytes(inbox, preceding, 5),
+        world.isendBytes(payload, following, 5),
+    ]
+    # a fresh receipt names a transfer that has not completed
+    assert all(receipt.active for receipt in pending)
+    # and is true while it is in flight
+    assert all(bool(receipt) for receipt in pending)
+
+    # block until both are done, reaching the wait that lives on the module
+    reports = libmpi.waitAll(pending)
+    # one report per transfer
+    assert len(reports) == 2
+    # and waiting has emptied every receipt
+    assert not any(receipt.active for receipt in pending)
+    # so a spent receipt is false
+    assert not any(bool(receipt) for receipt in pending)
+
+    # the payload came round the ring
+    assert bytes(inbox) == bytes([preceding, 0xAB])
+
+    # the report of the receive tells the whole story of the transfer
+    report = reports[0]
+    # who sent it
+    assert report.source == preceding
+    # the label it carried
+    assert report.tag == 5
+    # how many octets arrived
+    assert report.bytes == 2
+    # that it was not cancelled
+    assert report.cancelled is False
+    # that its own status code is a whole number, zero when nothing went wrong
+    assert isinstance(report.error, int)
+    # and that it renders as a readable summary
+    assert "mpi.Status" in repr(report)
+
+    # the same, but waiting for whichever transfer finishes first
+    again = bytearray(2)
+    pending = [
+        world.irecvBytes(again, preceding, 6),
+        world.isendBytes(payload, following, 6),
+    ]
+    # wait for one of them
+    index, outcome = libmpi.waitAny(pending)
+    # it names one of the two
+    assert index in (0, 1)
+    # and that receipt is now empty, while the other may still be in flight
+    assert not pending[index].active
+    # finish whatever is left
+    libmpi.waitAll(pending)
+    # and the payload came round once more
+    assert bytes(again) == bytes([preceding, 0xAB])
+
+    # a receipt can also be polled without blocking: post a pair, then ask until the receive says
+    # it is done, which hands back a report where an empty poll hands back {None}
+    landing = bytearray(2)
+    receiving = world.irecvBytes(landing, preceding, 8)
+    sending = world.isendBytes(payload, following, 8)
+    # spin on the non-blocking poll
+    polled = receiving.test()
+    while polled is None:
+        polled = receiving.test()
+    # once it completes, the poll reports on the very same transfer
+    assert polled.source == preceding
+    # and clears the receipt
+    assert not receiving.active
+    # let the matching send drain
+    sending.wait()
+
+    # mpi writes into the buffer long after the call that started the transfer returned, so the
+    # receipt must hold on to it; without that, a buffer nobody else names would be reclaimed
+    # while the transfer was still writing into it
+    import sys
+
+    # make one, and count who refers to it
+    orphan = bytearray(2)
+    before = sys.getrefcount(orphan)
+    # start a transfer into it
+    receipt = world.irecvBytes(orphan, preceding, 13)
+    # and somebody new refers to it now: the receipt
+    assert sys.getrefcount(orphan) > before
+    # so the transfer lands in it, no matter who else lets go
+    libmpi.waitAll([receipt, world.isendBytes(payload, following, 13)])
+    # carrying what the process before me sent
+    assert bytes(orphan) == bytes([preceding, 0xAB])
+    # and once the receipt is spent and gone, so is its claim on the buffer
+    del receipt
+    assert sys.getrefcount(orphan) == before
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_port.py
+++ b/tests/mpi.ext/libmpi_port.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the conduit bindings: build ports both ways the module offers, and move text, raw
+octets, and arbitrary objects around a ring of processes
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # bring mpi up, arranging for the shutdown
+    mpi.init()
+    # get the world communicator straight from the bindings
+    libmpi = mpi.libmpi
+    world = libmpi.world()
+    # and its structure
+    size = world.size
+    rank = world.rank
+
+    # a ring needs at least two processes; with one there is nobody to talk to
+    if size < 2:
+        return
+
+    # the process i will hear from, and the one i will send to
+    preceding = (rank - 1) % size
+    following = (rank + 1) % size
+
+    # build the conduit to my predecessor the way a communicator hands it over
+    source = world.port(peer=preceding, tag=1)
+    # and the one to my successor by asking the bound constructor directly
+    destination = libmpi.Port(communicator=world, peer=following, tag=1)
+    # both remember the communicator they belong to
+    assert destination.communicator.size == size
+    # the peer at the other end
+    assert source.peer == preceding
+    # and the label their messages carry
+    assert source.tag == 1
+
+    # ship text to my successor, then take the text my predecessor shipped me
+    destination.sendString(f"hello {following}")
+    assert source.recvString() == f"hello {rank}"
+
+    # the same, but flattening an arbitrary object on the way out and rebuilding it on the way in
+    destination.send({"to": following, "ring": True})
+    assert source.recv() == {"to": rank, "ring": True}
+
+    # and once more with raw octets, which must come back byte for byte
+    destination.sendBytes(bytes([rank, 0xEE]))
+    assert source.recvBytes() == bytes([preceding, 0xEE])
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_reductions.py
+++ b/tests/mpi.ext/libmpi_reductions.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the reduction family that the bindings spell as named methods: the whole-number and
+real-number overloads must be told apart by the argument, and naming a destination must deliver
+the answer to that rank alone
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # bring mpi up, arranging for the shutdown
+    mpi.init()
+    # get the world communicator straight from the bindings
+    libmpi = mpi.libmpi
+    world = libmpi.world()
+    # and its structure
+    size = world.size
+    rank = world.rank
+    # the sum of every rank, which the checks below lean on
+    total = size * (size - 1) // 2
+
+    # a sum over whole numbers is dispatched to the integral overload, so it stays whole
+    whole = world.sum(item=rank)
+    assert isinstance(whole, int)
+    # and adds up
+    assert whole == total
+
+    # a sum over real numbers is dispatched to the real overload, so it stays real
+    real = world.sum(item=float(rank))
+    assert isinstance(real, float)
+    # and adds up too
+    assert real == float(total)
+
+    # the product, the max, and the min, each delivered to everybody
+    assert world.max(item=rank) == size - 1
+    assert world.min(item=rank) == 0
+    # the product of the ranks is zero once rank zero joins in
+    assert world.product(item=rank) == 0
+
+    # naming a destination delivers the answer to that rank alone
+    largest = world.max(item=rank, destination=0)
+    # so only the root sees it
+    if rank == 0:
+        assert largest == size - 1
+    # and everybody else is handed nothing
+    else:
+        assert largest is None
+
+    # the collectives that name their operator rather than implying it agree with the above
+    assert world.allreduce(rank, libmpi.Op.sum) == total
+    # and preserve the cell type in the same way
+    assert isinstance(world.allreduce(float(rank), libmpi.Op.sum), float)
+
+    # an inclusive scan hands me the sum over everybody who precedes me, myself included
+    assert world.scan(rank, libmpi.Op.sum) == rank * (rank + 1) // 2
+
+    # the exclusive one leaves me out, and the standard leaves it undefined at rank zero
+    running = world.exscan(rank, libmpi.Op.sum)
+    if rank == 0:
+        assert running is None
+    # everywhere else it is the sum over my strict predecessors
+    else:
+        assert running == rank * (rank - 1) // 2
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_runtime.py
+++ b/tests/mpi.ext/libmpi_runtime.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the module level runtime: bring mpi up, ask it what it granted, and check the standard
+communicators, the clock, and the host name
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # and the bindings themselves
+    libmpi = mpi.libmpi
+
+    # importing the package does not bring mpi up, so nothing has been initialized yet
+    assert libmpi.initialized() is False
+    # and nothing has been taken down
+    assert libmpi.finalized() is False
+
+    # bring mpi up through the package, which also arranges for the shutdown at exit; asking for
+    # the level of thread support reports what mpi settled on, as one of the levels it names
+    granted = libmpi.initialize()
+    # which is one of the {Thread} values
+    assert isinstance(granted, libmpi.Thread)
+    # and the package's own {init} agrees mpi is now up
+    mpi.init()
+    # so the runtime says so
+    assert libmpi.initialized() is True
+
+    # the communicator that holds every process in the job
+    world = libmpi.world()
+    # its size is at least one
+    assert world.size >= 1
+    # and my rank sits inside it
+    assert world.rank in range(world.size)
+
+    # the communicator that holds this process alone
+    alone = libmpi.self()
+    # has exactly one member
+    assert alone.size == 1
+    # in which i am the only rank
+    assert alone.rank == 0
+
+    # the communicator that holds nobody at all
+    nothing = libmpi.null()
+    # names no communicator
+    assert nothing.isNull() is True
+    # so it is false in a boolean test
+    assert bool(nothing) is False
+
+    # the clock hands back a real number of seconds
+    assert isinstance(libmpi.wtime(), float)
+    # and its resolution is a positive number of seconds
+    assert libmpi.wtick() > 0.0
+
+    # time only moves forward, so a later reading is no earlier than an earlier one
+    first = libmpi.wtime()
+    second = libmpi.wtime()
+    assert second >= first
+
+    # the host this process runs on has a name
+    host = libmpi.processorName()
+    # which is a non-empty string
+    assert isinstance(host, str)
+    assert len(host) > 0
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/libmpi_sanity.py
+++ b/tests/mpi.ext/libmpi_sanity.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Sanity check: verify that the bindings module publishes every entity its clients are told to
+expect, so that a missing or misnamed binding is caught here rather than deep inside a test that
+happens to lean on it
+"""
+
+
+def test():
+    # access the bindings directly, without bringing mpi up
+    from mpi import libmpi
+
+    # the structural classes the module hands back
+    assert libmpi.Communicator is not None
+    assert libmpi.Cartesian is not None
+    assert libmpi.Group is not None
+    assert libmpi.Port is not None
+    assert libmpi.Request is not None
+    assert libmpi.Status is not None
+
+    # the cartesian communicator is a refinement of the plain one
+    assert issubclass(libmpi.Cartesian, libmpi.Communicator)
+
+    # the enumerations
+    assert libmpi.Op is not None
+    assert libmpi.Comparison is not None
+    assert libmpi.Thread is not None
+
+    # the exception hierarchy
+    assert libmpi.Error is not None
+    assert libmpi.MPIError is not None
+    assert libmpi.ShapeError is not None
+
+    # the runtime entry points
+    assert callable(libmpi.initialize)
+    assert callable(libmpi.finalize)
+    assert callable(libmpi.initialized)
+    assert callable(libmpi.finalized)
+
+    # the standard communicators
+    assert callable(libmpi.world)
+    assert callable(libmpi.self)
+    assert callable(libmpi.null)
+
+    # the clock and the host
+    assert callable(libmpi.wtime)
+    assert callable(libmpi.wtick)
+    assert callable(libmpi.processorName)
+
+    # the collective waits that live on the module, since neither belongs to a single receipt
+    assert callable(libmpi.waitAll)
+    assert callable(libmpi.waitAny)
+
+    # the constants, each of which is a whole number
+    assert isinstance(libmpi.undefined, int)
+    assert isinstance(libmpi.anySource, int)
+    assert isinstance(libmpi.anyTag, int)
+    assert isinstance(libmpi.procNull, int)
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/mpi.ext/localhost
+++ b/tests/mpi.ext/localhost
@@ -1,0 +1,1 @@
+localhost slots=8

--- a/tests/mpi.ext/sanity.py
+++ b/tests/mpi.ext/sanity.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Sanity check: verify that the bindings module is present and loadable
+"""
+
+
+def test():
+    # access the package that hosts the bindings
+    import mpi
+
+    # the extension module must have loaded; a {None} here means this machine has no mpi, and
+    # this suite has no business running at all
+    assert mpi.libmpi is not None
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file


### PR DESCRIPTION
Adds `tests/mpi.ext/`, a test suite that drives the `pyre::mpi` pybind11 bindings directly (`from mpi import libmpi`) rather than through the `mpi` package wrappers, so a binding-layer regression is isolated to a named test rather than surfacing indirectly through the package tests.

## Coverage

12 drivers, one concern each:

- `sanity`, `libmpi_sanity`, `libmpi_enums` — introspection: the module loads and publishes every class, enum, exception, constant, and function its clients expect. Serial only.
- `libmpi_exceptions` — the `Error`/`MPIError`/`ShapeError` hierarchy, and that a failed call arrives under its own name.
- `libmpi_runtime` — init/finalize state, `world`/`self`/`null`, the clock, the host name.
- `libmpi_communicator` — structure, `compare`/`duplicate`/`split`/`include`/`exclude`/`restrict`/`port`/`cartesian`.
- `libmpi_group` — membership, the set operations, `compare`, `translateRanks`.
- `libmpi_reductions` — the int/real overload dispatch, the `destination` handling, `scan`/`exscan`.
- `libmpi_collectives` — the number collectives (list ↔ vector) and the object collectives (pickle), plus `bcast`.
- `libmpi_port` — both port constructors; text, object, and raw-byte round-trips on a ring.
- `libmpi_nonblocking` — `isend`/`irecv`, the `Request` and `Status` surface, `waitAll`/`waitAny`, and the keep-alive that ties a buffer's life to its receipt.
- `libmpi_cartesian` — grid layout, `coordinates`/`rankAt`/`shift`/`sub`.

Each behavioral driver runs twice: once serially against a lone process, so the bindings are known to work with no mpi machine at all, and once under the launcher against a real one.

## Build

`.mm/pyre-mpi.ext.tests` mirrors `pyre-mpi.pkg.tests` (serialized `.pre` chain, per-driver serial/parallel cases and harnesses); registered in `.mm/pyre-mpi.mm`.

## Verification

- Every driver silent serially and at its rank count under `mpiexec`.
- `mm tests.mpi.ext.libmpi_cartesian` runs the full chain green.