### PR TITLE
Import code coverage support into merlin

### DIFF
--- a/share/mm/make/compilers/clang/clang++.mm
+++ b/share/mm/make/compilers/clang/clang++.mm
@@ -37,7 +37,13 @@ clang++.compile.isysroot := -isysroot
 clang++.debug := -g
 clang++.reldeb := -Og -fno-omit-frame-pointer
 clang++.opt := -O3
-clang++.cov := --coverage
+# llvm source based coverage; richer than the gcov compatible {--coverage} because it records
+# regions and branches rather than lines, and it resolves templates correctly. the same string is
+# valid at both compile and link time, so the single target variable serves both categories
+clang++.cov := -fprofile-instr-generate -fcoverage-mapping
+# the flag that rewrites a source path prefix in the coverage mapping; the coverage machinery uses it
+# to map installed header paths back to their source tree so the report attributes to editable files
+clang++.cov.prefixmap := -fcoverage-prefix-map
 clang++.prof := -pg
 clang++.shared := -fPIC
 # openmp support

--- a/share/mm/make/compilers/clang/clang.mm
+++ b/share/mm/make/compilers/clang/clang.mm
@@ -31,7 +31,13 @@ clang.compile.isysroot := -isysroot
 clang.debug := -g
 clang.opt := -O3
 clang.reldeb := -Og -fno-omit-frame-pointer
-clang.cov := --coverage
+# llvm source based coverage; richer than the gcov compatible {--coverage} because it records
+# regions and branches rather than lines, and it resolves templates correctly. the same string is
+# valid at both compile and link time, so the single target variable serves both categories
+clang.cov := -fprofile-instr-generate -fcoverage-mapping
+# the flag that rewrites a source path prefix in the coverage mapping; the coverage machinery uses it
+# to map installed header paths back to their source tree so the report attributes to editable files
+clang.cov.prefixmap := -fcoverage-prefix-map
 clang.prof := -pg
 clang.shared := -fPIC
 # openmp support

--- a/share/mm/make/compilers/clang/flang.mm
+++ b/share/mm/make/compilers/clang/flang.mm
@@ -33,8 +33,14 @@ flang.debug := -g
 # VERIFY: gfortran uses -g -O; using -g -O2 here as a conservative LLVM-friendly choice
 flang.reldeb := -g -O2
 flang.opt := -O3
-# VERIFY: --coverage (LLVM style) vs -coverage (GCC style); flang-new likely uses --coverage
-flang.cov := --coverage
+# match the llvm source based coverage the {clang} front ends use, so a mixed c++/fortran binary
+# links against a single coverage runtime and its objects feed the same {llvm-profdata} merge.
+# VERIFY: flang's coverage support trails clang's; if a build rejects these, fall back to the gcov
+# compatible {--coverage} and read this suite's fortran with {gcov}/{gcovr} instead of {llvm-cov}
+flang.cov := -fprofile-instr-generate -fcoverage-mapping
+# the flag that rewrites a source path prefix in the coverage mapping; the coverage machinery uses it
+# to map installed header paths back to their source tree so the report attributes to editable files
+flang.cov.prefixmap := -fcoverage-prefix-map
 # VERIFY: gprof-style -pg has limited support in LLVM Fortran; may silently do nothing
 flang.prof := -pg
 flang.shared := -fPIC

--- a/share/mm/make/compilers/gcc/g++.mm
+++ b/share/mm/make/compilers/gcc/g++.mm
@@ -32,6 +32,9 @@ g++.debug := -g
 g++.reldeb := -g -O
 g++.opt := -O3
 g++.cov := --coverage
+# the flag that rewrites a source path prefix in the coverage notes; the coverage machinery uses it to
+# map installed header paths back to their source tree so the report attributes to editable files
+g++.cov.prefixmap := -fprofile-prefix-map
 g++.prof := -pg
 g++.shared := -fPIC
 # openmp support
@@ -57,9 +60,10 @@ g++.link.ext = $(platform.c++.ext)
 # command line options
 g++.defines = MM_COMPILER_gcc
 
-# clean up temporaries left behind while compiling
+# clean up temporaries left behind while compiling: the dependency file, plus the gcov coverage
+# notes and data ({.gcno}/{.gcda}) a {cov} build drops beside the object
 #  usage: g++.clean {base-name}
-g++.clean = $(1).d
+g++.clean = $(1).d $(1).gcno $(1).gcda
 
 # dependency generation
 # g++ does this in one pass: the dependency file gets generated during the compilation phase so

--- a/share/mm/make/compilers/gcc/gcc.mm
+++ b/share/mm/make/compilers/gcc/gcc.mm
@@ -32,6 +32,9 @@ gcc.debug := -g
 gcc.reldeb := -g -O
 gcc.opt := -O3
 gcc.cov := --coverage
+# the flag that rewrites a source path prefix in the coverage notes; the coverage machinery uses it to
+# map installed header paths back to their source tree so the report attributes to editable files
+gcc.cov.prefixmap := -fprofile-prefix-map
 gcc.prof := -pg
 gcc.shared := -fPIC
 # openmp support
@@ -53,9 +56,10 @@ gcc.link.ext = $(platform.c.ext)
 # command line options
 gcc.defines = MM_COMPILER_gcc
 
-# clean up temporaries left behind while compiling
+# clean up temporaries left behind while compiling: the dependency file, plus the gcov coverage
+# notes and data ({.gcno}/{.gcda}) a {cov} build drops beside the object
 #  usage: gcc.clean {base-name}
-gcc.clean = $(1).d
+gcc.clean = $(1).d $(1).gcno $(1).gcda
 
 # dependency generation
 # gcc does this in one pass: the dependency file gets generated during the compilation phase so

--- a/share/mm/make/compilers/gcc/gfortran.mm
+++ b/share/mm/make/compilers/gcc/gfortran.mm
@@ -31,6 +31,9 @@ gfortran.debug := -g
 gfortran.reldeb := -g -O
 gfortran.opt := -O3
 gfortran.cov := -coverage
+# the flag that rewrites a source path prefix in the coverage notes; the coverage machinery uses it to
+# map installed header paths back to their source tree so the report attributes to editable files
+gfortran.cov.prefixmap := -fprofile-prefix-map
 gfortran.prof := -pg
 gfortran.shared := -fPIC
 # openmp support
@@ -61,6 +64,11 @@ gfortran.mixed.libraries += gfortran
 # gfortran cannot generate dependencies
 define gfortran.makedep =
 endef
+
+# clean up temporaries left behind while compiling: the gcov coverage notes and data
+# ({.gcno}/{.gcda}) a {cov} build drops beside the object; gfortran emits no dependency file
+#  usage: gfortran.clean {base-name}
+gfortran.clean = $(1).gcno $(1).gcda
 
 
 # end of file

--- a/share/mm/make/compilers/init.mm
+++ b/share/mm/make/compilers/init.mm
@@ -121,6 +121,7 @@ ${strip
     platform.$(1)
     $(compiler.$(1))
     $(target.variants:%=targets.%.$(1))
+    ${if ${and ${filter cov,$(target.variants)},$($(compiler.$(1)).cov)},coverage.$(1)}
     $(developer:%=developers.%.$(1))
 }
 endef

--- a/share/mm/make/coverage/init.mm
+++ b/share/mm/make/coverage/init.mm
@@ -1,0 +1,33 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# whether a coverage build is in effect; set in the model pass once {target.variants} is final
+coverage.active ?=
+# the instrumentation back end: {llvm} for the clang family, {gcov} for gcc; resolved from the
+# c++ compiler in the model pass
+coverage.backend ?=
+# the directory that collects the raw per-run profile data and the rendered reports; anchored under
+# the staging area in the model pass, since these are derived products of a build, not shipped files
+coverage.raw ?=
+coverage.report ?=
+# the lcov interchange file the vscode {Coverage Gutters} extension and the html renderers consume
+coverage.info ?=
+# the merged, indexed profile the llvm reporters read; the single product of folding all the raw
+# per-run profiles together
+coverage.profdata ?=
+# the compiled test-driver binaries the report attributes template instantiations to; discovered
+# automatically from the registered test suites in the model pass
+coverage.drivers ?=
+# extra instrumented binaries a project wants folded into the llvm report beyond the shared libraries
+# and the test drivers mm discovers automatically; an escape hatch for binaries mm cannot find on its
+# own, not the normal path
+coverage.objects ?=
+# the {installed-header=source-header} pairs that map coverage paths back to the source tree, one per
+# library; computed from the library model in the model pass
+coverage.prefixmap ?=
+
+
+# end of file

--- a/share/mm/make/coverage/model.mm
+++ b/share/mm/make/coverage/model.mm
@@ -1,0 +1,118 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# a coverage build is one whose variants include {cov}; the target machinery has already folded the
+# {cov} compile and link flags in by this point, so all that is left is to arrange the post-run
+# reporting
+coverage.active := ${filter cov,$(target.variants)}
+
+# pick the instrumentation back end from the c++ compiler: the clang family emits llvm source based
+# coverage that {llvm-profdata}/{llvm-cov} consume, while gcc emits gcov data that {gcovr} reads
+coverage.backend := ${if ${filter clang%,$(compiler.c++)},llvm,gcov}
+
+# anchor the derived products under the staging area, in a sibling of the build tree so a
+# {coverage.clean} can wipe them without touching object files
+coverage.raw := $(builder.staging)coverage/raw/
+coverage.report := $(builder.staging)coverage/report/
+# the lcov file lands at the root of the coverage area, at a stable path the editor can watch
+coverage.info := $(builder.staging)coverage/lcov.info
+# the merged profile the llvm reporters index against
+coverage.profdata := $(builder.staging)coverage/merged.profdata
+
+# when the llvm back end is active, steer every instrumented process launched during the build --
+# most importantly the test drivers -- to write its own raw profile into the collection directory.
+# {%p} keys the file by pid and {%m} by the binary's coverage signature, so concurrent drivers and
+# distinct binaries never clobber one another; the runtime creates the directory tree on first
+# write. exporting it here, once, spares every test recipe from having to thread it through by hand
+ifneq ($(strip $(coverage.active)),)
+ifeq ($(coverage.backend),llvm)
+export LLVM_PROFILE_FILE := $(coverage.raw)%p-%m.profraw
+endif
+endif
+
+# tie the top level {coverage} target to the back end specific reporter now that {coverage.backend} is
+# final; the report recipes themselves live in the rules pass, following mm's split of rule templates
+# in {rules.mm} from their instantiation here
+${eval coverage: coverage.$(coverage.backend)}
+
+# the raw profiles the llvm reporter folds together; a recursively expanded {wildcard} so the glob
+# runs when the recipe fires, by which point the test run has deposited the files
+coverage.raws = ${wildcard $(coverage.raw)*.profraw}
+
+# the compiled test drivers, gathered from every registered suite. this matters because a header-only
+# template library instantiates most of its code into the drivers rather than into any shared library,
+# so a report built only from the installed {.so}s would not see it. recursively expanded so the walk
+# runs when a reporter fires: this class loads before {projects}, so the suite metadata is not yet final
+# here and a deferred read is required. each suite's {staging.targets} mixes compiled, staged, and
+# interpreted cases, so keep the ones flagged {compiled} and take their {base} binary
+coverage.drivers = \
+    ${if $(coverage.active), \
+        ${foreach suite,$(testsuites), \
+            ${foreach case,$($(suite).staging.targets), \
+                ${if $($(case).compiled),$($(case).base)} \
+            } \
+        } \
+    }
+# the instrumented binaries to attribute the profiles to: every shared library installed under the
+# prefix, the compiled test drivers, and whatever extra objects a project names through
+# {coverage.objects}. the {wildcard} over the drivers keeps only those a given run actually built, so a
+# partial test run never hands llvm-cov a missing {-object}
+coverage.binaries = \
+    ${wildcard $(builder.dest.lib)*.so $(builder.dest.lib)*.dylib} \
+    ${wildcard $(coverage.drivers)} \
+    $(coverage.objects)
+# llvm-cov takes the first binary as a positional argument and every subsequent one behind its own
+# {-object} flag; assemble that argument vector once for the three reporters to share
+coverage.objargs = \
+    ${firstword $(coverage.binaries)} \
+    ${patsubst %,-object %,${wordlist 2,${words $(coverage.binaries)},$(coverage.binaries)}}
+
+# rewrite installed header paths back to source. a test driver includes its project's headers from the
+# install prefix, so the coverage data records the installed copy's path; that makes gcov's reporter --
+# rooted at the project -- drop the headers, and makes the llvm reporter attribute them to the prefix
+# rather than to the tree the developer edits. for each library, map its installed header directory back
+# to the source directory the headers were copied from; both are already known to the library model. the
+# {sort} keys on the {incdir} left-hand side, and because a parent directory string sorts before any
+# child of it, this yields the general-to-specific order the compilers' last-match-wins mapping requires.
+# recursively expanded so it is evaluated where it is consumed -- in each object's compile options during
+# the projects pass -- by which point the libraries that object depends on have registered
+coverage.prefixmap = ${sort ${foreach lib,$(libraries),$($(lib).incdir)=$($(lib).prefix)}}
+
+# expose the coverage contribution to the compiler option machinery as a per language party:
+# {compiler.option.sources} adds a {coverage.<language>} source, but only when {cov} is selected and the
+# language's compiler instruments -- so these flags reach a compile if and only if the compiler actually
+# does coverage. a language participates only if its compiler names a non-trivial {cov} flag; an empty
+# {cov} means the compiler does not instrument, so it contributes nothing. for a participating language,
+# first initialize each option category to empty -- exactly as {target.init} does for its own party -- so
+# the option assembly, which queries every category, never expands an undefined
+# {coverage.<language>.<category>}. then, if the compiler also names a {cov.prefixmap} flag, fill in the
+# flags category with the map: recursively expanded so the map is computed at each object's bake, and
+# defined here -- before {projects} -- so it exists by the time the first workflow bakes. only the map
+# lookup is deferred; the language and its compiler's flag name are fixed now. {value} reads the compiler
+# slot and {origin} tests the prefix-map flag without expanding either, so a missing compiler or flag
+# trips no undefined-variable warning
+${foreach \
+    language, \
+    $(languages.compiled), \
+    ${if ${value compiler.$(language)}, \
+        ${if $($(compiler.$(language)).cov), \
+            ${foreach \
+                category, \
+                $(languages.$(language).categories), \
+                ${eval coverage.$(language).$(category) ?=} \
+            } \
+            ${if ${filter-out undefined,${origin $(compiler.$(language)).cov.prefixmap}}, \
+                ${eval \
+                    coverage.$(language).flags = \
+                        $${foreach pair,$$(coverage.prefixmap),$($(compiler.$(language)).cov.prefixmap)=$$(pair)} \
+                } \
+            } \
+        } \
+    } \
+}
+
+
+# end of file

--- a/share/mm/make/coverage/rules.mm
+++ b/share/mm/make/coverage/rules.mm
@@ -1,0 +1,75 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the coverage registry summary
+coverage.info-target:
+	@${call log.sec,"coverage","code coverage reporting for a {cov} build"}
+	@${call log.var,"active",${if $(coverage.active),"yes","no -- add 'cov' to the target variants"}}
+	@${call log.var,"backend","$(coverage.backend)"}
+	@${call log.var,"raw data","$(coverage.raw)"}
+	@${call log.var,"report","$(coverage.report)"}
+	@${call log.var,"lcov","$(coverage.info)"}
+	@${call log.sec,"  actions",}
+	@${call log.help,"coverage","merge the collected data and render the report"}
+	@${call log.help,"coverage.clean","discard the collected data and the rendered report"}
+	@${call log.help,"coverage.info","show these settings"}
+
+# the user facing info alias, matching the {<thing>.info} convention of the other registries
+coverage.info: coverage.info-target
+
+
+# the report generator dispatches on the instrumentation back end; the {coverage} target that ties it
+# to the resolved back end is emitted from the model pass, where {coverage.backend} is final. each
+# recipe first refuses to run outside a {cov} build, since without the instrumentation there is no
+# data to gather and the tools would only emit confusing errors
+
+# the llvm back end: fold the per-run raw profiles into one indexed profile, then read it against the
+# instrumented binaries to produce a terminal summary, a browsable html tree, and an lcov file for
+# the editor. the shared libraries are discovered under the install tree; a header-only template
+# library adds its compiled drivers through {coverage.objects}, since its code lives only there
+coverage.llvm:
+	@${if $(coverage.active),,${call log.error,"not a coverage build; add cov to the target variants and rerun"}; exit 1}
+	@command -v llvm-profdata >/dev/null 2>&1 || { ${call log.error,"'llvm-profdata' not found on the PATH"}; ${call log.info,"it ships with the llvm toolchain; see the coverage notes for the package name"}; exit 1; }
+	@${if $(strip $(coverage.raws)),,${call log.error,"no profile data under $(coverage.raw); build and run the tests under the same coverage target first"}; exit 1}
+	@${if $(strip $(coverage.binaries)),,${call log.error,"found no instrumented binaries; add compiled drivers or libraries through 'coverage.objects'"}; exit 1}
+	@${call log.action,"merge","$(coverage.profdata)"}
+	@$(mkdirp) ${dir $(coverage.profdata)}
+	@llvm-profdata merge -sparse $(coverage.raws) -o $(coverage.profdata)
+	@${call log.action,"report","coverage summary"}
+	@llvm-cov report -instr-profile=$(coverage.profdata) $(coverage.objargs)
+	@${call log.action,"html","$(coverage.report)"}
+	@llvm-cov show -instr-profile=$(coverage.profdata) -format=html -output-dir=$(coverage.report) $(coverage.objargs)
+	@${call log.action,"lcov","$(coverage.info)"}
+	@llvm-cov export -instr-profile=$(coverage.profdata) -format=lcov $(coverage.objargs) > $(coverage.info)
+
+# the gcov back end: {gcovr} discovers the {.gcno}/{.gcda} pairs and renders both an html tree and an
+# lcov file in one pass, keeping the two back ends interchangeable downstream. it searches two roots
+# because the coverage data is split: a test driver's data lands next to its in-tree source under the
+# project home, while a library object's data lands next to the object in the staging tree
+coverage.gcov:
+	@${if $(coverage.active),,${call log.error,"not a coverage build; add cov to the target variants and rerun"}; exit 1}
+	@command -v gcovr >/dev/null 2>&1 || ( \
+	    ${call log.error,"'gcovr' not found on the PATH"}; \
+	    ${call log.info,"see the coverage notes for the package name"}; \
+	    exit 1 )
+	@$(mkdirp) $(coverage.report)
+	@${call log.action,"report","coverage summary"}
+	@gcovr --root $(project.home) --print-summary \
+	    --html-details $(coverage.report)index.html \
+	    --lcov $(coverage.info) \
+	    $(project.home) $(builder.staging)
+
+# discard the collected data and the rendered report, leaving the instrumented objects in place so a
+# fresh measurement run does not force a rebuild
+coverage.clean:
+	@${call log.action,"rm","$(builder.staging)coverage"}
+	@$(rm.force-recurse) $(builder.staging)coverage
+
+# these are phony bookkeeping targets, never files
+.PHONY: coverage coverage.llvm coverage.gcov coverage.clean coverage.info coverage.info-target
+
+
+# end of file

--- a/share/mm/make/merlin.mm
+++ b/share/mm/make/merlin.mm
@@ -22,7 +22,7 @@ define model :=
     log mm modes
     languages platforms hosts users developers
     compilers targets builder runners toolchains
-	extern projects
+	extern coverage projects
 endef
 
 # the categories of methods each object provides


### PR DESCRIPTION
Imports code coverage support into merlin's copy of the mm make engine (`share/mm/make`).

A `cov` build variant instruments the compiled languages and adds a `coverage` target that
renders a terminal summary, an HTML tree, and an lcov file via the clang (`llvm-cov`) or gcc
(`gcovr`) back end. Coverage of header-only / template code is attributed back to the source
tree rather than the installed prefix.

This is a straight copy of the `make/` changes from standalone mm — no driver changes — so the
`merlin mm` banner in `mm/rules.mm` is intentionally left untouched. Merged tree validated via
`--engine`: loads clean, zero undefined-variable warnings in cov and non-cov builds.

Full feature detail, both back ends, and cross-toolchain validation: aivazis/mm#51.
