### PR TITLE
mpi: Group.include/exclude accept any iterable, not just a list

### DIFF
--- a/extensions/mpi/Group.cc
+++ b/extensions/mpi/Group.cc
@@ -11,6 +11,26 @@
 #include "forward.h"
 
 
+// helpers local to this translation unit
+namespace pyre::mpi::py {
+    // materialize any python iterable of ranks into a rank vector; accepting an iterable rather
+    // than insisting on a {list} lets callers pass a comprehension or a lazy generator expression
+    inline auto
+    asRanks(const py::iterable & ranks) -> Group::ranks_type
+    {
+        // start with an empty rank vector
+        auto members = Group::ranks_type{};
+        // drain the iterable, casting each item to a rank
+        for (const auto & rank : ranks) {
+            // fold it in
+            members.push_back(rank.cast<Group::ranks_type::value_type>());
+        }
+        // hand back the materialized ranks
+        return members;
+    }
+}
+
+
 // add the bindings for the process group
 void
 pyre::mpi::py::group(py::module & m)
@@ -73,8 +93,10 @@ pyre::mpi::py::group(py::module & m)
     cls.def(
         // the name
         "include",
-        // the implementation
-        &Group::include,
+        // the implementation: materialize any iterable of ranks, then delegate to the c++ layer
+        [](const Group & self, const py::iterable & ranks) -> Group {
+            return self.include(asRanks(ranks));
+        },
         // the signature
         "ranks"_a,
         // the docstring
@@ -83,8 +105,10 @@ pyre::mpi::py::group(py::module & m)
     cls.def(
         // the name
         "exclude",
-        // the implementation
-        &Group::exclude,
+        // the implementation: materialize any iterable of ranks, then delegate to the c++ layer
+        [](const Group & self, const py::iterable & ranks) -> Group {
+            return self.exclude(asRanks(ranks));
+        },
         // the signature
         "ranks"_a,
         // the docstring


### PR DESCRIPTION
## Problem

`Group.include` / `Group.exclude` are bound directly off the C++ methods, whose parameter is
`ranks_type` (`std::vector<int>`), so pybind11 exposes them as `List[int]`. But the package tests
pass a **generator**:

```python
evens = whole.include(rank for rank in range(world.size) if rank % 2 == 0)
```

pybind11 will not cast a generator to a `std::vector`, so this raises
`TypeError: include(): incompatible function arguments`. The tests' clear intent is that these
accept any iterable.

This was latent until `tests/mpi.pkg/group_include.py` and `group_exclude.py` began running
**multi-rank** (they used to be vacuous single-rank harnesses); a from-scratch multi-rank run in a
Docker container surfaced it.

## Fix

Bind `include`/`exclude` through small lambdas that accept `py::iterable` and materialize it into a
`ranks_type` via a local `asRanks` helper, then delegate to the C++ implementation. A list, a
`range`, or a lazy generator expression all work now.

## Verification

Full `mm tests` suite (including `group_include`/`group_exclude` at `-np 7`) passes in an
`ubuntu:24.04` + clang container.