### PR TITLE
h5: link MPI includes when building against parallel HDF5

### DIFF
--- a/.cmake/pyre_h5.cmake
+++ b/.cmake/pyre_h5.cmake
@@ -58,6 +58,12 @@ function(pyre_h5Lib)
     # libpyre now needs the hdf5 c library; the plain signature (matching {pyre_pyreLib}) links
     # it transitively, so consumers whose header templates call the hdf5 c api get it too
     target_link_libraries(pyre HDF5::HDF5)
+    # a parallel build of hdf5 exposes {mpi.h} through its public headers, so anything that
+    # includes them needs the mpi include directories; pull them in via {MPI::MPI_CXX} so users
+    # don't have to add the mpi include path to the compile flags by hand
+    if(HDF5_IS_PARALLEL AND MPI_FOUND)
+      target_link_libraries(pyre MPI::MPI_CXX)
+    endif()
   endif(HDF5_FOUND)
 endfunction(pyre_h5Lib)
 

--- a/.mm/pyre-h5.lib.tests
+++ b/.mm/pyre-h5.lib.tests
@@ -9,6 +9,12 @@ pyre-h5.lib.tests.stem := h5.lib
 pyre-h5.lib.tests.prerequisites := pyre-h5.lib journal.lib
 pyre-h5.lib.tests.extern := pyre-h5.lib journal.lib hdf5
 
+# a parallel {hdf5} pulls in {mpi.h} through its public headers; when {mpi} is available, add it
+# as an extern so the include path lands on the compile line without any manual flags
+ifeq ($(mpi.available), mpi)
+pyre-h5.lib.tests.extern += mpi
+endif
+
 # c++ compiler arguments
 pyre-h5.lib.tests.c++.defines += $(pyre.lib.c++.defines)
 pyre-h5.lib.tests.c++.flags += -Wall $(pyre.lib.c++.flags)

--- a/.mm/pyre-h5.mm
+++ b/.mm/pyre-h5.mm
@@ -6,6 +6,7 @@
 
 # check availability
 hdf5.available := ${findstring hdf5,$(extern.available)}
+mpi.available := ${findstring mpi,$(extern.available)}
 
 # if {hdf5} is available
 ifeq ($(hdf5.available), hdf5)
@@ -33,6 +34,13 @@ pyre-h5.lib.extern := journal.lib hdf5
 pyre-h5.lib.c++.flags += $(pyre.lib.c++.flags)
 pyre-h5.lib.c++.defines += $(pyre.lib.c++.defines)
 
+# a parallel build of {hdf5} exposes {mpi.h} through its public headers, so anything that
+# includes them needs the mpi include directories; when {mpi} is available, add it as an extern
+# so the include path lands on the compile line without any manual flags
+ifeq ($(mpi.available), mpi)
+pyre-h5.lib.extern += mpi
+endif
+
 # the h5 extension meta-data; it wraps the library above
 pyre-h5.ext.root := extensions/h5/
 # the module stays {h5}; {packages/pyre/extensions} re-exports it as {libh5}
@@ -46,6 +54,11 @@ pyre-h5.ext.lib.prerequisites := pyre-h5.lib pyre.lib
 pyre-h5.ext.extern := pyre.lib journal.lib hdf5 pybind11 python
 pyre-h5.ext.lib.c++.flags += $(pyre-h5.lib.c++.flags)
 pyre-h5.ext.lib.c++.defines += $(pyre-h5.lib.c++.defines)
+
+# as with the library, a parallel {hdf5} pulls in {mpi.h}; add {mpi} to the extension externs too
+ifeq ($(mpi.available), mpi)
+pyre-h5.ext.extern += mpi
+endif
 
 
 # get the testsuites

--- a/README.md
+++ b/README.md
@@ -256,4 +256,81 @@ installation. Let's verify:
 
 Both statements should succeed, and the latter should print out the `pyre` installation location.
 
+## Building with CMake
+
+In addition to `mm`, `pyre` ships a full `CMake` build. This is a good option if you already have
+`CMake` in your toolchain, want to embed `pyre` in another `CMake` project via `find_package(pyre)`,
+or prefer a standard out-of-source build.
+
+### Dependencies
+
+You need a C++ compiler with C++23 support (e.g. `gcc` 13+ or `clang` 16+), `CMake` 3.19 or newer,
+and `make`. The `python` bindings additionally require `python` 3.7+, `pybind11`, and `PyYAML`.
+The following external libraries are optional; when present, `CMake` detects them and builds the
+corresponding support:
+
+- `MPI` (e.g. OpenMPI)
+- `GSL`
+- `HDF5` (the parallel build is preferred when `MPI` is available)
+- `PostgreSQL` (`libpq`)
+
+On a Debian/Ubuntu system you can install the system dependencies with:
+
+``` text
+~> sudo apt install -y cmake make libgsl-dev libopenmpi-dev libhdf5-dev libpq-dev
+~> pip3 install pybind11 PyYAML numpy
+```
+
+### Configuring, building, and installing
+
+`CMake` builds are done out of source. Create a build directory, point `CMake` at the `pyre` source
+tree, and choose an install prefix; here we use `~/tools/pyre`:
+
+``` text
+~/dv/pyre> mkdir -p ~/tools/pyre build
+~/dv/pyre> cd build
+~/dv/pyre/build> cmake \
+    -DCMAKE_INSTALL_PREFIX=${HOME}/tools/pyre \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=gcc \
+    -DCMAKE_CXX_COMPILER=g++ \
+    -Dpybind11_DIR=$(python3 -c "import pybind11; print(pybind11.get_cmake_dir())") \
+    -DPYRE_MPI_OVERSUBSCRIBE=ON \
+    ..
+~/dv/pyre/build> cmake --build . -j 4 --target install
+```
+
+A few notes:
+
+- `-Dpybind11_DIR=...` points `CMake` at the `pybind11` installed in your `python` environment; the
+  command substitution above resolves it automatically.
+- Build types are the usual `CMake` values: `Release`, `Debug`, or `RelWithDebInfo`.
+- Useful options include `-DPYRE_BUILD_TESTING=ON` (default when `pyre` is the top-level project),
+  `-DWITH_CUDA=ON`, and `-DHAVE_TENSOR=ON`.
+- The optional external libraries (`MPI`, `GSL`, `HDF5`, `PostgreSQL`) are auto-detected: when
+  `find_package` locates them, the corresponding support is built automatically — there is no
+  option to toggle by hand. If a parallel `HDF5` is found, `pyre` links `MPI::MPI_CXX` into
+  `libpyre` for you, so the `mpi.h` its headers pull in is resolved without any extra compile flags.
+- A small number of heavily-templated translation units (for example
+  `extensions/pyre/grid/grids.cc`) are memory-hungry to compile — a single `g++` process can use
+  roughly 10 GB of RAM. Keep the parallel job count (`-j`) modest on machines with limited memory to
+  avoid exhausting RAM.
+
+### Verifying
+
+The `python` package is installed under `${prefix}/packages`. Add it to your `PYTHONPATH` and import
+`pyre`:
+
+``` text
+~/dv/pyre/build> export PYTHONPATH=${HOME}/tools/pyre/packages:${PYTHONPATH}
+~/dv/pyre/build> python3 -c "import pyre; print(pyre.__file__); print(pyre.version())"
+```
+
+You can also run the test suite from the build directory with `ctest` (the `postgres` suites need a
+running database server, so exclude them if you don't have one):
+
+``` text
+~/dv/pyre/build> ctest --output-on-failure -E postgres
+```
+
 [comment]: <> (end of file)


### PR DESCRIPTION
## Problem

A parallel build of HDF5 exposes `mpi.h` through its public headers (`H5public.h` does `#include <mpi.h>`), so any translation unit that pulls in the hdf5 C headers needs the MPI include directories on its compile line.

Both build systems declare `hdf5` as a dependency of the `pyre::h5` sources but omit MPI. As a result, compiling `lib/h5/*.cc` fails with:

```
H5public.h:65:10: fatal error: mpi.h: No such file or directory
```

whenever the discovered HDF5 is a parallel build. This reproduces with a stock Ubuntu `libhdf5-dev` (parallel/OpenMPI) under both cmake and mm.

## Fix

- **cmake** (`.cmake/pyre_h5.cmake`): link `MPI::MPI_CXX` into `libpyre` when `HDF5_IS_PARALLEL AND MPI_FOUND`, so the MPI include dirs propagate transitively to the h5 sources.
- **mm** (`.mm/pyre-h5.mm`, `.mm/pyre-h5.lib.tests`): add the `mpi` extern to `pyre-h5.lib`, `pyre-h5.ext`, and `pyre-h5.lib.tests`, guarded on `mpi` availability (mirrors the existing pattern in `pyre-mpi.mm`).

Both changes are conditional, so they are no-ops when MPI / parallel HDF5 is not present.

## Docs

Also documents the cmake build procedure in the README.

## Testing

- cmake: verified a fresh configure + `cmake --build . --target pyre` compiles all `lib/h5/*.cc` cleanly **without** any manual `-DCMAKE_CXX_FLAGS`, and a full `--target install` succeeds and `import pyre` works.
- mm: the change mirrors the proven `pyre-mpi.mm` idiom and is guarded on availability; not runtime-verified (no configured mm environment on the test machine).