### PR TITLE
math: correct the constexpr {asin}/{acos} domains

### DIFF
--- a/.cmake/pyre_tests_pyre_lib.cmake
+++ b/.cmake/pyre_tests_pyre_lib.cmake
@@ -349,6 +349,8 @@ set_property(TEST tests.pyre.lib.viz.iterators.polarsaw.cleanup PROPERTY
   )
 
 
+# math
+pyre_test_driver(tests/pyre.lib/math/transcendental.cc)
 
 
 # tensor

--- a/lib/pyre/math/transcendental.icc
+++ b/lib/pyre/math/transcendental.icc
@@ -192,6 +192,14 @@ constexpr auto
 pyre::math::asin(double x) -> double
 {
     if (std::is_constant_evaluated()) {
+        // pin the endpoints: the {atan} argument would divide by zero at |x| == 1
+        if (x == 1.0) {
+            return M_PI / 2.0;
+        }
+        if (x == -1.0) {
+            return -M_PI / 2.0;
+        }
+        // elsewhere on the domain use the identity {asin(x) = atan(x / sqrt(1 - x^2))}
         return pyre::math::atan(x / pyre::math::sqrt(1.0 - x * x));
     } else {
         return std::asin(x);
@@ -203,7 +211,9 @@ constexpr auto
 pyre::math::acos(double x) -> double
 {
     if (std::is_constant_evaluated()) {
-        return pyre::math::atan(pyre::math::sqrt(1.0 - x * x) / x);
+        // use the identity {acos(x) = pi/2 - asin(x)}; valid across the whole domain and
+        // correctly landing in [0, pi] for negative {x} where {atan(sqrt(1 - x^2) / x)} would not
+        return M_PI / 2.0 - pyre::math::asin(x);
     } else {
         return std::acos(x);
     }

--- a/tests/pyre.lib/math/transcendental.cc
+++ b/tests/pyre.lib/math/transcendental.cc
@@ -1,0 +1,73 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+#include <cassert>
+#include <cmath>
+// get the constexpr transcendental functions
+#include <pyre/math.h>
+
+
+// compare two doubles to within an absolute tolerance
+constexpr auto
+close(double a, double b, double tol = 1.0e-9) -> bool
+{
+    // the signed difference
+    const auto d = a - b;
+    // its magnitude is within tolerance
+    return (d < 0.0 ? -d : d) < tol;
+}
+
+
+// the constant pi, to full double precision
+constexpr auto pi = M_PI;
+
+
+// verify {asin} across its domain, endpoints included, at compile time
+// the endpoints used to divide by zero in {atan(x / sqrt(1 - x^2))}, making them non-constexpr
+static_assert(close(pyre::math::asin(0.0), 0.0));
+static_assert(close(pyre::math::asin(1.0), pi / 2.0));
+static_assert(close(pyre::math::asin(-1.0), -pi / 2.0));
+static_assert(close(pyre::math::asin(0.5), pi / 6.0));
+static_assert(close(pyre::math::asin(-0.5), -pi / 6.0));
+
+// verify {acos} across its domain, endpoints included, at compile time
+// {acos(0)} used to divide by zero and {acos(x < 0)} used to land outside [0, pi] with the wrong sign
+static_assert(close(pyre::math::acos(0.0), pi / 2.0));
+static_assert(close(pyre::math::acos(1.0), 0.0));
+static_assert(close(pyre::math::acos(-1.0), pi));
+static_assert(close(pyre::math::acos(0.5), pi / 3.0));
+static_assert(close(pyre::math::acos(-0.5), 2.0 * pi / 3.0));
+
+// verify the {acos(x) = pi/2 - asin(x)} identity holds at compile time across the domain
+static_assert(close(pyre::math::acos(0.25) + pyre::math::asin(0.25), pi / 2.0));
+static_assert(close(pyre::math::acos(-0.75) + pyre::math::asin(-0.75), pi / 2.0));
+
+
+// main program
+int
+main(int argc, char * argv[])
+{
+    // exercise the same domain at run time, where the functions delegate to the standard library;
+    // this pins the constexpr path to the runtime path so the two cannot silently diverge
+    assert(close(pyre::math::asin(1.0), std::asin(1.0)));
+    assert(close(pyre::math::asin(-1.0), std::asin(-1.0)));
+    assert(close(pyre::math::asin(0.5), std::asin(0.5)));
+    assert(close(pyre::math::acos(0.0), std::acos(0.0)));
+    assert(close(pyre::math::acos(-0.5), std::acos(-0.5)));
+    assert(close(pyre::math::acos(-1.0), std::acos(-1.0)));
+
+    // out-of-domain inputs yield NaN, matching the standard library
+    assert(std::isnan(pyre::math::asin(2.0)));
+    assert(std::isnan(pyre::math::acos(-2.0)));
+
+    // all done
+    return 0;
+}
+
+
+// end of file


### PR DESCRIPTION
Fixes the domains of the `constexpr` inverse-trig functions added in the tensor work and adds a dedicated test.

### The bugs

The compile-time branches of `pyre::math::asin` and `pyre::math::acos` were only valid on part of their domains:

- **`asin(±1)`** — `atan(x / sqrt(1 - x*x))` divides by zero at the endpoints, which is UB in a constant expression (the endpoints were not usable at compile time).
- **`acos(0)`** — `atan(sqrt(1 - x*x) / x)` divides by zero.
- **`acos(x < 0)`** — the same formula lands in `(-π/2, 0)` instead of `(π/2, π)`, i.e. wrong by π (e.g. `acos(-0.5)` gave `-π/3` instead of `2π/3`).
- **`acos(-1)`** — gave `0` instead of `π`.

### The fix

- `asin`: pin the `±1` endpoints explicitly, avoiding the division by zero; use the `atan` identity elsewhere.
- `acos`: use the identity `acos(x) = π/2 - asin(x)`, which is correct across the whole domain and lands in `[0, π]` for negative `x`.

Out-of-domain inputs still yield `NaN`, matching the standard library, and the runtime branches are unchanged (they delegate to `std::asin`/`std::acos`).

### Test

Adds `tests/pyre.lib/math/transcendental.cc` — the first test under `tests/pyre.lib/math/`. It covers the fix at **compile time** via `static_assert` (endpoints, zero, negative arguments, and the `acos = π/2 - asin` identity) and at **run time**, where it also pins the constexpr path to the standard-library path so the two cannot silently diverge. Wired into both `mm` (c++20-gated exclude list) and CMake (`pyre_test_driver_cxx20`).

Verified with `mm tests.pyre.lib.math` on clang/c++23.
