### PR TITLE
ci: drop libpq from the conda environment

### DIFF
--- a/.github/matrix/conda.yml
+++ b/.github/matrix/conda.yml
@@ -30,8 +30,6 @@ dependencies:
   # the native external packages
   - gsl
   - hdf5
-  # libpq lets the postgres bindings load
-  - libpq
   # numpy, for the gsl test suite
   - numpy
   # skip openmpi until {pyre.platforms} has a conda package manager


### PR DESCRIPTION
libpq was added to the conda CI environment temporarily, to move the failure past the `ImportError` net in `pyre.extensions` while diagnosing the postgres pybind11 migration.

With libpq present, the postgres extension builds and its tests run — but the conda runners have no postgres server, and there is no server-skip net, so the connection-dependent tests (`libpq_connect`, `libpq_execute`, `libpq_async`, and the `postgres_*` component tests) fail.

Dropping libpq restores the last-known-green state: postgres is gated out entirely (not found → not built → the binding import is caught at `pyre/extensions/__init__.py:41`), so the conda workflows go green again.

Standing up a real postgres server in CI (a `services: postgres:` container with `PG*` env wired to it) would let these tests actually run, but that is a separate piece of work, not a revert.