### PR TITLE
merlin: mirror the mm dpkg libpq header discovery fix

### DIFF
--- a/packages/merlin/shells/MM.py
+++ b/packages/merlin/shells/MM.py
@@ -2470,6 +2470,29 @@ class MM(pyre.application, family="pyre.applications.mm", namespace="mm"):
                     print(f"hdf5.parallel ?= {variant}", file=f)
                     # anchor the package root like everything else
                     print(f"hdf5.dir ?= $(dpkg.prefix)", file=f)
+                # libpq: debian/ubuntu put the client headers in a {postgresql} subdirectory of
+                # {/usr/include} that the bare {dir}/include default misses, and the library in the
+                # multiarch lib dir; read both real locations from {dpkg -L}
+                elif name == "libpq":
+                    # the files the dev package installed
+                    files = self._dpkgFiles(dpkg, candidate)
+                    # locate the client header and the dev-symlink library
+                    header = next((p for p in files if p.name == "libpq-fe.h"), None)
+                    library = next((p for p in files if p.name == "libpq.so"), None)
+                    # point the include path at wherever {libpq-fe.h} really lives
+                    if header:
+                        print(
+                            f"libpq.incpath ?= {self._dpkgAnchor(header.parent, prefix)}",
+                            file=f,
+                        )
+                    # and the library path at wherever the dev symlink really lives
+                    if library:
+                        print(
+                            f"libpq.libpath ?= {self._dpkgAnchor(library.parent, prefix)}",
+                            file=f,
+                        )
+                    # anchor the package root like everything else
+                    print(f"libpq.dir ?= $(dpkg.prefix)", file=f)
                 # all other packages anchor to the dpkg prefix
                 else:
                     print(f"{name}.dir ?= $(dpkg.prefix)", file=f)


### PR DESCRIPTION
Mirrors the dpkg discovery fix from **aivazis/mm#50** into pyre's embedded clone of mm's `Builder`
(`packages/merlin/shells/MM.py`), so pyre's bundled mm finds `libpq` correctly on Debian/Ubuntu.

## Change

`_buildDpkgPackageDatabase` gains a `libpq` emitter branch: `libpq-dev` puts `libpq-fe.h` in
`/usr/include/postgresql/` and `libpq.so` in the multiarch lib dir, which the bare `$(dir)/include`
default misses. Read the real locations from `dpkg -L` and emit `libpq.incpath` / `libpq.libpath`.

Same shape as the hdf5/mpi branches from #202. No make-engine change needed this time (only the
Python emitter), so no `share/mm/make` update.

## Verification

With aivazis/mm#50 (same logic) the `pyre-postgres` bindings compile against a live postgresql-16
server in an `ubuntu:24.04` container; without it they fail on `libpq-fe.h not found`.