### PR TITLE
merlin: mirror the mm dpkg hdf5/mpi variant-subdir discovery fix

### DIFF
--- a/packages/merlin/shells/MM.py
+++ b/packages/merlin/shells/MM.py
@@ -2378,11 +2378,38 @@ class MM(pyre.application, family="pyre.applications.mm", namespace="mm"):
                     if pyVersion:
                         print(f"python.version ?= {pyVersion}", file=f)
                     print(f"python.dir ?= $(dpkg.prefix)", file=f)
-                # mpi needs its flavor to select the right library names
+                # mpi: debian/ubuntu tuck the flavor's headers and libraries under a
+                # {<multiarch>/<flavor>} subtree ({openmpi/include}, {openmpi/lib}) rather than the
+                # bare {dir}/include and {dir}/lib, so read the real locations from {dpkg -L}
                 elif name == "mpi":
-                    print(f"mpi.dir ?= $(dpkg.prefix)", file=f)
+                    # the flavor selects the library names downstream
                     flavor = "openmpi" if "openmpi" in candidate else "mpich"
                     print(f"mpi.flavor ?= {flavor}", file=f)
+                    # the files the dev package installed
+                    files = self._dpkgFiles(dpkg, candidate)
+                    # locate the C header — the one on an {include} path, not the fortran module —
+                    # and the runtime library's dev symlink
+                    header = next(
+                        (p for p in files if p.name == "mpi.h" and "/include/" in str(p)),
+                        None,
+                    )
+                    library = next(
+                        (p for p in files if p.name == "libmpi.so"), None
+                    )
+                    # point the include path at wherever {mpi.h} really lives
+                    if header:
+                        print(
+                            f"mpi.incpath ?= {self._dpkgAnchor(header.parent, prefix)}",
+                            file=f,
+                        )
+                    # and the library path at wherever the dev symlink really lives
+                    if library:
+                        print(
+                            f"mpi.libpath ?= {self._dpkgAnchor(library.parent, prefix)}",
+                            file=f,
+                        )
+                    # anchor the package root like everything else
+                    print(f"mpi.dir ?= $(dpkg.prefix)", file=f)
                 # numpy headers live under the python package directory
                 elif name == "numpy":
                     includePath = self._queryPythonExpression(
@@ -2411,6 +2438,38 @@ class MM(pyre.application, family="pyre.applications.mm", namespace="mm"):
                             print(f"pybind11.dir ?= {pybind11Root}", file=f)
                     else:
                         print(f"pybind11.dir ?= $(dpkg.prefix)", file=f)
+                # hdf5: debian/ubuntu split the flavors into variant subdirectories — headers under
+                # {include/hdf5/<variant>} and libraries under {lib/<multiarch>/hdf5/<variant>} — so
+                # the bare {dir}/include and {dir}/lib defaults miss them; read the real locations
+                # from {dpkg -L}, which also reveals the variant and hence {hdf5.parallel}
+                elif name == "hdf5":
+                    # the files the dev package installed
+                    files = self._dpkgFiles(dpkg, candidate)
+                    # locate the umbrella header and the dev-symlink library
+                    header = next((path for path in files if path.name == "hdf5.h"), None)
+                    library = next(
+                        (path for path in files if path.name == "libhdf5.so"), None
+                    )
+                    # point the include path at wherever {hdf5.h} really lives
+                    if header:
+                        print(
+                            f"hdf5.incpath ?= {self._dpkgAnchor(header.parent, prefix)}",
+                            file=f,
+                        )
+                    # and the library path at wherever the dev symlink really lives
+                    if library:
+                        print(
+                            f"hdf5.libpath ?= {self._dpkgAnchor(library.parent, prefix)}",
+                            file=f,
+                        )
+                    # the enclosing directory name is the flavor and doubles as {hdf5.parallel}:
+                    # {serial} is a plain build; {openmpi}/{mpich} name mpi, so the {findstring mpi}
+                    # gate in hdf5/init.mm folds mpi into {hdf5.dependencies} for parallel builds
+                    variant = header.parent.name if header else "serial"
+                    # {hdf5.parallel} carries the flavor name so parallel builds induce the mpi edge
+                    print(f"hdf5.parallel ?= {variant}", file=f)
+                    # anchor the package root like everything else
+                    print(f"hdf5.dir ?= $(dpkg.prefix)", file=f)
                 # all other packages anchor to the dpkg prefix
                 else:
                     print(f"{name}.dir ?= $(dpkg.prefix)", file=f)

--- a/share/mm/make/extern/hdf5/init.mm
+++ b/share/mm/make/extern/hdf5/init.mm
@@ -10,10 +10,11 @@ extern += ${if ${filter hdf5,$(extern)},,hdf5}
 # find my configuration file
 hdf5.config := ${dir ${call extern.config,hdf5}}
 
-hdf5.parallel ?= off
-# {parallel} selects serial vs mpi-aware hdf5, so it must always carry a value; declare it required
+hdf5.parallel ?= serial
+# {parallel} names the build flavor: {serial} is a plain build, {openmpi}/{mpich} are mpi-aware and
+# induce the mpi dependency below; it must always carry a value, so declare it required
 hdf5.markers.required ?= parallel
-hdf5.markers.required.hint ?= "(hdf5.parallel must be 'on' or 'off')"
+hdf5.markers.required.hint ?= "(hdf5.parallel must be 'serial', 'openmpi', or 'mpich')"
 
 # compiler flags
 hdf5.flags ?=


### PR DESCRIPTION
Pyre bundles an embedded clone of the `mm` build tool (`packages/merlin/shells/MM.py`, a copy of
mm's `Builder`) plus a straight copy of mm's make engine under `share/mm/make/`. This mirrors the
dpkg discovery fix from **aivazis/mm#49** into both so pyre's bundled mm discovers hdf5/mpi correctly
on Debian/Ubuntu.

## Changes

- **`packages/merlin/shells/MM.py`** — `_buildDpkgPackageDatabase` gains bespoke hdf5 and mpi emitter
  branches that read the real include/lib locations from `dpkg -L` (Ubuntu tucks them into
  `hdf5/serial`, `openmpi/include`, … variant subdirs the bare `$(dir)/include` default misses).
  hdf5 emits `hdf5.parallel` = the flavor so the make engine's `findstring mpi` gate owns the
  transitive mpi edge.
- **`share/mm/make/extern/hdf5/init.mm`** — corrects the stale `hdf5.parallel` marker hint
  (`on/off` → `serial`/`openmpi`/`mpich`) and default (`off` → `serial`), matching the make engine.

Identical in intent to aivazis/mm#49; kept as a separate PR because it lives in the pyre repo. The
expected `merlin mm` banner difference in `share/mm/make/mm/rules.mm` is left untouched.

## Verification

The standalone mm (aivazis/mm#49) with this same logic builds pyre from scratch against apt packages
in an `ubuntu:24.04` container with the full test suite green.