### PR TITLE
merlin: sync mm make layer — DEBUG/NDEBUG as a dev/release mode disposition

### DIFF
--- a/share/mm/make/compilers/init.mm
+++ b/share/mm/make/compilers/init.mm
@@ -118,6 +118,7 @@ define compiler.option.sources =
 ${strip
     $(2)
     mm
+    mode.compiler
     platform.$(1)
     $(compiler.$(1))
     $(target.variants:%=targets.%.$(1))

--- a/share/mm/make/modes/default.mm
+++ b/share/mm/make/modes/default.mm
@@ -9,5 +9,11 @@
 # npm: empty installs fresh ({npm i}); non-empty installs from the committed lock ({npm ci})
 mode.npm.locked := yes
 
+# compiler: whether the developer-time checks are compiled in -- the {assert}s, the code under
+# {#if defined(DEBUG)}, and journal's {debug}/{firewall} channels. this is a mode disposition,
+# orthogonal to the opt/debug optimization target; {make/modes/init.mm} turns it into the
+# coherent {DEBUG}/{NDEBUG} macro pair. the baseline is a deployment build, so the checks are off
+mode.compiler.assertions :=
+
 
 # end of file

--- a/share/mm/make/modes/dev.mm
+++ b/share/mm/make/modes/dev.mm
@@ -7,5 +7,9 @@
 # {dev} resolves dependencies fresh rather than from the committed lock
 mode.npm.locked :=
 
+# {dev} keeps the developer-time checks live: {assert}s fire, the {#if defined(DEBUG)} blocks
+# compile in, and journal's {debug}/{firewall} channels are real -- even in an optimized build
+mode.compiler.assertions := yes
+
 
 # end of file

--- a/share/mm/make/modes/init.mm
+++ b/share/mm/make/modes/init.mm
@@ -9,6 +9,21 @@ include make/modes/default.mm
 # the selected mode's overrides; a mode with no file here is a fatal error
 include make/modes/$(project.mode).mm
 
+# {mode.compiler} joins the compiler option sources as a flat, language-independent contributor,
+# just like {mm}; declare its full category set so no slot is ever an undefined variable
+mode.compiler.flags :=
+# take ownership of the two disposition macros as a coherent pair: exactly one is defined at any
+# time, so client code can never land in an ambiguous state. checks on ({assertions} set) means
+# our {DEBUG} convention and no {NDEBUG}; checks off means the standard {NDEBUG} assert guard and
+# no {DEBUG}. the exclusivity here is what makes {NDEBUG} dominate {DEBUG} -- the precedence the
+# journal api already assumes -- moot in practice
+mode.compiler.defines := ${if $(mode.compiler.assertions),DEBUG,NDEBUG}
+mode.compiler.incpath :=
+mode.compiler.ldflags :=
+mode.compiler.libpath :=
+mode.compiler.rpath :=
+mode.compiler.libraries :=
+
 # the implemented modes, discovered from the files present here, minus the framework files
 modes.available := ${filter-out init default rules model,${basename ${notdir ${wildcard $(mm.home)/make/modes/*.mm}}}}
 

--- a/share/mm/make/modes/rules.mm
+++ b/share/mm/make/modes/rules.mm
@@ -11,6 +11,9 @@ mode.info:
 	@${call log.var,available,$(modes.available)}
 	@${call log.sec,"  npm",}
 	@${call log.var,locked,$(mode.npm.locked)}
+	@${call log.sec,"  compiler",}
+	@${call log.var,assertions,${if $(mode.compiler.assertions),yes,no}}
+	@${call log.var,defines,$(mode.compiler.defines)}
 
 # what the build mode controls and the values it can take
 mode.help: | mm.banner
@@ -27,6 +30,7 @@ mode.help: | mm.banner
 	@$(log)
 	@${call log.sec,"settings",}
 	@${call log.help,"mode.npm.locked","install npm deps from the committed lock when set (otherwise resolve fresh)"}
+	@${call log.help,"mode.compiler.assertions","compile in the developer-time checks (asserts, DEBUG blocks, journal debug/firewall) when set"}
 	@$(log)
 
 

--- a/share/mm/make/targets/debug.mm
+++ b/share/mm/make/targets/debug.mm
@@ -12,10 +12,6 @@ ${eval ${call target.init,debug}}
 
 # adjust
 ${call target.adjust,debug,$(languages.compiled),flags ldflags}
-# define the DEBUG macro
-${foreach language,c c++ cuda cython fortran, \
-    ${eval targets.debug.$(language).defines += DEBUG} \
-}
 
 # build my info target
 ${eval ${call target.info.flags,debug}}

--- a/share/mm/make/targets/reldeb.mm
+++ b/share/mm/make/targets/reldeb.mm
@@ -12,10 +12,6 @@ ${eval ${call target.init,reldeb}}
 
 # adjust
 ${call target.adjust,reldeb,$(languages.compiled),flags ldflags}
-# define the DEBUG macro
-${foreach language,c c++ cuda cython fortran, \
-    ${eval targets.reldeb.$(language).defines += DEBUG} \
-}
 
 # build my info target
 ${eval ${call target.info.flags,reldeb}}


### PR DESCRIPTION
Mirror of [aivazis/mm#52](https://github.com/aivazis/mm/pull/52) into the embedded merlin make layer (`share/mm/make`).

## Summary

Whether a build compiles in its developer-time checks — the `assert`s, the code under `#if defined(DEBUG)`, and `journal`'s `debug`/`firewall` channels — is now a **dev/release mode** disposition, orthogonal to the **opt/debug optimization target**. An optimized developer build still checks its invariants; a release build drops them regardless of optimization level.

Previously `DEBUG` was defined by the `debug`/`reldeb` targets, so assert liveness rode the optimization axis. The default local build is `opt`, which defined neither `DEBUG` nor `NDEBUG` — leaving `assert()` nominally live but every `#if defined(DEBUG)` check (and `journal`'s `firewall_t`) compiled out. That is exactly why a wrong-length `pyre::grid::Index` assert rode through local `opt` runs and surfaced only in CI's debug legs.

## The convention

`DEBUG` (our convention) and `NDEBUG` (the standard `<cassert>` guard) are independent macros; all four combinations are reachable and two are incoherent. mm now owns them as a coherent pair: **exactly one is defined at all times**.

- **dev** → `-DDEBUG`, no `NDEBUG`: developer code in, `assert()` live, `journal` developer channels real.
- **release / conda / macports / ubuntu** → `-DNDEBUG`, no `DEBUG`: developer code gone, `assert()` a no-op, developer channels `null_t`.

`journal`'s `api.h` already reads the pair correctly (with `NDEBUG` dominating `DEBUG`), so it needs no change; the mode now feeds it deterministically.

## Changed files (all under `share/mm/make`)

- `modes/default.mm`, `modes/dev.mm` — knob `mode.compiler.assertions` (baseline empty; `yes` in dev).
- `modes/init.mm` — single ownership point mapping the knob to the `DEBUG`/`NDEBUG` pair, plus the flat category set for the new source.
- `compilers/init.mm` — `mode.compiler` added to `compiler.option.sources`.
- `targets/debug.mm`, `targets/reldeb.mm` — `DEBUG` removed; targets are now purely optimization/symbols.
- `modes/rules.mm` — `mode.info` / `mode.help` advertise the knob.

## Behavior change

Release/deployment modes now define `-DNDEBUG`, newly silencing bare (unwrapped) `assert()` in release. Default local builds (opt+dev) now compile in `journal` `debug`/`firewall` channels and keep asserts live.