### PR TITLE
Modernize `pyre`’s CUDA support and port CUDA grids to the new packing API

### DIFF
--- a/.cmake/pyre_cuda.cmake
+++ b/.cmake/pyre_cuda.cmake
@@ -44,11 +44,12 @@ function(pyre_cudaLib)
     # specify the directory for the library compilation products
     pyre_library_directory(cuda lib)
     # its headers reach {pyre/memory.h} and {pyre/journal.h}, so it stands on {pyre}, which is
-    # also what puts our own headers on the consumer's include path
-    target_link_libraries(cuda INTERFACE pyre ${CUDA_LIBRARIES})
-    # set the include directories
+    # also what puts our own headers on the consumer's include path; the cuda runtime arrives
+    # as an imported target, which carries its own include path along with the library
+    target_link_libraries(cuda INTERFACE pyre CUDA::cudart)
+    # set the include directories; the toolkit headers ride in on {CUDA::cudart}, so all that
+    # is left is finding our own, in the build tree and in the prefix
     target_include_directories(cuda INTERFACE
-      ${CUDA_INCLUDE_DIRS}
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/lib>
       $<INSTALL_INTERFACE:${PYRE_DEST_INCLUDE}>
       )
@@ -61,10 +62,9 @@ function(pyre_cudaLib)
       EXPORT pyre-targets
       )
     pyre_exportTarget(cuda cuda)
-    # {CUDA_LIBRARIES}, as the deprecated {FindCUDA} assembles it, names the threads imported
-    # target rather than a bare library, so a consumer that asks for this component has to be
-    # able to resolve that one as well
-    pyre_exportOptionalRequirement(cuda Threads Threads::Threads)
+    # this target names {CUDA::cudart}, so a consumer that asks for the add-on has to be able
+    # to resolve it; teach the generated configuration where it comes from
+    pyre_exportOptionalRequirement(cuda CUDAToolkit CUDA::cudart)
   endif()
   # all done
 endfunction(pyre_cudaLib)
@@ -80,10 +80,9 @@ function(pyre_cudaModule)
     set_target_properties(cudamodule PROPERTIES LIBRARY_OUTPUT_NAME cuda)
     # specify the directory for the module compilation products
     pyre_library_directory(cudamodule extensions)
-    # set the libraries to link against
-    target_link_libraries(cudamodule PRIVATE pyre journal pybind11::module ${CUDA_LIBRARIES})
-    # set the include directories
-    target_include_directories(cudamodule PRIVATE ${CUDA_INCLUDE_DIRS})
+    # set the libraries to link against; {CUDA::cudart} brings the toolkit headers with it,
+    # so the module needs no include directories of its own
+    target_link_libraries(cudamodule PRIVATE pyre journal pybind11::module CUDA::cudart)
     # add the sources
     target_sources(cudamodule PRIVATE
       extensions/cuda/cuda.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,11 +112,12 @@ message(STATUS "Parallel HDF5: ${HDF5_IS_PARALLEL}")
 
 # find cuda if it is required
 if(WITH_CUDA)
-    # add the cuda package
-    find_package(CUDA REQUIRED)
-  if(CUDA_FOUND)
-    enable_language(CUDA)
-  endif()
+    # add the cuda package; {FindCUDA} has been deprecated since cmake 3.10, and {CUDAToolkit}
+    # is what replaces it: it hands back imported targets instead of the variable soup
+    find_package(CUDAToolkit REQUIRED)
+    if(CUDAToolkit_FOUND)
+        enable_language(CUDA)
+    endif()
 endif()
 
 # postgres

--- a/benchmarks/cuda.lib/matrix_invariants.cc
+++ b/benchmarks/cuda.lib/matrix_invariants.cc
@@ -127,8 +127,8 @@ managedInvariants(pack_t tensorPack, pack_t invariantPack, int nThreadPerBlock, 
 
     // execute the kernel wrapper
     computeInvariantsManaged(
-        nTensors, nThreadPerBlock, nBlocks, tensorArray.data()->data(), I1.data()->data(),
-        I2.data()->data(), I3.data()->data());
+        nTensors, nThreadPerBlock, nBlocks, tensorArray.data(), I1.data(),
+        I2.data(), I3.data());
 
     // wait for GPU to finish before stopping the timer
     status = cudaDeviceSynchronize();
@@ -244,12 +244,12 @@ pinnedInvariants(pack_t tensorPack, pack_t invariantPack, int nThreadPerBlock, i
     walltimer.start();
 
     // synchronize the tensors between host and device
-    tensorArray.data()->synchronizeHostToDevice();
+    tensorArray.storage().synchronizeHostToDevice();
 
     // execute the kernel
     computeInvariantsPinned(
-        nTensors, nThreadPerBlock, nBlocks, tensorArray.data()->device(), I1.data()->device(),
-        I2.data()->device(), I3.data()->device());
+        nTensors, nThreadPerBlock, nBlocks, tensorArray.storage().device(), I1.storage().device(),
+        I2.storage().device(), I3.storage().device());
 
     // wait for GPU to finish before synchronizing the invariants
     status = cudaDeviceSynchronize();
@@ -264,11 +264,11 @@ pinnedInvariants(pack_t tensorPack, pack_t invariantPack, int nThreadPerBlock, i
     }
 
     // and synchronize the invariants between device and host
-    I1.data()->synchronizeDeviceToHost();
+    I1.storage().synchronizeDeviceToHost();
 
-    I2.data()->synchronizeDeviceToHost();
+    I2.storage().synchronizeDeviceToHost();
 
-    I3.data()->synchronizeDeviceToHost();
+    I3.storage().synchronizeDeviceToHost();
 
     // wait for GPU to finish before stopping the timer
     status = cudaDeviceSynchronize();
@@ -384,8 +384,8 @@ mappedInvariants(pack_t tensorPack, pack_t invariantPack, int nThreadPerBlock, i
     walltimer.start();
 
     computeInvariantsMapped(
-        nTensors, nThreadPerBlock, nBlocks, tensorArray.data()->device(), I1.data()->device(),
-        I2.data()->device(), I3.data()->device());
+        nTensors, nThreadPerBlock, nBlocks, tensorArray.storage().device(), I1.storage().device(),
+        I2.storage().device(), I3.storage().device());
 
     // wait for GPU to finish before stopping the timer
     status = cudaDeviceSynchronize();

--- a/benchmarks/cuda.lib/matrix_inverse.cc
+++ b/benchmarks/cuda.lib/matrix_inverse.cc
@@ -122,8 +122,8 @@ managedInverses(pack_t tensorPack, int nThreadPerBlock, int nTensors)
 
     // execute the kernel wrapper
     computeInvariantsManaged(
-        nTensors, nThreadPerBlock, nBlocks, tensorArray.data()->data(),
-        inverseArray.data()->data());
+        nTensors, nThreadPerBlock, nBlocks, tensorArray.data(),
+        inverseArray.data());
 
     // wait for GPU to finish before stopping the timer
     status = cudaDeviceSynchronize();
@@ -264,12 +264,12 @@ pinnedInverses(pack_t tensorPack, int nThreadPerBlock, int nTensors)
     walltimer.start();
 
     // synchronize the tensors between host and device
-    tensorArray.data()->synchronizeHostToDevice();
+    tensorArray.storage().synchronizeHostToDevice();
 
     // execute the kernel wrapper
     computeInvariantsPinned(
-        nTensors, nThreadPerBlock, nBlocks, tensorArray.data()->device(),
-        inverseArray.data()->device());
+        nTensors, nThreadPerBlock, nBlocks, tensorArray.storage().device(),
+        inverseArray.storage().device());
 
     // wait for GPU to finish before synchronizing the inverse
     status = cudaDeviceSynchronize();
@@ -284,7 +284,7 @@ pinnedInverses(pack_t tensorPack, int nThreadPerBlock, int nTensors)
     }
 
     // and synchronize the inverse between device and host
-    inverseArray.data()->synchronizeDeviceToHost();
+    inverseArray.storage().synchronizeDeviceToHost();
 
     // wait for GPU to finish before stopping the timer
     status = cudaDeviceSynchronize();
@@ -397,8 +397,8 @@ mappedInverses(pack_t tensorPack, int nThreadPerBlock, int nTensors)
 
     // execute the kernel wrapper
     computeInvariantsMapped(
-        nTensors, nThreadPerBlock, nBlocks, tensorArray.data()->device(),
-        inverseArray.data()->device());
+        nTensors, nThreadPerBlock, nBlocks, tensorArray.storage().device(),
+        inverseArray.storage().device());
 
     // wait for GPU to finish before stopping the timer
     status = cudaDeviceSynchronize();

--- a/etc/cmake/consumer/CMakeLists.txt
+++ b/etc/cmake/consumer/CMakeLists.txt
@@ -145,10 +145,9 @@ endif()
 if(PYRE_CONSUMER_EXPECT_CUDA)
   # asking for the component is what sends the configuration looking for what it needs
   find_package(pyre REQUIRED COMPONENTS cuda)
-  # the deprecated {FindCUDA} builds its library list out of the threads imported target, so
-  # that is the one the add-on leans on
-  if(NOT TARGET Threads::Threads)
-    message(FATAL_ERROR "asking for the 'cuda' component did not locate threads")
+  # the add-on names the cuda runtime, so that is the imported target the search must produce
+  if(NOT TARGET CUDA::cudart)
+    message(FATAL_ERROR "asking for the 'cuda' component did not locate the cuda runtime")
   endif()
   # compiling this proves the cuda headers and our own arrive through {pyre::cuda}
   add_executable(cuda cuda.cc)

--- a/lib/cuda/memory/Pinned.h
+++ b/lib/cuda/memory/Pinned.h
@@ -86,7 +86,7 @@ public:
     ~Pinned();
     // constructors
     Pinned(const Pinned &) = default;
-    Pinned(Pinned &&) = default;
+    Pinned(Pinned &&);
     Pinned & operator=(const Pinned &) = default;
     Pinned & operator=(Pinned &&) = default;
 };

--- a/lib/cuda/memory/Pinned.h
+++ b/lib/cuda/memory/Pinned.h
@@ -86,7 +86,10 @@ public:
     ~Pinned();
     // constructors
     Pinned(const Pinned &) = delete;
-    Pinned(Pinned &&);
+    // moving me hands over a shared pointer and swaps a raw one, neither of which can throw;
+    // saying so lets me travel through containers and through {grid}, whose own move is
+    // declared {noexcept}
+    Pinned(Pinned &&) noexcept;
     Pinned & operator=(const Pinned &) = delete;
     Pinned & operator=(Pinned &&) = delete;
 };

--- a/lib/cuda/memory/Pinned.h
+++ b/lib/cuda/memory/Pinned.h
@@ -54,13 +54,13 @@ public:
     // cpu gpu synchronization
 public:
     // synchronize all memory from cpu to gpu
-    inline auto synchronizeHostToDevice();
+    inline auto synchronizeHostToDevice() const;
     // synchronize part off the memory from cpu to gpu
-    inline auto synchronizeHostToDevice(difference_type, cell_count_type);
+    inline auto synchronizeHostToDevice(difference_type, cell_count_type) const;
     // synchronize all memory from gpu to cpu
-    inline auto synchronizeDeviceToHost();
+    inline auto synchronizeDeviceToHost() const;
     // synchronize part off the memory from gpu to cpu
-    inline auto synchronizeDeviceToHost(difference_type, cell_count_type);
+    inline auto synchronizeDeviceToHost(difference_type, cell_count_type) const;
 
     // iterator support
 public:

--- a/lib/cuda/memory/Pinned.h
+++ b/lib/cuda/memory/Pinned.h
@@ -85,10 +85,10 @@ public:
     // destructor
     ~Pinned();
     // constructors
-    Pinned(const Pinned &) = default;
+    Pinned(const Pinned &) = delete;
     Pinned(Pinned &&);
-    Pinned & operator=(const Pinned &) = default;
-    Pinned & operator=(Pinned &&) = default;
+    Pinned & operator=(const Pinned &) = delete;
+    Pinned & operator=(Pinned &&) = delete;
 };
 
 // get the inline definitions

--- a/lib/cuda/memory/Pinned.icc
+++ b/lib/cuda/memory/Pinned.icc
@@ -185,7 +185,7 @@ pyre::cuda::memory::Pinned<T, isConst>::device() const -> pointer
 // data synchronization host to device
 template <class T, bool isConst>
 auto
-pyre::cuda::memory::Pinned<T, isConst>::synchronizeHostToDevice()
+pyre::cuda::memory::Pinned<T, isConst>::synchronizeHostToDevice() const
 {
     // set cuda error
     cudaError_t status;
@@ -216,7 +216,7 @@ pyre::cuda::memory::Pinned<T, isConst>::synchronizeHostToDevice()
 template <class T, bool isConst>
 auto
 pyre::cuda::memory::Pinned<T, isConst>::synchronizeHostToDevice(
-    difference_type startOffset, cell_count_type copySize)
+    difference_type startOffset, cell_count_type copySize) const
 { // set cuda error
     cudaError_t status;
 
@@ -263,7 +263,7 @@ pyre::cuda::memory::Pinned<T, isConst>::synchronizeHostToDevice(
 // data synchronization device to host
 template <class T, bool isConst>
 auto
-pyre::cuda::memory::Pinned<T, isConst>::synchronizeDeviceToHost()
+pyre::cuda::memory::Pinned<T, isConst>::synchronizeDeviceToHost() const
 {
     // set cuda error
     cudaError_t status;
@@ -294,7 +294,7 @@ pyre::cuda::memory::Pinned<T, isConst>::synchronizeDeviceToHost()
 template <class T, bool isConst>
 auto
 pyre::cuda::memory::Pinned<T, isConst>::synchronizeDeviceToHost(
-    difference_type startOffset, cell_count_type copySize)
+    difference_type startOffset, cell_count_type copySize) const
 { // set cuda error
     cudaError_t status;
 

--- a/lib/cuda/memory/Pinned.icc
+++ b/lib/cuda/memory/Pinned.icc
@@ -117,7 +117,7 @@ pyre::cuda::memory::Pinned<T, isConst>::Pinned(handle_type host_handle, cell_cou
 
 // move constructor
 template <class T, bool isConst>
-pyre::cuda::memory::Pinned<T, isConst>::Pinned(Pinned && other) :
+pyre::cuda::memory::Pinned<T, isConst>::Pinned(Pinned && other) noexcept :
     _host_data { std::move(other._host_data) },
     _device_data { std::exchange(other._device_data, nullptr) },
     _cells { other._cells }

--- a/lib/cuda/memory/Pinned.icc
+++ b/lib/cuda/memory/Pinned.icc
@@ -109,6 +109,9 @@ pyre::cuda::memory::Pinned<T, isConst>::Pinned(cell_count_type cells) :
 template <class T, bool isConst>
 pyre::cuda::memory::Pinned<T, isConst>::Pinned(handle_type host_handle, cell_count_type cells) :
     _host_data { host_handle },
+    // the caller handed us host cells only; there is no device allocation to go with them, and
+    // saying so explicitly is what keeps my destructor from handing garbage to {cudaFree}
+    _device_data { nullptr },
     _cells { cells }
 {}
 

--- a/lib/cuda/memory/Pinned.icc
+++ b/lib/cuda/memory/Pinned.icc
@@ -112,6 +112,14 @@ pyre::cuda::memory::Pinned<T, isConst>::Pinned(handle_type host_handle, cell_cou
     _cells { cells }
 {}
 
+// move constructor
+template <class T, bool isConst>
+pyre::cuda::memory::Pinned<T, isConst>::Pinned(Pinned && other) :
+    _host_data { std::move(other._host_data) },
+    _device_data { std::exchange(other._device_data, nullptr) },
+    _cells { other._cells }
+{}
+
 // destructor
 template <class T, bool isConst>
 pyre::cuda::memory::Pinned<T, isConst>::~Pinned()


### PR DESCRIPTION
This PR updates `pyre`'s CUDA support and ports the CUDA grid benchmarks to the new grid packing API.

Main changes:
* update CMake support by replacing the deprecated `FindCUDA` with the modern `CUDAToolkit` package and imported targets;
* port the CUDA benchmarks to the updated grid interface;
* fix the move semantics of pinned CUDA storage by transferring ownership of the device allocation and clearing the moved-from pointer.