### PR TITLE
Propagate the `pyre` dependencies to all downstream projects that build with `CMake`

### DIFF
--- a/.cmake/pyre-config.cmake.in
+++ b/.cmake/pyre-config.cmake.in
@@ -1,3 +1,5 @@
+# -*- cmake -*-
+#
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved
 

--- a/.cmake/pyre-config.cmake.in
+++ b/.cmake/pyre-config.cmake.in
@@ -3,21 +3,25 @@
 
 @PACKAGE_INIT@
 
-include(${CMAKE_CURRENT_LIST_DIR}/pyre-targets.cmake)
-check_required_components(pyre)
-
-# support for searching dependencies
+# support for locating dependencies
 include(CMakeFindDependencyMacro)
 
-# conditionally propagate the MPI dependency
-if(@MPI_CXX_FOUND@)
-find_dependency(MPI COMPONENTS CXX)
+# if the build linked against hdf5, consumers need it too; the quoted form protects against
+# an empty substitution collapsing into a syntax error
+if("@HDF5_FOUND@")
+  # locate it
+  find_dependency(HDF5 COMPONENTS C HL)
 endif()
 
-# conditionally propagate the HDF5 dependency
-if(@HDF5_FOUND@)
-find_dependency(HDF5 COMPONENTS C HL)
+# a parallel hdf5 places mpi in the link interface of libpyre, so consumers need it as well
+if("@HDF5_IS_PARALLEL@" AND "@MPI_FOUND@")
+  # locate it
+  find_dependency(MPI COMPONENTS CXX)
 endif()
 
+# load the exported targets
+include(${CMAKE_CURRENT_LIST_DIR}/pyre-targets.cmake)
+# and verify that all requested components are present
+check_required_components(pyre)
 
 # end of file

--- a/.cmake/pyre-config.cmake.in
+++ b/.cmake/pyre-config.cmake.in
@@ -3,25 +3,20 @@
 
 @PACKAGE_INIT@
 
-# support for locating dependencies
+# support for locating the packages we depend on
 include(CMakeFindDependencyMacro)
 
-# if the build linked against hdf5, consumers need it too; the quoted form protects against
-# an empty substitution collapsing into a syntax error
-if("@HDF5_FOUND@")
-  # locate it
-  find_dependency(HDF5 COMPONENTS C HL)
-endif()
-
-# a parallel hdf5 places mpi in the link interface of libpyre, so consumers need it as well
-if("@HDF5_IS_PARALLEL@" AND "@MPI_FOUND@")
-  # locate it
-  find_dependency(MPI COMPONENTS CXX)
-endif()
+# our exported targets name imported targets that belong to other packages; the searches below
+# are generated from the places where the build established those links, so this list is exactly
+# what this particular installation needs, no more and no less
+@PYRE_EXPORT_REQUIREMENTS@
+# our headers are c++23, strictly: the exported targets carry the standard as a usage
+# requirement, and this turns off the compiler extensions that would otherwise ride along
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # load the exported targets
-include(${CMAKE_CURRENT_LIST_DIR}/pyre-targets.cmake)
-# and verify that all requested components are present
+include("${CMAKE_CURRENT_LIST_DIR}/pyre-targets.cmake")
+# and verify that all the requested components are present
 check_required_components(pyre)
 
 # end of file

--- a/.cmake/pyre-config.cmake.in
+++ b/.cmake/pyre-config.cmake.in
@@ -6,4 +6,18 @@
 include(${CMAKE_CURRENT_LIST_DIR}/pyre-targets.cmake)
 check_required_components(pyre)
 
+# support for searching dependencies
+include(CMakeFindDependencyMacro)
+
+# conditionally propagate the MPI dependency
+if(@MPI_CXX_FOUND@)
+find_dependency(MPI COMPONENTS CXX)
+endif()
+
+# conditionally propagate the HDF5 dependency
+if(@HDF5_FOUND@)
+find_dependency(HDF5 COMPONENTS C HL)
+endif()
+
+
 # end of file

--- a/.cmake/pyre-config.cmake.in
+++ b/.cmake/pyre-config.cmake.in
@@ -12,8 +12,12 @@ include(CMakeFindDependencyMacro)
 # are generated from the places where the build established those links, so this list is exactly
 # what this particular installation needs, no more and no less
 @PYRE_EXPORT_REQUIREMENTS@
-# our headers are c++23, strictly: the exported targets carry the standard as a usage
+# our headers are c++23, strictly: the exported targets carry the standard itself as a usage
 # requirement, and this turns off the compiler extensions that would otherwise ride along
+# N.B.: cmake has no way to make this part of a usage requirement, because {CXX_EXTENSIONS} is
+# a plain target property rather than an interface one; a target only picks the setting up when
+# it is created, so ask for {pyre} before you declare the targets that will link against it, or
+# they will quietly compile as {gnu++23}
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # load the exported targets

--- a/.cmake/pyre_cuda.cmake
+++ b/.cmake/pyre_cuda.cmake
@@ -61,6 +61,10 @@ function(pyre_cudaLib)
       EXPORT pyre-targets
       )
     pyre_exportTarget(cuda cuda)
+    # {CUDA_LIBRARIES}, as the deprecated {FindCUDA} assembles it, names the threads imported
+    # target rather than a bare library, so a consumer that asks for this component has to be
+    # able to resolve that one as well
+    pyre_exportOptionalRequirement(cuda Threads Threads::Threads)
   endif()
   # all done
 endfunction(pyre_cudaLib)

--- a/.cmake/pyre_cuda.cmake
+++ b/.cmake/pyre_cuda.cmake
@@ -43,10 +43,24 @@ function(pyre_cudaLib)
     add_library(cuda INTERFACE)
     # specify the directory for the library compilation products
     pyre_library_directory(cuda lib)
-    target_link_libraries(cuda INTERFACE ${CUDA_LIBRARIES})
+    # its headers reach {pyre/memory.h} and {pyre/journal.h}, so it stands on {pyre}, which is
+    # also what puts our own headers on the consumer's include path
+    target_link_libraries(cuda INTERFACE pyre ${CUDA_LIBRARIES})
     # set the include directories
-    target_include_directories(cuda INTERFACE ${CUDA_INCLUDE_DIRS})
+    target_include_directories(cuda INTERFACE
+      ${CUDA_INCLUDE_DIRS}
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/lib>
+      $<INSTALL_INTERFACE:${PYRE_DEST_INCLUDE}>
+      )
     add_library(pyre::cuda ALIAS cuda)
+
+    # hand it downstream; the headers ship either way, so without this a consumer finds
+    # {pyre/cuda.h} in the prefix and has nothing to link it against
+    install(
+      TARGETS cuda
+      EXPORT pyre-targets
+      )
+    pyre_exportTarget(cuda cuda)
   endif()
   # all done
 endfunction(pyre_cudaLib)

--- a/.cmake/pyre_exports.cmake
+++ b/.cmake/pyre_exports.cmake
@@ -1,0 +1,107 @@
+# -*- cmake -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# record an external package that one of our exported targets names in its link interface
+# {package} is what to look for, {target} is the imported target the search must produce, and
+# the remaining arguments are handed to {find_dependency} verbatim
+function(pyre_exportRequirement package target)
+  # find out whether the package configuration file has already been rendered
+  get_property(sealed GLOBAL PROPERTY PYRE_EXPORT_SEALED)
+  # if it has, this requirement would never reach the installed file
+  if(sealed)
+    # so complain loudly instead of shipping a package nobody can consume
+    message(FATAL_ERROR
+      "'${package}' joined an exported link interface after the {pyre} package configuration "
+      "was rendered; move the {pyre_exportRequirement} call ahead of {pyre_exportRequirements}")
+  endif()
+  # flatten the search arguments into a single blank separated string so the entry survives
+  # the trip through the property as one piece
+  string(REPLACE ";" " " arguments "${ARGN}")
+  # and stash it
+  set_property(GLOBAL APPEND PROPERTY PYRE_EXPORT_REQUIREMENTS "${package} ${target} ${arguments}")
+  # all done
+endfunction(pyre_exportRequirement)
+
+
+# verify that every external package our exported targets name has been recorded, render the
+# recorded requirements as cmake code, and hand the text back through {variable}
+function(pyre_exportRequirements variable)
+  # retrieve what the build recorded
+  get_property(requirements GLOBAL PROPERTY PYRE_EXPORT_REQUIREMENTS)
+
+  # the imported targets we know how to resolve, and the code that resolves them
+  set(known "")
+  set(text "")
+  # go through the requirements in the order they were recorded
+  foreach(requirement IN LISTS requirements)
+    # take the entry apart
+    string(REPLACE " " ";" fields "${requirement}")
+    # the first two fields name the package and the imported target it must produce
+    list(POP_FRONT fields package target)
+    # and whatever is left is the argument list for the search
+    list(JOIN fields " " arguments)
+    # remember the target so the audit below can account for it
+    list(APPEND known ${target})
+    # emit the search itself
+    string(APPEND text "find_dependency(${package} ${arguments})\n")
+    # a successful search is not proof that the imported target exists: a consumer running with
+    # {CMAKE_FIND_PACKAGE_PREFER_CONFIG} can resolve the package's own configuration file, which
+    # may well publish the target under a different name; catch that here, while we can still
+    # say something useful, rather than at the consumer's generate step
+    string(APPEND text "if(NOT TARGET ${target})\n")
+    string(APPEND text "  set(pyre_FOUND FALSE)\n")
+    string(APPEND text "  set(pyre_NOT_FOUND_MESSAGE\n")
+    string(APPEND text
+      "      \"{pyre} was built against ${package}, but locating it did not define the imported "
+      "target '${target}' that the {pyre} targets name; check whether "
+      "CMAKE_FIND_PACKAGE_PREFER_CONFIG is steering the search towards a different "
+      "${package} package\")\n")
+    string(APPEND text "  return()\n")
+    string(APPEND text "endif()\n")
+  endforeach()
+
+  # now audit the exported targets: anything they name that we cannot resolve is a target the
+  # consumer will be asked to supply, and the whole point of the exercise is that it shouldn't
+  foreach(exported pyre journal)
+    # collect the link interface
+    get_target_property(interface ${exported} INTERFACE_LINK_LIBRARIES)
+    # an empty interface has nothing to answer for
+    if(NOT interface)
+      continue()
+    endif()
+    # otherwise, look at each entry
+    foreach(dependency IN LISTS interface)
+      # a private link on a static library rides along wrapped, and would still have to be
+      # resolved by the consumer; unwrap it so it gets the same scrutiny as the rest
+      string(REGEX REPLACE "^\\$<LINK_ONLY:(.*)>$" "\\1" dependency "${dependency}")
+      # only namespaced imported targets place a burden on the consumer
+      if(NOT dependency MATCHES "^([A-Za-z0-9_+.-]+)::")
+        continue()
+      endif()
+      # and our own are resolved by the targets file itself
+      if(CMAKE_MATCH_1 STREQUAL "pyre")
+        continue()
+      endif()
+      # everything else must have been recorded at the point of the link
+      if(NOT dependency IN_LIST known)
+        message(FATAL_ERROR
+          "the exported target '${exported}' names the imported target '${dependency}', but "
+          "nothing taught the {pyre} package configuration how to find it; add a matching "
+          "{pyre_exportRequirement} call next to the {target_link_libraries} that introduced it")
+      endif()
+    endforeach()
+  endforeach()
+
+  # refuse any further recording, so a link established after this point cannot slip past the
+  # file we are about to render
+  set_property(GLOBAL PROPERTY PYRE_EXPORT_SEALED TRUE)
+  # publish the rendered text
+  set(${variable} "${text}" PARENT_SCOPE)
+  # all done
+endfunction(pyre_exportRequirements)
+
+
+# end of file

--- a/.cmake/pyre_exports.cmake
+++ b/.cmake/pyre_exports.cmake
@@ -68,8 +68,13 @@ endfunction(pyre_exportGate)
 
 # render the code that locates {package} and confirms it produced {target}, into {variable}
 function(pyre_exportSearch package target arguments variable)
+  # assemble the search, keeping it tidy when the package takes no extra arguments
+  set(call "${package}")
+  if(arguments)
+    string(APPEND call " ${arguments}")
+  endif()
   # start with the search itself
-  set(text "find_dependency(${package} ${arguments})\n")
+  set(text "find_dependency(${call})\n")
   # a successful search is not proof that the imported target exists: a consumer running with
   # {CMAKE_FIND_PACKAGE_PREFER_CONFIG} can resolve the package's own configuration file, which
   # may well publish the target under a different name; catch that here, while we can still
@@ -99,8 +104,10 @@ function(pyre_exportRequirements variable)
   get_property(requirements GLOBAL PROPERTY PYRE_EXPORT_REQUIREMENTS)
   get_property(optional GLOBAL PROPERTY PYRE_EXPORT_OPTIONAL)
 
-  # the imported targets we know how to resolve, and the code that resolves them
+  # the imported targets we know how to resolve, the subset of those that every consumer gets
+  # unconditionally, and the code that resolves them
   set(known "")
+  set(core "")
   set(text "")
 
   # tell consumers which pieces this installation carries, so that {check_required_components}
@@ -117,8 +124,10 @@ function(pyre_exportRequirements variable)
     list(POP_FRONT fields package target)
     # and whatever is left is the argument list for the search
     list(JOIN fields " " arguments)
-    # remember the target so the audit below can account for it
+    # remember the target so the audit below can account for it, and note that every consumer
+    # gets this one whether they ask for it or not
     list(APPEND known ${target})
+    list(APPEND core ${target})
     # render the search and take it as is
     pyre_exportSearch("${package}" "${target}" "${arguments}" search)
     string(APPEND text "${search}")
@@ -132,6 +141,11 @@ function(pyre_exportRequirements variable)
     list(JOIN fields " " arguments)
     # the audit accounts for it just the same
     list(APPEND known ${target})
+    # but if every consumer already resolves it, saying so again buys nothing; note that this
+    # only skips searches the core covers, so two add-ons that share a package each keep theirs
+    if(target IN_LIST core)
+      continue()
+    endif()
     # render the search
     pyre_exportSearch("${package}" "${target}" "${arguments}" search)
     # drop the trailing newline and indent the body to sit inside the test

--- a/.cmake/pyre_exports.cmake
+++ b/.cmake/pyre_exports.cmake
@@ -4,19 +4,27 @@
 # (c) 1998-2026 all rights reserved
 
 
-# record an external package that one of our exported targets names in its link interface
+# add {target} to the set of things we hand downstream, under the name {component}
+# consumers ask for the optional pieces by name, as in {find_package(pyre COMPONENTS mpi)}, and
+# the generated configuration publishes a {pyre_<component>_FOUND} flag for each one that this
+# installation actually carries
+function(pyre_exportTarget target component)
+  # make sure we are still allowed to record
+  pyre_exportGate("${target}")
+  # remember the target, so the audit knows what to inspect
+  set_property(GLOBAL APPEND PROPERTY PYRE_EXPORT_TARGETS "${target}")
+  # and the name it goes by
+  set_property(GLOBAL APPEND PROPERTY PYRE_EXPORT_COMPONENTS "${component}")
+  # all done
+endfunction(pyre_exportTarget)
+
+
+# record an external package that one of our core targets names in its link interface
 # {package} is what to look for, {target} is the imported target the search must produce, and
 # the remaining arguments are handed to {find_dependency} verbatim
 function(pyre_exportRequirement package target)
-  # find out whether the package configuration file has already been rendered
-  get_property(sealed GLOBAL PROPERTY PYRE_EXPORT_SEALED)
-  # if it has, this requirement would never reach the installed file
-  if(sealed)
-    # so complain loudly instead of shipping a package nobody can consume
-    message(FATAL_ERROR
-      "'${package}' joined an exported link interface after the {pyre} package configuration "
-      "was rendered; move the {pyre_exportRequirement} call ahead of {pyre_exportRequirements}")
-  endif()
+  # make sure we are still allowed to record
+  pyre_exportGate("${package}")
   # flatten the search arguments into a single blank separated string so the entry survives
   # the trip through the property as one piece
   string(REPLACE ";" " " arguments "${ARGN}")
@@ -26,16 +34,82 @@ function(pyre_exportRequirement package target)
 endfunction(pyre_exportRequirement)
 
 
+# record an external package that only the optional target {component} needs
+# the search lands behind a test on the component list, so a consumer that never asks for the
+# add-on is never asked to have its dependencies installed; an exported target that nobody links
+# costs nothing, since cmake resolves a link interface only when something actually uses it
+function(pyre_exportOptionalRequirement component package target)
+  # make sure we are still allowed to record
+  pyre_exportGate("${package}")
+  # flatten the search arguments, as above
+  string(REPLACE ";" " " arguments "${ARGN}")
+  # and stash the entry, tagged with the component that needs it
+  set_property(GLOBAL APPEND PROPERTY
+    PYRE_EXPORT_OPTIONAL "${component} ${package} ${target} ${arguments}")
+  # all done
+endfunction(pyre_exportOptionalRequirement)
+
+
+# complain if the package configuration has already been rendered; {what} names whatever was
+# being recorded, so the diagnostic can point at it
+function(pyre_exportGate what)
+  # ask
+  get_property(sealed GLOBAL PROPERTY PYRE_EXPORT_SEALED)
+  # if the file is already written, this record would never reach it
+  if(sealed)
+    # so complain loudly instead of shipping a package nobody can consume
+    message(FATAL_ERROR
+      "'${what}' joined the {pyre} exports after the package configuration was rendered; move "
+      "the call ahead of {pyre_exportRequirements}")
+  endif()
+  # all done
+endfunction(pyre_exportGate)
+
+
+# render the code that locates {package} and confirms it produced {target}, into {variable}
+function(pyre_exportSearch package target arguments variable)
+  # start with the search itself
+  set(text "find_dependency(${package} ${arguments})\n")
+  # a successful search is not proof that the imported target exists: a consumer running with
+  # {CMAKE_FIND_PACKAGE_PREFER_CONFIG} can resolve the package's own configuration file, which
+  # may well publish the target under a different name; catch that here, while we can still
+  # say something useful, rather than at the consumer's generate step
+  string(APPEND text "if(NOT TARGET ${target})\n")
+  string(APPEND text "  set(pyre_FOUND FALSE)\n")
+  string(APPEND text "  set(pyre_NOT_FOUND_MESSAGE\n")
+  string(APPEND text
+    "      \"{pyre} was built against ${package}, but locating it did not define the imported "
+    "target '${target}' that the {pyre} targets name; check whether "
+    "CMAKE_FIND_PACKAGE_PREFER_CONFIG is steering the search towards a different "
+    "${package} package\")\n")
+  string(APPEND text "  return()\n")
+  string(APPEND text "endif()\n")
+  # publish
+  set(${variable} "${text}" PARENT_SCOPE)
+  # all done
+endfunction(pyre_exportSearch)
+
+
 # verify that every external package our exported targets name has been recorded, render the
 # recorded requirements as cmake code, and hand the text back through {variable}
 function(pyre_exportRequirements variable)
   # retrieve what the build recorded
+  get_property(targets GLOBAL PROPERTY PYRE_EXPORT_TARGETS)
+  get_property(components GLOBAL PROPERTY PYRE_EXPORT_COMPONENTS)
   get_property(requirements GLOBAL PROPERTY PYRE_EXPORT_REQUIREMENTS)
+  get_property(optional GLOBAL PROPERTY PYRE_EXPORT_OPTIONAL)
 
   # the imported targets we know how to resolve, and the code that resolves them
   set(known "")
   set(text "")
-  # go through the requirements in the order they were recorded
+
+  # tell consumers which pieces this installation carries, so that {check_required_components}
+  # can answer {find_package(pyre COMPONENTS ...)} correctly
+  foreach(component IN LISTS components)
+    string(APPEND text "set(pyre_${component}_FOUND TRUE)\n")
+  endforeach()
+
+  # the core dependencies, which every consumer of {pyre::pyre} needs
   foreach(requirement IN LISTS requirements)
     # take the entry apart
     string(REPLACE " " ";" fields "${requirement}")
@@ -45,27 +119,31 @@ function(pyre_exportRequirements variable)
     list(JOIN fields " " arguments)
     # remember the target so the audit below can account for it
     list(APPEND known ${target})
-    # emit the search itself
-    string(APPEND text "find_dependency(${package} ${arguments})\n")
-    # a successful search is not proof that the imported target exists: a consumer running with
-    # {CMAKE_FIND_PACKAGE_PREFER_CONFIG} can resolve the package's own configuration file, which
-    # may well publish the target under a different name; catch that here, while we can still
-    # say something useful, rather than at the consumer's generate step
-    string(APPEND text "if(NOT TARGET ${target})\n")
-    string(APPEND text "  set(pyre_FOUND FALSE)\n")
-    string(APPEND text "  set(pyre_NOT_FOUND_MESSAGE\n")
-    string(APPEND text
-      "      \"{pyre} was built against ${package}, but locating it did not define the imported "
-      "target '${target}' that the {pyre} targets name; check whether "
-      "CMAKE_FIND_PACKAGE_PREFER_CONFIG is steering the search towards a different "
-      "${package} package\")\n")
-    string(APPEND text "  return()\n")
-    string(APPEND text "endif()\n")
+    # render the search and take it as is
+    pyre_exportSearch("${package}" "${target}" "${arguments}" search)
+    string(APPEND text "${search}")
+  endforeach()
+
+  # and the add-on dependencies, each behind a test on what the consumer asked for
+  foreach(requirement IN LISTS optional)
+    # take the entry apart; this one leads with the component that needs it
+    string(REPLACE " " ";" fields "${requirement}")
+    list(POP_FRONT fields component package target)
+    list(JOIN fields " " arguments)
+    # the audit accounts for it just the same
+    list(APPEND known ${target})
+    # render the search
+    pyre_exportSearch("${package}" "${target}" "${arguments}" search)
+    # drop the trailing newline and indent the body to sit inside the test
+    string(REGEX REPLACE "\n$" "" search "${search}")
+    string(REPLACE "\n" "\n  " search "${search}")
+    # and gate it on the component
+    string(APPEND text "if(\"${component}\" IN_LIST pyre_FIND_COMPONENTS)\n  ${search}\nendif()\n")
   endforeach()
 
   # now audit the exported targets: anything they name that we cannot resolve is a target the
   # consumer will be asked to supply, and the whole point of the exercise is that it shouldn't
-  foreach(exported pyre journal)
+  foreach(exported IN LISTS targets)
     # collect the link interface
     get_target_property(interface ${exported} INTERFACE_LINK_LIBRARIES)
     # an empty interface has nothing to answer for

--- a/.cmake/pyre_exports.cmake
+++ b/.cmake/pyre_exports.cmake
@@ -19,6 +19,18 @@ function(pyre_exportTarget target component)
 endfunction(pyre_exportTarget)
 
 
+# record cmake code that the generated configuration must run before any of the searches
+# use it for whatever has to be true for a search to behave, such as a language the find module
+# needs or a hint that steers it towards the right build of a package
+function(pyre_exportPrologue text)
+  # make sure we are still allowed to record
+  pyre_exportGate("prologue")
+  # and stash it; the text is kept whole, newlines and all
+  set_property(GLOBAL APPEND PROPERTY PYRE_EXPORT_PROLOGUE "${text}")
+  # all done
+endfunction(pyre_exportPrologue)
+
+
 # record an external package that one of our core targets names in its link interface
 # {package} is what to look for, {target} is the imported target the search must produce, and
 # the remaining arguments are handed to {find_dependency} verbatim
@@ -99,6 +111,7 @@ endfunction(pyre_exportSearch)
 # recorded requirements as cmake code, and hand the text back through {variable}
 function(pyre_exportRequirements variable)
   # retrieve what the build recorded
+  get_property(prologue GLOBAL PROPERTY PYRE_EXPORT_PROLOGUE)
   get_property(targets GLOBAL PROPERTY PYRE_EXPORT_TARGETS)
   get_property(components GLOBAL PROPERTY PYRE_EXPORT_COMPONENTS)
   get_property(requirements GLOBAL PROPERTY PYRE_EXPORT_REQUIREMENTS)
@@ -109,6 +122,11 @@ function(pyre_exportRequirements variable)
   set(known "")
   set(core "")
   set(text "")
+
+  # whatever has to be in place before we go looking for anything
+  foreach(chunk IN LISTS prologue)
+    string(APPEND text "${chunk}\n")
+  endforeach()
 
   # tell consumers which pieces this installation carries, so that {check_required_components}
   # can answer {find_package(pyre COMPONENTS ...)} correctly

--- a/.cmake/pyre_gsl.cmake
+++ b/.cmake/pyre_gsl.cmake
@@ -7,7 +7,7 @@
 # build the gsl package
 function(pyre_gslPackage)
   # if we have gsl
-  if(${GSL_FOUND})
+  if(GSL_FOUND)
     # install the sources straight from the source directory
     install(
       DIRECTORY packages/gsl
@@ -22,7 +22,7 @@ endfunction(pyre_gslPackage)
 # build the gsl module
 function(pyre_gslModule)
   # if we have gsl
-  if (${GSL_FOUND})
+  if (GSL_FOUND)
     Python_add_library(gslmodule MODULE WITH_SOABI)
     # adjust the name to match what python expects
     set_target_properties(gslmodule PROPERTIES LIBRARY_OUTPUT_NAME libgsl)
@@ -51,7 +51,7 @@ function(pyre_gslModule)
       extensions/gsl/stats.cc
       )
 
-    if (${MPI_FOUND})
+    if (MPI_FOUND)
       # add the MPI aware sources to the pile
       target_sources(gslmodule PRIVATE extensions/gsl/partition.cc)
       # the mpi include directories

--- a/.cmake/pyre_h5.cmake
+++ b/.cmake/pyre_h5.cmake
@@ -58,12 +58,17 @@ function(pyre_h5Lib)
     # libpyre now needs the hdf5 c library; the plain signature (matching {pyre_pyreLib}) links
     # it transitively, so consumers whose header templates call the hdf5 c api get it too
     target_link_libraries(pyre HDF5::HDF5)
+    # which puts it in our exported link interface, so downstream projects have to be able to
+    # resolve it before they load our targets; teach the package configuration to do it for them
+    pyre_exportRequirement(HDF5 HDF5::HDF5 "COMPONENTS C HL")
     # a parallel build of hdf5 exposes {mpi.h} through its public headers, so anything that
     # includes them needs the mpi usage requirements; the plain signature propagates them to
     # every consumer of {pyre}, including the {h5} bindings; this restores the handling that
     # was lost when the deprecated mpi c++ bindings were retired
     if(HDF5_IS_PARALLEL AND MPI_FOUND)
       target_link_libraries(pyre MPI::MPI_CXX)
+      # and, again, downstream projects inherit the obligation to resolve it
+      pyre_exportRequirement(MPI MPI::MPI_CXX "COMPONENTS CXX")
     endif()
   endif(HDF5_FOUND)
 endfunction(pyre_h5Lib)

--- a/.cmake/pyre_h5.cmake
+++ b/.cmake/pyre_h5.cmake
@@ -60,6 +60,19 @@ function(pyre_h5Lib)
     target_link_libraries(pyre HDF5::HDF5)
     # which puts it in our exported link interface, so downstream projects have to be able to
     # resolve it before they load our targets; teach the package configuration to do it for them
+    # {FindHDF5} probes the hdf5 c toolchain with its {h5cc} wrapper and needs a c compiler to
+    # do it; a consumer whose own project is c++ only would otherwise be told, from deep inside
+    # the module, that the wrapper cannot compile a minimal hdf5 program
+    pyre_exportPrologue(
+"if(NOT CMAKE_C_COMPILER_LOADED)
+  enable_language(C)
+endif()")
+    # steer them towards the same flavour of hdf5 we linked; without this a consumer of a
+    # parallel build resolves whichever hdf5 the module prefers, and a serial one against our
+    # parallel headers is a mismatch they have to diagnose themselves
+    if(HDF5_IS_PARALLEL)
+      pyre_exportPrologue("set(HDF5_PREFER_PARALLEL ON)")
+    endif()
     pyre_exportRequirement(HDF5 HDF5::HDF5 "COMPONENTS C HL")
     # a parallel build of hdf5 exposes {mpi.h} through its public headers, so anything that
     # includes them needs the mpi usage requirements; the plain signature propagates them to

--- a/.cmake/pyre_journal.cmake
+++ b/.cmake/pyre_journal.cmake
@@ -58,6 +58,8 @@ function(pyre_journalLib)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/lib>
     $<INSTALL_INTERFACE:${PYRE_DEST_INCLUDE}>
     )
+  # journal is consumable on its own, and its headers are c++23 just like the rest
+  target_compile_features(journal PUBLIC cxx_std_23)
   # add the sources
   target_sources(journal
     PRIVATE

--- a/.cmake/pyre_journal.cmake
+++ b/.cmake/pyre_journal.cmake
@@ -85,6 +85,8 @@ function(pyre_journalLib)
     EXPORT pyre-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
+  # and publish it; journal is consumable entirely on its own
+  pyre_exportTarget(journal journal)
 
   # all done
 endfunction(pyre_journalLib)

--- a/.cmake/pyre_mpi.cmake
+++ b/.cmake/pyre_mpi.cmake
@@ -68,7 +68,7 @@ endfunction(pyre_mpiLib)
 # build the mpi module
 function(pyre_mpiModule)
   # if we have mpi
-  if (${MPI_FOUND})
+  if (MPI_FOUND)
     Python_add_library(mpimodule MODULE WITH_SOABI)
     # adjust the name to match what python expects
     set_target_properties(mpimodule PROPERTIES LIBRARY_OUTPUT_NAME libmpi)

--- a/.cmake/pyre_mpi.cmake
+++ b/.cmake/pyre_mpi.cmake
@@ -60,6 +60,17 @@ function(pyre_mpiLib)
       )
     add_library(pyre::mpi ALIAS mpi)
 
+    # hand it downstream; the headers ship either way, so without this a consumer finds
+    # {pyre/mpi.h} in the prefix and has nothing to link it against
+    install(
+      TARGETS mpi
+      EXPORT pyre-targets
+      )
+    pyre_exportTarget(mpi mpi)
+    # its link interface names the mpi imported target, so a consumer that asks for this
+    # component has to be able to resolve it
+    pyre_exportOptionalRequirement(mpi MPI MPI::MPI_CXX "COMPONENTS CXX")
+
   endif(MPI_FOUND)
   # all done
 endfunction(pyre_mpiLib)

--- a/.cmake/pyre_postgres.cmake
+++ b/.cmake/pyre_postgres.cmake
@@ -30,14 +30,26 @@ function(pyre_postgresLib)
     add_library(postgres INTERFACE)
     # specify the directory for the library compilation products
     pyre_library_directory(postgres lib)
-    # it stands on its own over libpq, and leans on journal for its diagnostics
-    target_link_libraries(postgres INTERFACE pyre journal ${PostgreSQL_LIBRARIES})
+    # it stands on its own over libpq, and leans on journal for its diagnostics; naming the
+    # imported target rather than the raw libraries keeps absolute paths out of the export, and
+    # carries the libpq include directories along with it, which the build interface below used
+    # to supply only to ourselves
+    target_link_libraries(postgres INTERFACE pyre journal PostgreSQL::PostgreSQL)
     target_include_directories(postgres INTERFACE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/lib>
-      $<BUILD_INTERFACE:${PostgreSQL_INCLUDE_DIRS}>
       $<INSTALL_INTERFACE:${PYRE_DEST_INCLUDE}>
       )
     add_library(pyre::postgres ALIAS postgres)
+
+    # hand it downstream; the headers ship either way, so without this a consumer finds
+    # {pyre/postgres.h} in the prefix and has nothing to link it against
+    install(
+      TARGETS postgres
+      EXPORT pyre-targets
+      )
+    pyre_exportTarget(postgres postgres)
+    # and a consumer that asks for this component has to be able to resolve libpq
+    pyre_exportOptionalRequirement(postgres PostgreSQL PostgreSQL::PostgreSQL)
 
   endif(PostgreSQL_FOUND)
   # all done

--- a/.cmake/pyre_postgres.cmake
+++ b/.cmake/pyre_postgres.cmake
@@ -47,7 +47,7 @@ endfunction(pyre_postgresLib)
 # build the postgres module
 function(pyre_postgresModule)
   # if we have postgres
-  if (${PostgreSQL_FOUND})
+  if (PostgreSQL_FOUND)
     Python_add_library(postgresmodule MODULE WITH_SOABI)
     # adjust the name to match what python expects; the module is {postgres}, and it lands in
     # {pyre.extensions}, where the package imports it as {libpq}

--- a/.cmake/pyre_pyre.cmake
+++ b/.cmake/pyre_pyre.cmake
@@ -152,6 +152,8 @@ function(pyre_pyreLib)
     EXPORT pyre-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
+  # and publish it, so consumers can ask for it by name
+  pyre_exportTarget(pyre pyre)
 
   # all done
 endfunction(pyre_pyreLib)

--- a/.cmake/pyre_pyre.cmake
+++ b/.cmake/pyre_pyre.cmake
@@ -109,6 +109,9 @@ function(pyre_pyreLib)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/lib>
     $<INSTALL_INTERFACE:${PYRE_DEST_INCLUDE}>
     )
+  # our headers are c++23; say so, so that consumers get the standard raised for them instead
+  # of discovering the requirement when every include explodes
+  target_compile_features(pyre PUBLIC cxx_std_23)
   # add the sources
   target_sources(pyre
     PRIVATE

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -157,7 +157,7 @@ jobs:
           # nothing here locates hdf5 or selects a language standard; the package configuration
           # in the prefix has to do both, which is what this step is checking
           echo " -- configuring a downstream project against the installed prefix"
-          cmake -DCMAKE_PREFIX_PATH=${prefix} -DCMAKE_CXX_COMPILER=${cxx} -DPYRE_CONSUMER_EXPECT_HDF5=ON ${{github.workspace}}/pyre/etc/cmake/consumer
+          cmake -DCMAKE_PREFIX_PATH=${prefix} -DCMAKE_CXX_COMPILER=${cxx} -DPYRE_CONSUMER_EXPECT_MPI=ON -DPYRE_CONSUMER_EXPECT_HDF5=ON ${{github.workspace}}/pyre/etc/cmake/consumer
           echo " -- building it"
           make -j$(nproc)
           echo " -- running it"

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -148,4 +148,22 @@ jobs:
           # which this runner does not have
           ctest --output-on-failure -E postgres
 
+      - name: consume the installed package
+        run: |
+          echo " -- switching to the consumer build directory"
+          cd ${{runner.temp}}
+          mkdir consumer
+          cd consumer
+          # nothing here locates hdf5 or selects a language standard; the package configuration
+          # in the prefix has to do both, which is what this step is checking
+          echo " -- configuring a downstream project against the installed prefix"
+          cmake -DCMAKE_PREFIX_PATH=${prefix} -DCMAKE_CXX_COMPILER=${cxx} -DPYRE_CONSUMER_EXPECT_HDF5=ON ${{github.workspace}}/pyre/etc/cmake/consumer
+          echo " -- building it"
+          make -j$(nproc)
+          echo " -- running it"
+          ctest --output-on-failure
+        env:
+          prefix: ${{runner.temp}}/install
+          cxx: ${{matrix.cxx}}
+
 # end of file

--- a/.github/workflows/pr-cmake.yaml
+++ b/.github/workflows/pr-cmake.yaml
@@ -146,7 +146,7 @@ jobs:
           # nothing here locates hdf5 or selects a language standard; the package configuration
           # in the prefix has to do both, which is what this step is checking
           echo " -- configuring a downstream project against the installed prefix"
-          cmake -DCMAKE_PREFIX_PATH=${prefix} -DCMAKE_CXX_COMPILER=${cxx} -DPYRE_CONSUMER_EXPECT_HDF5=ON ${{github.workspace}}/pyre/etc/cmake/consumer
+          cmake -DCMAKE_PREFIX_PATH=${prefix} -DCMAKE_CXX_COMPILER=${cxx} -DPYRE_CONSUMER_EXPECT_MPI=ON -DPYRE_CONSUMER_EXPECT_HDF5=ON ${{github.workspace}}/pyre/etc/cmake/consumer
           echo " -- building it"
           make -j$(nproc)
           echo " -- running it"

--- a/.github/workflows/pr-cmake.yaml
+++ b/.github/workflows/pr-cmake.yaml
@@ -137,4 +137,81 @@ jobs:
           # which this runner does not have
           ctest -E postgres
 
+      - name: consume the installed package
+        run: |
+          echo " -- switching to the consumer build directory"
+          cd ${{runner.temp}}
+          mkdir consumer
+          cd consumer
+          # nothing here locates hdf5 or selects a language standard; the package configuration
+          # in the prefix has to do both, which is what this step is checking
+          echo " -- configuring a downstream project against the installed prefix"
+          cmake -DCMAKE_PREFIX_PATH=${prefix} -DCMAKE_CXX_COMPILER=${cxx} -DPYRE_CONSUMER_EXPECT_HDF5=ON ${{github.workspace}}/pyre/etc/cmake/consumer
+          echo " -- building it"
+          make -j$(nproc)
+          echo " -- running it"
+          ctest --output-on-failure
+        env:
+          prefix: ${{runner.temp}}/install
+          cxx: ${{matrix.cxx}}
+
+  # build without hdf5 and confirm the package configuration does not ask consumers for it; this
+  # is the only way to catch a configuration that demands more than the installation actually uses
+  minimal:
+    name: without hdf5 on ubuntu-26.04
+    runs-on: ubuntu-26.04
+    env:
+      pythonVersion: "3.14"
+      prefix: ${{github.workspace}}/install
+
+    steps:
+      - name: ubuntu-26.04 refresh
+        run: |
+          echo " -- update the package cache"
+          sudo apt update
+          echo " -- install our dependencies"
+          # hdf5 stays installed on purpose: we disable the search rather than remove the
+          # package, so that what drops the dependency is demonstrably the configuration
+          sudo apt install -y cmake openssh-server libgsl-dev libopenmpi-dev libhdf5-dev
+
+      - name: python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: install dependencies
+        run: |
+          python${pythonVersion} -m pip install --upgrade pip
+          pip3 install pybind11 PyYAML numpy
+
+      - name: checkout pyre
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: 'pyre'
+
+      - name: build pyre without hdf5
+        run: |
+          echo " -- switching to the build directory"
+          cd ${{runner.temp}}
+          mkdir build
+          cd build
+          echo " -- configuring the build with the hdf5 search disabled"
+          cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-15 -DCMAKE_CXX_COMPILER=g++-15 -DPython_ROOT_DIR=${pythonLocation} -Dpybind11_DIR=${pythonLocation}/lib/python${pythonVersion}/site-packages/pybind11/share/cmake/pybind11 -DCMAKE_DISABLE_FIND_PACKAGE_HDF5=ON -DPYRE_BUILD_TESTING=OFF ${{github.workspace}}/pyre
+          echo " -- building pyre"
+          make -j$(nproc) install
+
+      - name: consume the installed package
+        run: |
+          echo " -- switching to the consumer build directory"
+          cd ${{runner.temp}}
+          mkdir consumer
+          cd consumer
+          echo " -- configuring a downstream project against the installed prefix"
+          cmake -DCMAKE_PREFIX_PATH=${prefix} -DCMAKE_CXX_COMPILER=g++-15 -DPYRE_CONSUMER_EXPECT_HDF5=OFF ${{github.workspace}}/pyre/etc/cmake/consumer
+          echo " -- building it"
+          make -j$(nproc)
+          echo " -- running it"
+          ctest --output-on-failure
+
 # end of file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ include(pyre_mpi)
 include(pyre_gsl)
 include(pyre_h5)
 include(pyre_postgres)
+include(pyre_exports)
 
 # programs
 find_program(BASH_PROGRAM bash)
@@ -176,6 +177,10 @@ write_basic_package_version_file(
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
     )
+
+# audit the exported link interfaces and render the searches that resolve them; every library
+# has been built by now, so the record of what they link is complete
+pyre_exportRequirements(PYRE_EXPORT_REQUIREMENTS)
 
 # install config file for find_package
 configure_package_config_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ find_package(GSL)
 
 # hdf5
 # if mpi is installed
-if(${MPI_FOUND})
+if(MPI_FOUND)
     # prefer the parallel version of hdf5
     set(HDF5_PREFER_PARALLEL ON)
     # leave a marker
@@ -106,10 +106,10 @@ find_package(HDF5 COMPONENTS C HL)
 message(STATUS "Parallel HDF5: ${HDF5_IS_PARALLEL}")
 
 # find cuda if it is required
-if(${WITH_CUDA})
+if(WITH_CUDA)
     # add the cuda package
     find_package(CUDA REQUIRED)
-  if(${CUDA_FOUND})
+  if(CUDA_FOUND)
     enable_language(CUDA)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ if(MPI_FOUND)
     # leave a marker
     message(STATUS "We have MPI; ask for parallel HDF5: ${HDF5_PREFER_PARALLEL}")
 endif()
+# our own sources are c++ only, so nothing has enabled the c language yet; {FindHDF5} probes
+# the hdf5 c toolchain with its {h5cc} wrapper and cannot do it without a c compiler
+enable_language(C)
 # hunt it down; pyre::h5 wraps the hdf5 C api directly, so the C++ component is no longer needed
 find_package(HDF5 COMPONENTS C HL)
 # report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@
 
 # cmake setup
 # v3.18 is needed to pass Development.Module to FindPython
-cmake_minimum_required(VERSION 3.19...3.25)
+# v3.20 is needed for the {cxx_std_23} compile feature our exported targets carry
+cmake_minimum_required(VERSION 3.20...3.25)
 
 # options
 option(WITH_CUDA "enable support for CUDA" OFF)

--- a/etc/cmake/consumer/CMakeLists.txt
+++ b/etc/cmake/consumer/CMakeLists.txt
@@ -15,6 +15,7 @@ project(pyre-consumer LANGUAGES CXX)
 option(PYRE_CONSUMER_EXPECT_HDF5 "the installation was built against hdf5" OFF)
 option(PYRE_CONSUMER_EXPECT_MPI "the installation carries the mpi add-on" OFF)
 option(PYRE_CONSUMER_EXPECT_CUDA "the installation carries the cuda add-on" OFF)
+option(PYRE_CONSUMER_EXPECT_POSTGRES "the installation carries the postgres add-on" OFF)
 
 # deliberately, there is no {find_package(HDF5)} or {find_package(MPI)} ahead of this call, and
 # no {CMAKE_CXX_STANDARD} anywhere in this file: resolving the dependencies of the exported
@@ -122,6 +123,22 @@ if(PYRE_CONSUMER_EXPECT_MPI)
   target_link_libraries(mpi PRIVATE pyre::mpi)
   # and it must run cleanly
   add_test(NAME mpi COMMAND mpi)
+endif()
+
+# the postgres add-on, on the same terms as mpi above
+if(PYRE_CONSUMER_EXPECT_POSTGRES)
+  # asking for the component is what sends the configuration looking for libpq
+  find_package(pyre REQUIRED COMPONENTS postgres)
+  # which must have resolved the imported target the add-on names
+  if(NOT TARGET PostgreSQL::PostgreSQL)
+    message(FATAL_ERROR "asking for the 'postgres' component did not locate libpq")
+  endif()
+  # compiling this proves the libpq headers arrive through {pyre::postgres}
+  add_executable(postgres postgres.cc)
+  # the one link a client should need
+  target_link_libraries(postgres PRIVATE pyre::postgres)
+  # and it must run cleanly
+  add_test(NAME postgres COMMAND postgres)
 endif()
 
 # the cuda add-on, on the same terms as mpi above

--- a/etc/cmake/consumer/CMakeLists.txt
+++ b/etc/cmake/consumer/CMakeLists.txt
@@ -14,6 +14,7 @@ project(pyre-consumer LANGUAGES CXX)
 # what the installation under test is expected to carry
 option(PYRE_CONSUMER_EXPECT_HDF5 "the installation was built against hdf5" OFF)
 option(PYRE_CONSUMER_EXPECT_MPI "the installation carries the mpi add-on" OFF)
+option(PYRE_CONSUMER_EXPECT_CUDA "the installation carries the cuda add-on" OFF)
 
 # deliberately, there is no {find_package(HDF5)} or {find_package(MPI)} ahead of this call, and
 # no {CMAKE_CXX_STANDARD} anywhere in this file: resolving the dependencies of the exported
@@ -118,6 +119,23 @@ if(PYRE_CONSUMER_EXPECT_MPI)
   target_link_libraries(mpi PRIVATE pyre::mpi)
   # and it must run cleanly
   add_test(NAME mpi COMMAND mpi)
+endif()
+
+# the cuda add-on, on the same terms as mpi above
+if(PYRE_CONSUMER_EXPECT_CUDA)
+  # asking for the component is what sends the configuration looking for what it needs
+  find_package(pyre REQUIRED COMPONENTS cuda)
+  # the deprecated {FindCUDA} builds its library list out of the threads imported target, so
+  # that is the one the add-on leans on
+  if(NOT TARGET Threads::Threads)
+    message(FATAL_ERROR "asking for the 'cuda' component did not locate threads")
+  endif()
+  # compiling this proves the cuda headers and our own arrive through {pyre::cuda}
+  add_executable(cuda cuda.cc)
+  # the one link a client should need
+  target_link_libraries(cuda PRIVATE pyre::cuda)
+  # and it must run cleanly
+  add_test(NAME cuda COMMAND cuda)
 endif()
 
 # the hdf5 wrappers, when this installation has them

--- a/etc/cmake/consumer/CMakeLists.txt
+++ b/etc/cmake/consumer/CMakeLists.txt
@@ -20,6 +20,9 @@ option(PYRE_CONSUMER_EXPECT_CUDA "the installation carries the cuda add-on" OFF)
 # no {CMAKE_CXX_STANDARD} anywhere in this file: resolving the dependencies of the exported
 # targets and raising the language standard are the package configuration's job, and whether it
 # does them is precisely what this project tests
+# note also that this comes before any {add_executable} below, which is what lets the
+# configuration turn the compiler extensions off for our targets; a project that declares its
+# targets first would quietly get {gnu++23} instead
 find_package(pyre REQUIRED)
 
 # the export set: these are the two targets the package promises

--- a/etc/cmake/consumer/CMakeLists.txt
+++ b/etc/cmake/consumer/CMakeLists.txt
@@ -13,6 +13,7 @@ project(pyre-consumer LANGUAGES CXX)
 
 # what the installation under test is expected to carry
 option(PYRE_CONSUMER_EXPECT_HDF5 "the installation was built against hdf5" OFF)
+option(PYRE_CONSUMER_EXPECT_MPI "the installation carries the mpi add-on" OFF)
 
 # deliberately, there is no {find_package(HDF5)} or {find_package(MPI)} ahead of this call, and
 # no {CMAKE_CXX_STANDARD} anywhere in this file: resolving the dependencies of the exported
@@ -26,6 +27,24 @@ foreach(target pyre::pyre pyre::journal)
   if(NOT TARGET ${target})
     # if not, the installation is unusable
     message(FATAL_ERROR "the {pyre} package did not define '${target}'")
+  endif()
+endforeach()
+
+# the core pieces announce themselves as components, so that {find_package(pyre COMPONENTS ...)}
+# can be answered; check the two that are always there
+foreach(component pyre journal)
+  # each must have been published by the configuration
+  if(NOT pyre_${component}_FOUND)
+    message(FATAL_ERROR "the {pyre} package did not publish the '${component}' component")
+  endif()
+endforeach()
+
+# the optional add-ons ship only when the build found what they wrap; whenever one is announced,
+# the target that goes with it has to be there too, or the announcement is a lie
+foreach(component mpi postgres cuda)
+  # an add-on this installation does not carry is not a problem
+  if(pyre_${component}_FOUND AND NOT TARGET pyre::${component})
+    message(FATAL_ERROR "the {pyre} package announced '${component}' but defined no target")
   endif()
 endforeach()
 
@@ -82,6 +101,24 @@ add_executable(pyre pyre.cc)
 target_link_libraries(pyre PRIVATE pyre::pyre)
 # and it must run cleanly
 add_test(NAME pyre COMMAND pyre)
+
+# the mpi add-on, when this installation has it; asking for it by name is what makes the
+# configuration go looking for mpi, which it deliberately does not do for consumers who never
+# mention the component
+if(PYRE_CONSUMER_EXPECT_MPI)
+  # this second call re-runs the configuration, this time with a component list
+  find_package(pyre REQUIRED COMPONENTS mpi)
+  # which must have resolved the imported target the add-on names
+  if(NOT TARGET MPI::MPI_CXX)
+    message(FATAL_ERROR "asking for the 'mpi' component did not locate mpi")
+  endif()
+  # compiling this proves the mpi headers arrive through {pyre::mpi}
+  add_executable(mpi mpi.cc)
+  # the one link a client should need
+  target_link_libraries(mpi PRIVATE pyre::mpi)
+  # and it must run cleanly
+  add_test(NAME mpi COMMAND mpi)
+endif()
 
 # the hdf5 wrappers, when this installation has them
 if(PYRE_CONSUMER_EXPECT_HDF5)

--- a/etc/cmake/consumer/CMakeLists.txt
+++ b/etc/cmake/consumer/CMakeLists.txt
@@ -1,0 +1,97 @@
+# -*- cmake -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# a mock downstream project
+# it exists to exercise the {pyre} package configuration the way a real client does: from the
+# outside, against an installed prefix, with nothing but {find_package} to go on; it is never
+# built as part of {pyre} itself
+cmake_minimum_required(VERSION 3.20)
+project(pyre-consumer LANGUAGES CXX)
+
+# what the installation under test is expected to carry
+option(PYRE_CONSUMER_EXPECT_HDF5 "the installation was built against hdf5" OFF)
+
+# deliberately, there is no {find_package(HDF5)} or {find_package(MPI)} ahead of this call, and
+# no {CMAKE_CXX_STANDARD} anywhere in this file: resolving the dependencies of the exported
+# targets and raising the language standard are the package configuration's job, and whether it
+# does them is precisely what this project tests
+find_package(pyre REQUIRED)
+
+# the export set: these are the two targets the package promises
+foreach(target pyre::pyre pyre::journal)
+  # each of them must have made it out of the targets file
+  if(NOT TARGET ${target})
+    # if not, the installation is unusable
+    message(FATAL_ERROR "the {pyre} package did not define '${target}'")
+  endif()
+endforeach()
+
+# the version file must have told us what we found
+if(NOT pyre_VERSION)
+  # otherwise {find_package(pyre 2.0)} would have nothing to compare against
+  message(FATAL_ERROR "the {pyre} package did not report a version")
+endif()
+
+# the standard must have arrived as a usage requirement, without extensions
+if(CMAKE_CXX_EXTENSIONS)
+  # a consumer that gets {gnu++23} is not getting what our headers were written against
+  message(FATAL_ERROR "the {pyre} package left the compiler extensions turned on")
+endif()
+
+# now check the exported link interface against what this installation was built with; asking
+# about the interface rather than about the global target namespace matters, because a bare
+# {if(TARGET HDF5::HDF5)} would pass for the wrong reason the moment anything else finds hdf5
+get_target_property(interface pyre::pyre INTERFACE_LINK_LIBRARIES)
+# if hdf5 was in the build
+if(PYRE_CONSUMER_EXPECT_HDF5)
+  # the wrappers must be in the interface
+  if(NOT "HDF5::HDF5" IN_LIST interface)
+    message(FATAL_ERROR "'pyre::pyre' does not carry HDF5::HDF5 in its link interface")
+  endif()
+  # and the configuration must have resolved it on our behalf
+  if(NOT TARGET HDF5::HDF5)
+    message(FATAL_ERROR "the {pyre} package did not locate hdf5 for us")
+  endif()
+# otherwise
+else()
+  # nothing in the interface may demand it
+  if("HDF5::HDF5" IN_LIST interface)
+    message(FATAL_ERROR "'pyre::pyre' demands HDF5::HDF5 from an installation built without it")
+  endif()
+endif()
+
+# the drivers get run, not just built: unresolved symbols, the {libpyre} to {libjournal} lookup
+# at load time, and headers that disagree with the library they were installed next to are all
+# invisible to a compile-only check
+enable_testing()
+
+# journal on its own
+add_executable(journal journal.cc)
+# it links against nothing else
+target_link_libraries(journal PRIVATE pyre::journal)
+# and it must run cleanly
+add_test(NAME journal COMMAND journal)
+
+# libpyre; note that we never name {pyre::journal} here, so this also checks that it arrives
+# transitively through the exported interface
+add_executable(pyre pyre.cc)
+# the one link a client should need
+target_link_libraries(pyre PRIVATE pyre::pyre)
+# and it must run cleanly
+add_test(NAME pyre COMMAND pyre)
+
+# the hdf5 wrappers, when this installation has them
+if(PYRE_CONSUMER_EXPECT_HDF5)
+  # compiling this at all proves the hdf5 headers arrive through {pyre::pyre}
+  add_executable(h5 h5.cc)
+  # again, the single link
+  target_link_libraries(h5 PRIVATE pyre::pyre)
+  # and it must run cleanly
+  add_test(NAME h5 COMMAND h5)
+endif()
+
+
+# end of file

--- a/etc/cmake/consumer/cuda.cc
+++ b/etc/cmake/consumer/cuda.cc
@@ -1,0 +1,29 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// get the cuda layers; this header reaches both the cuda runtime and our own {pyre/memory.h}
+// and {pyre/journal.h}, so it compiles only if the exported {pyre::cuda} target carries the
+// cuda include directories and stands on {pyre}
+#include <pyre/cuda.h>
+
+
+// verify that the cuda add-on of an installation that carries it is reachable by a client that
+// asks for the component and names nothing but {pyre::cuda}
+// nothing here touches the driver api, so this passes on a machine with no gpu attached
+int
+main()
+{
+    // name a type from the wrappers; requiring it to be complete is what forces the compiler
+    // to work through the cuda headers
+    static_assert(sizeof(pyre::cuda::memory::managed_t<double>) > 0);
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/etc/cmake/consumer/h5.cc
+++ b/etc/cmake/consumer/h5.cc
@@ -1,0 +1,37 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// get the h5 wrappers; this header reaches {hdf5.h}, so it compiles only if the hdf5 include
+// directories arrive through the exported {pyre::pyre} target, with no help from this project
+#include <pyre/h5.h>
+// and the version, so that we touch a symbol from {libpyre} as well
+#include <pyre/version.h>
+
+
+// verify that the hdf5 layer of an installation built against hdf5 is reachable by a client
+// that names nothing but {pyre::pyre}
+int
+main()
+{
+    // name a type from the wrappers; requiring it to be complete is what forces the compiler
+    // to work through {hdf5.h}
+    static_assert(sizeof(pyre::h5::types::Datatype) > 0);
+
+    // and pull something out of the library, so this is a link test as well as a compile test
+    const auto version = pyre::version::version();
+    // the major number of any real release is not negative
+    if (std::get<0>(version) < 0) {
+        // which makes this unreachable; it exists so the call cannot be optimized away
+        return 1;
+    }
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/etc/cmake/consumer/journal.cc
+++ b/etc/cmake/consumer/journal.cc
@@ -1,0 +1,29 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// get the journal, the way a downstream client would
+#include <pyre/journal.h>
+
+
+// verify that {libjournal} is consumable on its own, i.e. that its headers are installed where
+// the exported target says they are and that its symbols resolve at load time
+int
+main()
+{
+    // make a channel
+    auto channel = pyre::journal::info_t("pyre.consumer.journal");
+    // mute it, so that a successful run says nothing
+    channel.deactivate();
+    // and exercise it; this is what pulls a symbol out of the library
+    channel << "the installed journal is reachable" << pyre::journal::endl(__HERE__);
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/etc/cmake/consumer/mpi.cc
+++ b/etc/cmake/consumer/mpi.cc
@@ -1,0 +1,29 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// get the mpi wrappers; this header reaches {mpi.h}, so it compiles only if the mpi usage
+// requirements arrive through the exported {pyre::mpi} target
+#include <pyre/mpi.h>
+
+
+// verify that the mpi add-on of an installation that carries it is reachable by a client that
+// asks for the component and names nothing but {pyre::mpi}
+// there is no {MPI_Init} here on purpose: this checks the package, not the runtime, so it has
+// to pass outside {mpiexec}
+int
+main()
+{
+    // name a type from the wrappers; requiring it to be complete is what forces the compiler
+    // to work through {mpi.h}
+    static_assert(sizeof(pyre::mpi::communicator_t) > 0);
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/etc/cmake/consumer/postgres.cc
+++ b/etc/cmake/consumer/postgres.cc
@@ -1,0 +1,30 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// get the postgres wrappers; this header reaches {libpq-fe.h}, so it compiles only if the
+// libpq include directories arrive through the exported {pyre::postgres} target
+#include <pyre/postgres.h>
+
+
+// verify that the postgres add-on of an installation that carries it is reachable by a client
+// that asks for the component and names nothing but {pyre::postgres}
+// there is no connection attempt here on purpose: this checks the package, not the runtime, so
+// it has to pass on a machine with no server of its own; the {pyre.db} and {pyre-postgres}
+// suites are the ones that want a live database
+int
+main()
+{
+    // name a type from the wrappers; requiring it to be complete is what forces the compiler
+    // to work through {libpq-fe.h}
+    static_assert(sizeof(pyre::postgres::connection_t) > 0);
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/etc/cmake/consumer/pyre.cc
+++ b/etc/cmake/consumer/pyre.cc
@@ -1,0 +1,50 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// get the version, which is where the library and its headers can disagree
+#include <pyre/version.h>
+// and the journal, which we never link against explicitly; it has to arrive through {pyre::pyre}
+#include <pyre/journal.h>
+
+
+// verify that a client that knows nothing but {pyre::pyre} gets a working library: the headers
+// where the exported target says they are, the symbols of {libpyre} at load time, {libjournal}
+// pulled in transitively, and headers that match the library installed alongside them
+int
+main()
+{
+    // ask the library what it was built as
+    const auto library = pyre::version::version();
+    // and ask the headers what they describe
+    const auto headers = pyre::version::headerVersion();
+
+    // a mismatch means the prefix has a stale library or stale headers
+    if (library != headers) {
+        // so complain
+        auto channel = pyre::journal::error_t("pyre.consumer.version");
+        // with the two versions side by side
+        channel
+            // what
+            << "the installed library and headers disagree about the version"
+            << pyre::journal::newline
+            // the details
+            << "library: " << std::get<0>(library) << "." << std::get<1>(library) << "."
+            << std::get<2>(library) << "." << std::get<3>(library) << pyre::journal::newline
+            << "headers: " << std::get<0>(headers) << "." << std::get<1>(headers) << "."
+            << std::get<2>(headers) << "." << std::get<3>(headers)
+            // where
+            << pyre::journal::endl(__HERE__);
+        // and fail
+        return 1;
+    }
+
+    // all done
+    return 0;
+}
+
+
+// end of file


### PR DESCRIPTION
The exported target `pyre::pyre` links against the imported targets `HDF5::HDF5` and, when the build resolved a parallel HDF5, `MPI::MPI_CXX`. Those targets must exist before `pyre::pyre` is loaded, but the installed `pyre-config.cmake` never located them, so a downstream project calling `find_package(pyre)` failed at generate time unless it had located HDF5 and MPI itself first.

This branch fixes that, and closes the gaps that let it happen: the package configuration is now generated from the build rather than maintained alongside it, and there is a mock downstream project in CI that exercises the installed package the way a real client does.

## Generating the configuration from the link sites

`.cmake/pyre_exports.cmake` records what the exported targets need, at the point where the need arises. Next to each `target_link_libraries` that puts an imported target into an exported interface sits a matching call:

```cmake
target_link_libraries(pyre HDF5::HDF5)
pyre_exportRequirement(HDF5 HDF5::HDF5 "COMPONENTS C HL")
```

`pyre_exportRequirements` renders those records into `pyre-config.cmake` immediately before `configure_package_config_file`. The installed file contains no conditionals: it states what that particular installation needs, resolved at build time.

Three properties follow from generating rather than maintaining it. There is one source of truth, adjacent to the link, so a new dependency is one line in the same block. Over-broad propagation is structurally impossible, because a dependency can only be recorded where it is linked. And the file cannot drift, because two checks enforce it:

- **An audit.** Before rendering, `pyre_exportRequirements` walks `INTERFACE_LINK_LIBRARIES` on every exported target and fails the configure for any namespaced imported target that was not recorded. This catches dependencies introduced in configurations the CI matrix does not build — it caught `Threads::Threads`, which `FindCUDA` smuggles into `${CUDA_LIBRARIES}` and which would otherwise have shipped as an unresolvable name in the `pyre::cuda` interface.
- **A seal.** `export()` and `install(EXPORT)` bind at generate time while `configure_package_config_file` binds at configure time, so a link established after the configuration is rendered would reach consumers without appearing in it. Recording is refused once rendering has happened.

Each generated search is followed by a check that it produced the imported target the export names. A successful `find_dependency(HDF5)` does not imply `HDF5::HDF5` exists: under `CMAKE_FIND_PACKAGE_PREFER_CONFIG`, routine in conda and spack environments, the search resolves HDF5's own configuration package, which publishes lowercase `hdf5::hdf5`. Without the check the configuration reports success and the consumer dies later with an unresolved target; with it, `find_package` fails with `pyre_NOT_FOUND_MESSAGE` naming the cause.

## Exported add-ons and components

`pyre::mpi`, `pyre::postgres` and `pyre::cuda` were created and aliased but never added to the export set, while their headers were installed unconditionally. A downstream project found `pyre/mpi.h` in the prefix with nothing to link against. All three are now exported, and the configuration publishes a `pyre_<component>_FOUND` flag for each piece an installation carries, so `check_required_components` can answer `find_package(pyre COMPONENTS mpi)` — which previously always failed, since nothing defined `pyre_mpi_FOUND`.

The dependencies of an add-on are resolved only when a consumer asks for its component:

```cmake
if("mpi" IN_LIST pyre_FIND_COMPONENTS)
  find_dependency(MPI COMPONENTS CXX)
```

so a consumer that wants only `pyre::pyre` is not asked to have MPI installed. Cmake resolves a link interface only when something links the target, so an exported add-on that nobody uses costs its consumers nothing.

Two of the three needed repair before exporting them was meaningful. `postgres` named `${PostgreSQL_LIBRARIES}` — absolute paths that would have been written verbatim into `pyre-targets.cmake` — and now names `PostgreSQL::PostgreSQL`, which also carries the libpq include directories that a `$<BUILD_INTERFACE:>` entry previously supplied only to ourselves. `cuda` linked nothing that put pyre's headers on the include path, so it could not have compiled its own `pyre/cuda.h`, which reaches `pyre/memory.h` and `pyre/journal.h`; it now links `pyre` and carries the same build and install interface include directories as the others.

## The language standard

The exported targets never declared their C++ standard, so every downstream project had to set `CMAKE_CXX_STANDARD 23` by hand or watch every include fail. Both core targets now carry `target_compile_features(... PUBLIC cxx_std_23)`, and the configuration sets `CMAKE_CXX_EXTENSIONS OFF` so consumers compile as strict `c++23`.

That second part has a limitation worth stating plainly, because it cannot be fixed: `CXX_EXTENSIONS` is a plain target property rather than an interface one, so it cannot propagate through an exported target, and a target picks the setting up only when it is created. A project that declares its targets before calling `find_package(pyre)` will quietly compile as `gnu++23`. The configuration says so at the point where a consumer will read it.

## Locating HDF5

`project(PYRE ... LANGUAGES CXX)` means the C language was never enabled, yet `FindHDF5` probes the HDF5 C toolchain with its `h5cc` wrapper and needs a C compiler to do it. The build now enables C immediately before the search, and the generated configuration does the same for consumers when they have not enabled it themselves.

The configuration also replays `HDF5_PREFER_PARALLEL` when the build resolved a parallel HDF5. Without it a consumer searched without the hint and could resolve a serial HDF5 against parallel-built headers — a real inconsistency rather than a cosmetic warning.

## The downstream consumer project

`etc/cmake/consumer` is a standalone cmake project, configured separately against an installed prefix. It lives under `etc/` alongside `etc/ci` and `etc/docker`, which is where this repository keeps material that CI consumes and neither build system compiles; `mm` globs `tests/<stem>/**` for sources, so a directory there would be safe only until a suite took that name.

It calls `find_package(pyre REQUIRED)` with no prior `find_package(HDF5)` and sets no language standard, then asserts on the content of `pyre::pyre`'s link interface rather than on the global target namespace. Six drivers are built and run under `ctest`, gated by what the installation carries: `journal` links `pyre::journal` alone; `pyre` links `pyre::pyre` alone and compares `pyre::version::version()` against `headerVersion()`, so a prefix with a stale library or stale headers fails; `h5`, `mpi`, `cuda` and `postgres` each include the corresponding gateway header and link only the add-on target. The add-on drivers ask for their component by name, which is what sends the configuration looking for the dependency. They are run rather than merely built, since unresolved symbols and the `libpyre`-to-`libjournal` lookup appear only at load time. They also compile without `PYRE_CORE`, which selects a different type set in `lib/journal/api.h` and which no existing test exercises.

## CI

Both cmake workflows configure, build and run the consumer against the install prefix after `make install`, using the same compiler as the leg. `pr-cmake.yaml` gains one job that builds with `-DCMAKE_DISABLE_FIND_PACKAGE_HDF5=ON` and runs the consumer expecting no HDF5 — the only construction that can catch a configuration demanding more than the installation uses. `libhdf5-dev` stays installed on that runner deliberately, so that what drops the dependency is demonstrably the configuration rather than the environment.

## Incidental

Eight sites wrote `if(${VAR})`, which expands to `if()` and aborts the configure when the variable is undefined — the state an optional package is left in when its search is disabled rather than merely unsuccessful. They now write `if(VAR)`.

## Compatibility

- `cmake_minimum_required` rises from 3.19 to 3.20, the release that introduced the `cxx_std_23` compile feature. Consumers need 3.20 or later to interpret the exported requirement.
- Consumers should call `find_package(pyre)` before declaring targets that link against it, or they will compile as `gnu++23`. See the note above.
- The build now enables the C language.

## Verification

Beyond CI, the branch was built and exercised on four arrangements that CI does not cover: a serial HDF5 with MPI present, where the configuration must *not* demand MPI; a parallel HDF5, where it must demand MPI and steer consumers to the matching flavour; a CUDA 12.4 installation, where all five targets export; and a build against a live PostgreSQL, where the `postgres` driver links `pyre::postgres`. Removing the generated block from an installed configuration, reproducing the state this branch fixes, makes the consumer fail immediately — the harness catches the original defect.

Two of those runs found defects rather than confirming assumptions: the audit rejected the cuda export because `${CUDA_LIBRARIES}` carries `Threads::Threads`, and the postgres consumer exposed that the configuration replays a dependency search without the hints that made it succeed, which is filed as #227.
