### PR TITLE
postgres: build pyre::postgres as its own sub-project

### DIFF
--- a/.mm/projects.mm
+++ b/.mm/projects.mm
@@ -5,6 +5,6 @@
 
 # establish the build order; {merlin} leads so it stages the {lib/mm} portinfo headers
 # into {include/mm} before any project with C++ sources compiles against them
-projects := merlin chroma pyre journal pyre-h5 pyre-mpi pyre-gsl pyre-cuda survey
+projects := merlin chroma pyre journal pyre-h5 pyre-postgres pyre-mpi pyre-gsl pyre-cuda survey
 
 # end of file

--- a/.mm/pyre-postgres.ext.tests
+++ b/.mm/pyre-postgres.ext.tests
@@ -5,8 +5,8 @@
 
 
 # the postgres extension testsuite
-postgres.ext.tests.stem := postgres.ext
-postgres.ext.tests.prerequisites := journal.lib postgres.lib journal.pkg pyre.pkg
+pyre-postgres.ext.tests.stem := postgres.ext
+pyre-postgres.ext.tests.prerequisites := pyre-postgres.ext journal.pkg pyre.pkg
 
 
 # the following tests pound on the test database; execute them in order

--- a/.mm/pyre-postgres.lib.tests
+++ b/.mm/pyre-postgres.lib.tests
@@ -5,13 +5,13 @@
 
 
 # the postgres library testsuite
-postgres.lib.tests.stem := postgres.lib
-postgres.lib.tests.prerequisites := postgres.lib journal.lib
-postgres.lib.tests.extern := postgres.lib journal.lib libpq
+pyre-postgres.lib.tests.stem := postgres.lib
+pyre-postgres.lib.tests.prerequisites := pyre-postgres.lib
+pyre-postgres.lib.tests.extern := pyre-postgres.lib journal.lib libpq
 
 # c++ compiler arguments
-postgres.lib.tests.c++.defines += $(pyre.lib.c++.defines)
-postgres.lib.tests.c++.flags += -Wall $(pyre.lib.c++.flags)
+pyre-postgres.lib.tests.c++.defines += $(pyre.lib.c++.defines)
+pyre-postgres.lib.tests.c++.flags += -Wall $(pyre.lib.c++.flags)
 
 
 # every driver below {sanity} needs a live server, and they all talk to the same one; the ones

--- a/.mm/pyre-postgres.mm
+++ b/.mm/pyre-postgres.mm
@@ -1,0 +1,59 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# check availability
+libpq.available := ${findstring libpq,$(extern.available)}
+
+# if {libpq} is available
+ifeq ($(libpq.available), libpq)
+
+
+# postgres ships no python package of its own; its python lives in {packages/pyre/db}, part of
+# {pyre.pkg}
+pyre-postgres.packages :=
+# a library
+pyre-postgres.libraries := pyre-postgres.lib
+# a python extension, deposited into the {pyre} package that hosts it
+pyre-postgres.extensions := pyre-postgres.ext
+# the library stands on its own, so it gets a c++ suite of its own; the extension suite exercises
+# the bindings. everything past {sanity} needs a live server
+pyre-postgres.tests := pyre-postgres.lib.tests pyre-postgres.ext.tests
+
+
+# the postgres library meta-data; it is header only, and it knows nothing about python
+pyre-postgres.lib.root := lib/postgres/
+pyre-postgres.lib.stem := postgres
+# deposit the headers under the {pyre} namespace so they never collide in a shared prefix
+pyre-postgres.lib.incdir := $(builder.dest.inc)pyre/postgres/
+# the gateway header is deposited one level above the rest, as {pyre/postgres.h}
+pyre-postgres.lib.gateway := postgres.h
+pyre-postgres.lib.prerequisites := journal.lib
+pyre-postgres.lib.extern := journal.lib libpq
+pyre-postgres.lib.c++.flags += $(pyre.lib.c++.flags)
+pyre-postgres.lib.c++.defines += $(pyre.lib.c++.defines)
+
+# the postgres extension meta-data; it wraps the library above
+pyre-postgres.ext.root := extensions/postgres/
+# the module stays {postgres}; {packages/pyre/extensions} re-exports it as {libpq}
+pyre-postgres.ext.stem := postgres
+# the module rides in the {pyre} package, alongside {libpyre}
+pyre-postgres.ext.pkg := pyre.pkg
+pyre-postgres.ext.wraps := pyre-postgres.lib
+pyre-postgres.ext.capsule :=
+pyre-postgres.ext.extern := pyre.lib journal.lib libpq pybind11 python
+pyre-postgres.ext.lib.c++.flags += $(pyre-postgres.lib.c++.flags)
+pyre-postgres.ext.lib.c++.defines += $(pyre-postgres.lib.c++.defines)
+pyre-postgres.ext.lib.prerequisites += pyre-postgres.lib journal.lib # pyre.lib is added automatically
+
+
+# get the testsuites
+include pyre-postgres.lib.tests pyre-postgres.ext.tests
+
+
+endif
+
+
+# end of file

--- a/.mm/pyre.mm
+++ b/.mm/pyre.mm
@@ -39,15 +39,6 @@ pyre.c++20 = \
   }
 
 
-# if we have {libpq}, build the {pyre::postgres} library, the extension that wraps it, and test
-# both; the library stands on its own, so it gets a suite of its own that never loads python
-${if ${findstring libpq,$(extern.available)},\
-    ${eval pyre.libraries += postgres.lib} \
-    ${eval pyre.extensions += postgres.ext} \
-    ${eval pyre.tests += postgres.lib.tests postgres.ext.tests} \
-}
-
-
 # the pyre package meta-data
 pyre.pkg.root := packages/pyre/
 pyre.pkg.stem := pyre
@@ -94,31 +85,6 @@ host.ext.extern := journal.lib python
 host.ext.lib.c++.flags += $(pyre.lib.c++.flags)
 host.ext.lib.c++.defines += $(pyre.lib.c++.defines)
 host.ext.lib.prerequisites += journal.lib # pyre.lib is added automatically
-
-
-# postgres
-# the {pyre::postgres} library meta-data; it is header only, and it knows nothing about python
-postgres.lib.root := lib/postgres/
-postgres.lib.stem := postgres
-# deposit the headers under the {pyre} namespace so they never collide in a shared prefix
-postgres.lib.incdir := $(builder.dest.inc)pyre/postgres/
-# the gateway header is deposited one level above the rest, as {pyre/postgres.h}
-postgres.lib.gateway := postgres.h
-postgres.lib.prerequisites := journal.lib
-postgres.lib.extern := journal.lib libpq
-postgres.lib.c++.flags += $(pyre.lib.c++.flags)
-postgres.lib.c++.defines += $(pyre.lib.c++.defines)
-
-# the {postgres} extension meta-data; it wraps the library above
-postgres.ext.root := extensions/postgres/
-postgres.ext.stem := postgres
-postgres.ext.pkg := pyre.pkg
-postgres.ext.wraps := postgres.lib
-postgres.ext.capsule :=
-postgres.ext.extern := pyre.lib journal.lib libpq pybind11 python
-postgres.ext.lib.c++.flags += $(pyre.lib.c++.flags)
-postgres.ext.lib.c++.defines += $(pyre.lib.c++.defines)
-postgres.ext.lib.prerequisites += postgres.lib journal.lib # pyre.lib is added automatically
 
 
 # the docker images


### PR DESCRIPTION
Factor the `pyre::postgres` build out of `pyre.mm` into its own `pyre-postgres.mm`
sub-project, matching `pyre-mpi` and `pyre-h5`. Build-config only; no source moves
(`lib/postgres`, `extensions/postgres`, `tests/postgres.{lib,ext}` stay put).

## Changes

- New `.mm/pyre-postgres.mm` holds the library + extension meta-data, gated on
  `libpq`. The header-only library installs its headers under `include/pyre/postgres/`
  with the gateway at `include/pyre/postgres.h` (unchanged); the extension module
  stays `postgres`, deposited into `pyre.pkg` and re-exported as `libpq`.
- Removed the postgres blocks from `.mm/pyre.mm`.
- Added `pyre-postgres` to the `projects` build order.
- Renamed the test configs `.mm/postgres.{lib,ext}.tests` → `.mm/pyre-postgres.{lib,ext}.tests`.
- Corrected the test-suite prerequisites so each suite builds standalone from a clean
  context: `pyre-postgres.ext.tests` now depends on `pyre-postgres.ext` (previously it
  never built the binding, so `libpq` was `None`); `pyre-postgres.lib.tests` depends on
  `pyre-postgres.lib`.

## Verification

Full build green; `from pyre.extensions import libpq` and `import pyre.db` both work.
From `mm clean`, `mm pyre-postgres.lib.tests` and `mm pyre-postgres.ext.tests` each
build their dependencies and pass (against a live server).
