### PR TITLE
mpi: make the python package available without the mpi runtime

### DIFF
--- a/.cmake/pyre_mpi.cmake
+++ b/.cmake/pyre_mpi.cmake
@@ -5,26 +5,25 @@
 
 
 function(pyre_mpiPackage)
-  # if we have mpi
-  if(${MPI_FOUND})
-    # install the sources straight from the source directory
-    install(
-      DIRECTORY packages/mpi
-      DESTINATION ${PYRE_DEST_PACKAGES}
-      FILES_MATCHING PATTERN *.py
-      )
-    # build the package meta-data
-    configure_file(
-      packages/mpi/meta.py.in packages/mpi/meta.py
-      @ONLY
-      )
-    # install the generated package meta-data file
-    install(
-      DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/packages/mpi
-      DESTINATION ${PYRE_DEST_PACKAGES}
-      FILES_MATCHING PATTERN *.py
-      )
-  endif()
+  # the pure-python {mpi} package ships unconditionally: it degrades to a trivial single-process
+  # communicator when the {libmpi} bindings are absent, so code written against it runs anywhere
+  # install the sources straight from the source directory
+  install(
+    DIRECTORY packages/mpi
+    DESTINATION ${PYRE_DEST_PACKAGES}
+    FILES_MATCHING PATTERN *.py
+    )
+  # build the package meta-data
+  configure_file(
+    packages/mpi/meta.py.in packages/mpi/meta.py
+    @ONLY
+    )
+  # install the generated package meta-data file
+  install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/packages/mpi
+    DESTINATION ${PYRE_DEST_PACKAGES}
+    FILES_MATCHING PATTERN *.py
+    )
   # all done
 endfunction(pyre_mpiPackage)
 

--- a/.mm/pyre-mpi.mm
+++ b/.mm/pyre-mpi.mm
@@ -7,12 +7,21 @@
 # check availability
 mpi.available := ${findstring mpi,$(extern.available)}
 
-# if {mpi} is available
+
+# the pure-python {mpi} package ships unconditionally: it degrades to a trivial single-process
+# communicator when the {libmpi} bindings are absent, so code written against it runs anywhere
+pyre-mpi.packages := pyre-mpi.pkg
+
+# the mpi package meta-data
+pyre-mpi.pkg.root := packages/mpi/
+pyre-mpi.pkg.stem := mpi
+pyre-mpi.pkg.ext :=
+
+
+# the library and the extension that wraps it need the actual mpi runtime
 ifeq ($(mpi.available), mpi)
 
 
-# mpi builds a python package
-pyre-mpi.packages := pyre-mpi.pkg
 # a library
 pyre-mpi.libraries := pyre-mpi.lib
 # a python extension
@@ -20,11 +29,6 @@ pyre-mpi.extensions := pyre-mpi.ext
 # and test suites
 pyre-mpi.tests := pyre-mpi.pkg.tests pyre-mpi.ext.tests pyre-mpi.lib.tests
 
-
-# the mpi package meta-data
-pyre-mpi.pkg.root := packages/mpi/
-pyre-mpi.pkg.stem := mpi
-pyre-mpi.pkg.ext :=
 
 # the mpi library meta-data
 pyre-mpi.lib.root := lib/mpi/

--- a/packages/mpi/__init__.py
+++ b/packages/mpi/__init__.py
@@ -30,10 +30,11 @@ world = TrivialCommunicator()
 try:
     # try to load the bindings
     from . import libmpi
-# if they were never built, this machine has no mpi; note that the exception must be this
-# narrow: bindings that exist but refuse to load are a bug, and a bug that presents itself as
-# the tranquil absence of mpi is one that nobody ever finds
-except ModuleNotFoundError:
+# treat any import failure as the absence of mpi: a relative {from . import libmpi} reports a
+# missing binding as a plain {ImportError} rather than {ModuleNotFoundError}, and on some
+# platforms a binding that is present can still fail to load for benign reasons; until we
+# understand that platform behaviour, the safe reading of any failure here is "no mpi runtime"
+except ImportError:
     # indicate that there is no runtime support
     libmpi = None
 


### PR DESCRIPTION
Make the pure-Python `mpi` package available regardless of whether the mpi runtime
is present at build time. The package already degrades to a `TrivialCommunicator`
(a one-process communicator) when the bindings are absent, so code written against
it — e.g. `gsl.matrix.bcast` / `gsl.vector.collect` — runs unchanged on a machine
with no mpi. Two things prevented that from working:

- The build shipped nothing at all without the mpi external: `.mm/pyre-mpi.mm` and
  `.cmake/pyre_mpi.cmake` gated the entire project — including the pure-Python
  package — on the runtime, so `import mpi` failed with `ModuleNotFoundError`.
- The degradation net in `packages/mpi/__init__.py` caught `ModuleNotFoundError`,
  but a relative `from . import libmpi` reports a missing binding as a plain
  `ImportError`, so the net missed it. This never surfaced only because the package
  was never installed without the bindings.

## Changes

- `packages/mpi/__init__.py`: catch `ImportError` when loading the bindings, so an
  absent (or benignly unloadable) `libmpi` degrades to no-runtime rather than
  raising.
- `.mm/pyre-mpi.mm`: build and install `pyre-mpi.pkg` unconditionally; keep
  `pyre-mpi.lib`, `pyre-mpi.ext`, and the test suites gated on `mpi.available`.
- `.cmake/pyre_mpi.cmake`: install the Python package unconditionally; the library
  and extension stay gated on `MPI_FOUND`.

## Verification

Built with mpi present (no regression). With `libmpi` hidden to simulate a no-mpi
build, `import mpi` yields `libmpi = None` and `world = TrivialCommunicator`, and
`gsl.matrix.bcast(matrix=m)` — the call that was failing in conda CI — completes
single-process.
