### PR TITLE
ci: fix the h5 extension info target after the pyre-h5 rename

### DIFF
--- a/.github/workflows/mm.yaml
+++ b/.github/workflows/mm.yaml
@@ -191,7 +191,7 @@ jobs:
           echo " -- verifying the journal extension"
           ${mm} journal.ext.info
           echo " -- verifying the h5 extension"
-          ${mm} h5.ext.info
+          ${mm} pyre-h5.ext.info
         env:
           mm: python3 ${{github.workspace}}/mm/mm --config=.github/matrix/mm.pfg
           target: ${{matrix.target}}


### PR DESCRIPTION
The `mm` workflow logged the h5 bindings with `mm h5.ext.info`, but PR #196 moved the extension into the `pyre-h5` sub-project, so the target is now `pyre-h5.ext` and `h5.ext` resolves to nothing.

Update the info step in `.github/workflows/mm.yaml` to `mm pyre-h5.ext.info`.

Verified locally: `mm pyre-h5.ext.info` dumps the extension metadata (exit 0); `mm h5.ext.info` produces nothing.