### PR TITLE
nexus: persistent worker teams, socket transports, and deferred responses

### DIFF
--- a/lib/pyre/grid/Index.h
+++ b/lib/pyre/grid/Index.h
@@ -54,6 +54,9 @@ public:
     explicit constexpr Index(Ts...) noexcept;
     // construct from an initializer list
     constexpr Index(std::initializer_list<value_type>) noexcept;
+    // construct from a shape, reading its extents as coordinates; this is what lets shape
+    // arithmetic land on an index, e.g. when centering a grid by anchoring it at -shape/2
+    explicit constexpr Index(const Shape<Rank> &) noexcept;
 
     // default metamethods
 public:

--- a/lib/pyre/grid/Index.icc
+++ b/lib/pyre/grid/Index.icc
@@ -10,6 +10,8 @@
 
 // support
 #include "Index.h"
+// the constructor from a shape reads its extents
+#include "Shape.h"
 
 
 // default constructor: park the index at the origin
@@ -34,6 +36,17 @@ constexpr pyre::grid::Index<Rank>::Index(Ts... xs) noexcept :
     // bring each argument into my coordinate type and lay them out in axis order
     _coords { static_cast<value_type>(xs)... }
 {}
+
+// from a shape: read the extents as coordinates
+template <std::size_t Rank>
+constexpr pyre::grid::Index<Rank>::Index(const Shape<Rank> & shape) noexcept
+{
+    // go through the axes
+    for (size_type axis = 0; axis < Rank; ++axis) {
+        // and transfer the extent along each one
+        _coords[axis] = shape[axis];
+    }
+}
 
 // initializer_list (debug length check)
 template <std::size_t Rank>

--- a/packages/pyre/http/Deferred.py
+++ b/packages/pyre/http/Deferred.py
@@ -1,0 +1,37 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the placeholder for responses that are produced asynchronously
+class Deferred:
+    """
+    A response placeholder that parks the client connection until the actual document is ready
+
+    Request handlers hand an instance to the server in place of a document when the response
+    is produced away from the request handling stack, e.g. by a team of worker processes. The
+    server installs its delivery hook and keeps the connection open; when the document shows
+    up, {resolve} pushes it through the hook and onto the wire
+    """
+
+    # interface
+    def resolve(self, response):
+        """
+        The actual {response} document is ready; hand it to the transport
+        """
+        # push the document through the hook the server installed when it parked the connection
+        return self.deliver(response=response)
+
+    # metamethods
+    def __init__(self, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # the delivery hook; the server installs it when it parks the connection
+        self.deliver = None
+        # all done
+        return
+
+
+# end of file

--- a/packages/pyre/http/Deferred.py
+++ b/packages/pyre/http/Deferred.py
@@ -24,12 +24,28 @@ class Deferred:
         # push the document through the hook the server installed when it parked the connection
         return self.deliver(response=response)
 
+    def cancel(self):
+        """
+        The parked connection is gone; nobody is waiting for the document any more
+
+        The server invokes this when the peer hangs up; whoever is producing the document
+        installs {abandoned} to hear about it, e.g. to withdraw the request from a work queue
+        """
+        # if anybody asked to know
+        if self.abandoned is not None:
+            # break the news
+            self.abandoned()
+        # all done
+        return
+
     # metamethods
     def __init__(self, **kwds):
         # chain up
         super().__init__(**kwds)
         # the delivery hook; the server installs it when it parks the connection
         self.deliver = None
+        # the cancellation hook; the document producer installs it to hear about hangups
+        self.abandoned = None
         # all done
         return
 

--- a/packages/pyre/http/Server.py
+++ b/packages/pyre/http/Server.py
@@ -116,6 +116,12 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
             if self.hub is not None:
                 # so we stop buffering events for a connection that is gone
                 self.hub.unsubscribe(channel)
+            # if a deferred response was parked on this connection
+            parked = self.parked.pop(channel, None)
+            # let it know
+            if parked is not None:
+                # that nobody is waiting for its document any more
+                parked.cancel()
             # check whether we know this peer
             try:
                 # in which case, forget him
@@ -205,6 +211,8 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
         if isinstance(response, self.deferred):
             # install the delivery hook
             response.deliver = functools.partial(self.complete, channel=channel, request=request)
+            # remember it, so a peer hangup can cancel it
+            self.parked[channel] = response
             # and keep watching the channel so we can tell when the peer hangs up
             return True
 
@@ -256,7 +264,9 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
         """
         The document of a parked connection is ready; send it to the peer
         """
-        # the document is no longer deferred, so it follows the standard path
+        # the connection is no longer parked
+        self.parked.pop(channel, None)
+        # and the document is no longer deferred, so it follows the standard path
         return self.respond(channel=channel, request=request, response=response)
 
     def stream(self, channel, request, response):
@@ -284,12 +294,15 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
         super().__init__(**kwds)
         # initialize my connection index
         self.requests = {}
+        # and the registry of responses parked on their connections
+        self.parked = {}
         # all done
         return
 
     # implementation details
     # private data
     requests = None
+    parked = None
     hub = None
     # constants
     MAX_BYTES = 1024 * 1024

--- a/packages/pyre/http/Server.py
+++ b/packages/pyre/http/Server.py
@@ -6,6 +6,7 @@
 
 
 # externals
+import functools
 import journal
 import pyre
 
@@ -22,6 +23,7 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
     # types
     from .Request import Request as request
     from .Response import Response as response
+    from .Deferred import Deferred as deferred
     from .EventStream import EventStream as eventStream
     from .Hub import Hub
 
@@ -176,8 +178,8 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
             # send an error report to the client
             return self.respond(channel=channel, request=request, response=error)
 
-        # if the user wants to see the headers
-        if headerReport.active:
+        # if the user wants to see the headers; a deferred response has none to show yet
+        if headerReport.active and not isinstance(response, self.deferred):
             # sign on
             headerReport.line(f"sending a {response.code} response with headers")
             # go through the headers
@@ -199,6 +201,13 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
         return self.application.pyre_respond(server=self, request=request)
 
     def respond(self, channel, request, response):
+        # a deferred response parks the connection until its document shows up
+        if isinstance(response, self.deferred):
+            # install the delivery hook
+            response.deliver = functools.partial(self.complete, channel=channel, request=request)
+            # and keep watching the channel so we can tell when the peer hangs up
+            return True
+
         # if this is a streaming response
         if response.streaming:
             # hand the channel to the hub instead of rendering and writing it once
@@ -242,6 +251,13 @@ class Server(pyre.nexus.server, family="pyre.nexus.servers.http"):
 
         # otherwise, let the response document decide whether we should keep the channel alive
         return response.alive
+
+    def complete(self, channel, request, response):
+        """
+        The document of a parked connection is ready; send it to the peer
+        """
+        # the document is no longer deferred, so it follows the standard path
+        return self.respond(channel=channel, request=request, response=response)
 
     def stream(self, channel, request, response):
         """

--- a/packages/pyre/ipc/Channel.py
+++ b/packages/pyre/ipc/Channel.py
@@ -6,6 +6,7 @@
 
 
 # externals
+import collections
 import os
 import fcntl
 
@@ -17,6 +18,12 @@ class Channel:
     of messages. See {Pipe} and {Socket} for concrete examples of encapsulation of the
     operating system services.
     """
+
+    # types
+    # the pair of connected endpoints handed out by channel factories; the {parent} end stays
+    # with the process that built the pair and does not survive an {exec}, while the {child}
+    # end is inheritable, destined for the other party of the conversation
+    ends = collections.namedtuple("ends", ["parent", "child"])
 
     # interface
     # channel life cycle management

--- a/packages/pyre/ipc/Dispatcher.py
+++ b/packages/pyre/ipc/Dispatcher.py
@@ -69,5 +69,12 @@ class Dispatcher(pyre.protocol, family="pyre.ipc.dispatchers"):
         to {channel}
         """
 
+    # introspection
+    @pyre.provides
+    def channels(self):
+        """
+        Generate the set of channels currently being watched, each exactly once
+        """
+
 
 # end of file

--- a/packages/pyre/ipc/Marshaler.py
+++ b/packages/pyre/ipc/Marshaler.py
@@ -28,6 +28,9 @@ class Marshaler(pyre.protocol, family="pyre.ipc.marshalers"):
     def recv(self, channel):
         """
         Extract and return one object from {channel}
+
+        Implementations raise {exceptions.EndOfStream} when the channel closes before a
+        complete message arrives, so clients can tell a dead peer from a bad payload
         """
 
     @pyre.provides

--- a/packages/pyre/ipc/Pickler.py
+++ b/packages/pyre/ipc/Pickler.py
@@ -13,6 +13,9 @@ import struct
 # my protocol
 from . import marshaler
 
+# the marker for conversations cut short
+from .exceptions import EndOfStream
+
 
 # class declaration
 class Pickler(pyre.component, family="pyre.ipc.marshalers.pickler", implements=marshaler):
@@ -50,13 +53,26 @@ class Pickler(pyre.component, family="pyre.ipc.marshalers.pickler", implements=m
     def recv(self, channel):
         """
         Extract and return a single item from {channel}
+
+        Raises {EndOfStream} when the channel closes before a complete message arrives,
+        whether cleanly between messages or mid-transmission
         """
-        # get the length
-        header = channel.read(maxlen=self.headerSize)
+        # get the length; insist on a complete header, since it may arrive in pieces even
+        # from a healthy peer, and read exactly the header, since overreading would swallow
+        # the beginning of whatever follows in the stream
+        header = channel.read(minlen=self.headerSize, maxlen=self.headerSize)
+        # if the channel ran dry before the header completed
+        if len(header) < self.headerSize:
+            # the conversation is over
+            raise EndOfStream(channel=channel, received=len(header), expected=self.headerSize)
         # unpack it
         (length,) = struct.unpack(self.packing, header)
-        # get the body
-        body = channel.read(minlen=length)
+        # get the body, again reading exactly what the header promised
+        body = channel.read(minlen=length, maxlen=length)
+        # if the channel ran dry mid-message
+        if len(body) < length:
+            # the peer died while transmitting
+            raise EndOfStream(channel=channel, received=len(body), expected=length)
         # extract the object and return it
         return pickle.loads(body)
 

--- a/packages/pyre/ipc/Pipe.py
+++ b/packages/pyre/ipc/Pipe.py
@@ -38,8 +38,8 @@ class Pipe(Channel):
         # dress up the end points as {Pipe} instances
         parent = cls(infd=from_child, outfd=to_child, **kwds)
         child = cls(infd=from_parent, outfd=to_parent, **kwds)
-        # and return them
-        return parent, child
+        # and return them as a labeled pair, so the order is part of the contract
+        return cls.ends(parent=parent, child=child)
 
     def close(self):
         """

--- a/packages/pyre/ipc/Pipes.py
+++ b/packages/pyre/ipc/Pipes.py
@@ -1,0 +1,42 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import pyre
+
+# my protocol
+from .Transport import Transport
+
+# the channel i deal in
+from .Pipe import Pipe
+
+
+# declaration
+class Pipes(pyre.component, family="pyre.ipc.transports.pipe", implements=Transport):
+    """
+    The transport that connects processes with pipes
+    """
+
+    # interface
+    @pyre.export
+    def open(self, **kwds):
+        """
+        Build a pair of connected channels, each backed by a pair of pipes
+        """
+        # delegate to the channel
+        return Pipe.open(**kwds)
+
+    @pyre.export
+    def wrap(self, infd, outfd, **kwds):
+        """
+        Dress the already open descriptors {infd} and {outfd} as a channel
+        """
+        # dress them up
+        return Pipe(infd=infd, outfd=outfd, **kwds)
+
+
+# end of file

--- a/packages/pyre/ipc/Selector.py
+++ b/packages/pyre/ipc/Selector.py
@@ -62,6 +62,32 @@ class Selector(Scheduler, family="pyre.ipc.dispatchers.selector", implements=dis
         return
 
     @pyre.export
+    def channels(self):
+        """
+        Generate the set of channels currently being watched, each exactly once
+        """
+        # keep track of what has been reported
+        seen = set()
+        # go through my event tables
+        for index in (self._read, self._write, self._exception):
+            # and the pile of events registered against each endpoint
+            for events in index.values():
+                # go through the events
+                for event in events:
+                    # get the channel
+                    channel = event.channel
+                    # if it has been reported already
+                    if channel in seen:
+                        # skip it
+                        continue
+                    # otherwise, mark it
+                    seen.add(channel)
+                    # and report it
+                    yield channel
+        # all done
+        return
+
+    @pyre.export
     def stop(self):
         """
         Request the selector to stop watching for further events

--- a/packages/pyre/ipc/Selector.py
+++ b/packages/pyre/ipc/Selector.py
@@ -6,6 +6,7 @@
 
 
 # externals
+import os
 import pyre
 import select
 import collections
@@ -139,7 +140,7 @@ class Selector(Scheduler, family="pyre.ipc.dispatchers.selector", implements=dis
                 # show me the channels that are watching for exceptions
                 if ewtd:
                     channel.line("      exception:")
-                for channel in ewtd:
+                for fd in ewtd:
                     for event in self._exception[fd]:
                         channel.line(f"        {event.channel}")
 
@@ -165,6 +166,12 @@ class Selector(Scheduler, family="pyre.ipc.dispatchers.selector", implements=dis
                 channel.line(f"  more watching: {self._watching}")
                 channel.log()
                 # keep going
+                continue
+            # a registration whose descriptor died behind our back poisons the whole call
+            except (OSError, ValueError):
+                # find the corpses and drop them, so everybody else keeps getting served
+                self._cull()
+                # and try again
                 continue
 
             # if my channel is active
@@ -203,20 +210,46 @@ class Selector(Scheduler, family="pyre.ipc.dispatchers.selector", implements=dis
         """
         # iterate over the active entities
         for active in entities:
+            # take possession of the pile, so interest registered by the handlers while
+            # they run accumulates separately instead of being invoked prematurely on
+            # this pass
+            pile = index.pop(active, [])
             # invoke the event handlers and save the events whose handlers return {True}
             events = list(
-                event
-                for event in index[active]
-                if event.handler(channel=event.channel, **event.context)
+                event for event in pile if event.handler(channel=event.channel, **event.context)
             )
-            # if no handlers requested to be rescheduled
-            if not events:
-                # remove the descriptor from the index
-                del index[active]
-            # otherwise
-            else:
-                # reschedule them
-                index[active] = events
+            # if any handlers requested to be rescheduled
+            if events:
+                # put them back, ahead of whatever interest arrived while they ran
+                index[active][:0] = events
+        # all done
+        return
+
+    def _cull(self):
+        """
+        Drop registrations whose descriptors are dead
+
+        {select} refuses to scan a closed descriptor, so a single corpse would starve
+        every healthy channel; this sweep runs when that happens and buries the corpses
+        """
+        # go through my event tables
+        for index in (self._read, self._write, self._exception):
+            # and a snapshot of their keys
+            for key in list(index.keys()):
+                # carefully
+                try:
+                    # resolve the key to a raw descriptor
+                    fileno = key if isinstance(key, int) else key.fileno()
+                    # closed high level objects report an invalid descriptor
+                    if fileno < 0:
+                        # which marks a corpse
+                        raise ValueError(fileno)
+                    # probe the descriptor
+                    os.fstat(fileno)
+                # if the resolution or the probe failed
+                except (ValueError, OSError):
+                    # this registration can never fire again
+                    del index[key]
         # all done
         return
 

--- a/packages/pyre/ipc/SelectorPSL.py
+++ b/packages/pyre/ipc/SelectorPSL.py
@@ -12,7 +12,6 @@ in the python standard library
 # external
 import pyre
 import journal
-import collections
 import selectors
 
 # interface
@@ -27,6 +26,11 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
     """
     An event demultiplexer implemented using the high level interface in the {selectors} module of
     the python standard library
+
+    The event piles are the single source of truth: the kernel side registration is derived
+    from them whenever they change shape. This matters because descriptor numbers are recycled
+    aggressively: a handler may close its channel and a fresh channel may reincarnate the same
+    number within a single dispatch cycle, so no cached view of the kernel state can be trusted
     """
 
     # interface obligations
@@ -35,30 +39,17 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
         """
         Add {call} to the handlers that will be invoked when {channel} is ready for reading
         """
-        # get my selector
-        selector = self._selector
         # get the read side of the channel
         fd = channel.inbound
-        # bind the {channel} with the {call} handler
-        event = self._event(channel=channel, handler=call, **kwds)
-        # get the current event mask
-        current = self._masks[fd]
-        # turn on the read bit
-        updated = current | selectors.EVENT_READ
-        # if the mask is modified
-        if current != updated:
-            # store the updated mask
-            self._masks[fd] = updated
-            # if the file descriptor is not already registered
-            try:
-                # add it to the watch list
-                selector.register(fd, events=updated)
-            # if it's already registered
-            except KeyError:
-                # modify the registration
-                selector.modify(fileobj=fd, events=updated)
-        # in any case, add the {event} to the read pile
-        self._read.setdefault(fd, []).append(event)
+        # a key with no registered interest is a fresh conversation, possibly on a recycled
+        # descriptor number; its kernel registration must be rebuilt from scratch
+        fresh = not self._read.get(fd) and not self._write.get(fd)
+        # the interest that must be armed: whatever is already registered, plus reading
+        mask = self._interest(key=fd) | selectors.EVENT_READ
+        # arm the kernel side
+        self._arm(key=fd, mask=mask, force=fresh)
+        # and add the {event} to the read pile
+        self._read.setdefault(fd, []).append(self._event(channel=channel, handler=call, **kwds))
         # all done
         return
 
@@ -67,30 +58,17 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
         """
         Add {call} to the handlers that will be invoked when {channel} is ready for writing
         """
-        # get my selector
-        selector = self._selector
-        # get the read side of the channel
+        # get the write side of the channel
         fd = channel.outbound
-        # bind the {channel} with the {call} handler
-        event = self._event(channel=channel, handler=call, **kwds)
-        # get the current event mask
-        current = self._masks[fd]
-        # turn on the read bit
-        updated = current | selectors.EVENT_WRITE
-        # if the mask is modified
-        if current != updated:
-            # store the updated mask
-            self._masks[fd] = updated
-            # if the file descriptor is not already registered
-            try:
-                # add it to the watch list
-                selector.register(fd, events=updated)
-            # if it's already registered
-            except KeyError:
-                # modify the registration
-                selector.modify(fileobj=fd, events=updated)
-        # in any case, add the {event} to the read pile
-        self._write.setdefault(fd, []).append(event)
+        # a key with no registered interest is a fresh conversation, possibly on a recycled
+        # descriptor number; its kernel registration must be rebuilt from scratch
+        fresh = not self._read.get(fd) and not self._write.get(fd)
+        # the interest that must be armed: whatever is already registered, plus writing
+        mask = self._interest(key=fd) | selectors.EVENT_WRITE
+        # arm the kernel side
+        self._arm(key=fd, mask=mask, force=fresh)
+        # and add the {event} to the write pile
+        self._write.setdefault(fd, []).append(self._event(channel=channel, handler=call, **kwds))
         # all done
         return
 
@@ -149,8 +127,6 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
         # my registration tables
         read = self._read
         write = self._write
-        # and the table of event masks
-        masks = self._masks
         # reset my state
         self._watching = True
 
@@ -177,63 +153,20 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
             for key, mask in selection:
                 # get the corresponding file descriptor
                 fd = key.fileobj
-                # the bits whose handler piles drain to empty during this pass
-                cleared = 0
                 # N.B.:
                 #     a decision had to be made regarding the order that handlers are invoked
                 #     this implementation calls the {read} handlers before the {write} handlers
                 # if the {mask} indicates {fd} is ready for read
                 if mask & selectors.EVENT_READ:
                     # invoke the read handlers
-                    reschedule = self.dispatch(index=read, key=fd)
-                    # if there is something to reschedule
-                    if reschedule:
-                        # update the {read} map
-                        read[fd] = reschedule
-                    # otherwise
-                    else:
-                        # remove this file descriptor from the pile
-                        read.pop(fd, 0)
-                        # and mark the read bit for clearing
-                        cleared |= selectors.EVENT_READ
+                    self.dispatch(index=read, key=fd)
                 # if the {mask} indicates {fd} is ready for write
                 if mask & selectors.EVENT_WRITE:
                     # invoke the write handlers
-                    reschedule = self.dispatch(index=write, key=fd)
-                    # if there is something to reschedule
-                    if reschedule:
-                        # update the {write} map
-                        write[fd] = reschedule
-                    # otherwise
-                    else:
-                        # remove this file descriptor from the pile
-                        write.pop(fd, 0)
-                        # and mark the write bit for clearing
-                        cleared |= selectors.EVENT_WRITE
-                # recompute the mask from the live table, not a pre-dispatch snapshot: a handler
-                # may have registered fresh interest on this same {fd} while it ran (e.g. a read
-                # handler arming a write), and that addition must survive
-                event = masks[fd] & ~cleared
-                # carefully, because a handler may have closed {fd} during dispatch
-                try:
-                    # if the {event} mask of this {fd} is now trivial
-                    if event == 0:
-                        # unregister it
-                        selector.unregister(fileobj=fd)
-                        # and remove it from the mask table
-                        masks.pop(fd, 0)
-                    # otherwise, if the registration changed
-                    elif masks[fd] != event:
-                        # modify the selector registration
-                        selector.modify(fileobj=fd, events=event)
-                        # and update the table
-                        masks[fd] = event
-                # if {fd} was closed out from under us
-                except (KeyError, ValueError, OSError):
-                    # forget it entirely
-                    read.pop(fd, 0)
-                    write.pop(fd, 0)
-                    masks.pop(fd, 0)
+                    self.dispatch(index=write, key=fd)
+                # settle this descriptor's kernel registration against the live piles, which
+                # the handlers may have reshaped arbitrarily while they ran
+                self._reconcile(key=fd)
 
             # raise any overdue alarms
             self.awaken()
@@ -250,8 +183,6 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
         # set up my termination flag
         self._watching = False
 
-        # set up the event mask map: fd -> mask
-        self._masks = collections.defaultdict(int)
         # set up the read map: fd -> list[_event]
         self._read = {}
         # and the write map: fd -> list[_event]
@@ -265,10 +196,13 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
         """
         Invoke the handlers for {key} registered in {index}
         """
+        # take possession of the pile, so interest registered by the handlers while they run
+        # accumulates separately instead of being invoked prematurely on this pass
+        pile = index.pop(key, [])
         # make a pile of event handlers to reschedule
         reschedule = []
-        # go through the pile registered under {key}
-        for event in index.get(key, ()):
+        # go through the snapshot
+        for event in pile:
             # very very carefully
             try:
                 # invoke the handler
@@ -278,15 +212,112 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
                 # let's try this again
                 keep = True
             # if something more serious happens
-            except OSError:
-                # something is wrong with the connection; discard the handler
+            except OSError as error:
+                # the connection is broken; discarding the handler is the only sane move,
+                # but say so, since silent drops make failures undiagnosable
+                channel = journal.debug("pyre.ipc.psl")
+                # describe what happened
+                channel.line(f"discarding a handler of {event.channel}")
+                channel.line(f"after it raised {error}")
+                # flush
+                channel.log()
+                # and drop it
                 keep = False
             # keepers
             if keep:
                 # get rescheduled
                 reschedule.append(event)
-        # hand off the rescheduling pile
-        return reschedule
+        # if any handlers survived
+        if reschedule:
+            # put them back, ahead of whatever interest arrived while they ran
+            index.setdefault(key, [])[:0] = reschedule
+        # all done
+        return
+
+    def _interest(self, key):
+        """
+        Compute the event mask implied by the current piles of {key}
+        """
+        # reading, if there are read handlers; writing, if there are write handlers
+        return (selectors.EVENT_READ if self._read.get(key) else 0) | (
+            selectors.EVENT_WRITE if self._write.get(key) else 0
+        )
+
+    def _arm(self, key, mask, force=False):
+        """
+        Ensure the kernel watches {key} for {mask}
+
+        With {force}, any standing registration under this descriptor number is torn down
+        first: the caller knows the conversation is fresh, so an existing entry is a leftover
+        from a closed channel that recycled the number, and the kernel side filter it claims
+        to hold died with the original descriptor
+        """
+        # get my selector
+        selector = self._selector
+        # carefully
+        try:
+            # look up the standing registration under this descriptor number
+            current = self._selector.get_key(key)
+        # if there is none
+        except KeyError:
+            # so note
+            current = None
+        # a standing registration can be trusted only when nobody demands a rebuild, it
+        # belongs to this very endpoint, and it watches for exactly the right events; the
+        # ownership test is meaningful only for object endpoints, since a raw descriptor
+        # number cannot be told apart from its own reincarnation
+        if (
+            current is not None
+            and not force
+            and (isinstance(key, int) or current.fileobj is key)
+            and current.events == mask
+        ):
+            # nothing to do
+            return
+        # if there is a standing registration
+        if current is not None:
+            # carefully, since its descriptor may be long dead
+            try:
+                # tear it down
+                selector.unregister(key)
+            # tolerating whatever state it is in
+            except (KeyError, ValueError, OSError):
+                # nothing further
+                pass
+        # and register afresh; a dead endpoint raises out of here, for the caller to judge
+        selector.register(key, events=mask)
+        # all done
+        return
+
+    def _reconcile(self, key):
+        """
+        Settle the kernel registration of {key} against the live piles
+        """
+        # compute the interest implied by the piles
+        mask = self._interest(key=key)
+        # if nothing is left
+        if not mask:
+            # carefully, since the descriptor may already be gone
+            try:
+                # tear down the registration
+                self._selector.unregister(key)
+            # tolerating whatever state it is in
+            except (KeyError, ValueError, OSError):
+                # nothing further
+                pass
+            # all done
+            return
+        # otherwise, carefully
+        try:
+            # make sure the kernel watches for exactly this interest
+            self._arm(key=key, mask=mask)
+        # if the endpoint is dead
+        except (ValueError, OSError):
+            # its handlers can never fire again; drop them
+            self._read.pop(key, None)
+            self._write.pop(key, None)
+        # all done
+        return
 
     # implementation details - private types
     class _event:

--- a/packages/pyre/ipc/SelectorPSL.py
+++ b/packages/pyre/ipc/SelectorPSL.py
@@ -104,6 +104,32 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
         raise NotImplementedError(f"class '{type(self).__name__}' does not support 'whenException'")
 
     @pyre.export
+    def channels(self):
+        """
+        Generate the set of channels currently being watched, each exactly once
+        """
+        # keep track of what has been reported
+        seen = set()
+        # go through my event tables
+        for index in (self._read, self._write):
+            # and the pile of events registered against each descriptor
+            for events in index.values():
+                # go through the events
+                for event in events:
+                    # get the channel
+                    channel = event.channel
+                    # if it has been reported already
+                    if channel in seen:
+                        # skip it
+                        continue
+                    # otherwise, mark it
+                    seen.add(channel)
+                    # and report it
+                    yield channel
+        # all done
+        return
+
+    @pyre.export
     def stop(self):
         """
         Ask the selector to stop waiting for further events

--- a/packages/pyre/ipc/Socket.py
+++ b/packages/pyre/ipc/Socket.py
@@ -60,6 +60,58 @@ class Socket(socket.socket, Channel):
         # otherwise, parse the address, decorate it and return it
         return self.inet().recognize(family=self.family, address=address)
 
+    # input/output
+    # these implementations assume stream semantics; datagram flavors must override
+    def read(self, minlen=0, maxlen=4 * 1024):
+        """
+        Read {count} bytes from my input channel
+        """
+        # make sure
+        if maxlen < minlen:
+            # that the input parameters are sane
+            maxlen = minlen
+        # reset the byte count
+        total = 0
+        # initialize the packet pile
+        packets = []
+        # for as long as it takes
+        while True:
+            # carefully
+            try:
+                # pull something from the channel
+                packet = self.recv(maxlen - total)
+            # if the peer closed the connection
+            except ConnectionResetError:
+                # bail
+                break
+
+            # otherwise, get the packet length
+            got = len(packet)
+            # if we got nothing, the channel is closed
+            if got == 0:
+                # bail
+                break
+            # otherwise, update the total
+            total += got
+            # and save the packet
+            packets.append(packet)
+            # if we have reached our goal
+            if total >= minlen:
+                # bail
+                break
+
+        # assemble the byte string and return it
+        return b"".join(packets)
+
+    def write(self, bytes):
+        """
+        Write the {bytes} to my output channel
+        """
+        # make sure the entire byte string is delivered
+        self.sendall(bytes)
+        # and return the number of bytes sent
+        return len(bytes)
+
     # interface
     def accept(self):
         """

--- a/packages/pyre/ipc/SocketPair.py
+++ b/packages/pyre/ipc/SocketPair.py
@@ -43,8 +43,8 @@ class SocketPair(Socket):
         # spawners, while the child side is inheritable so it can be handed to a new process
         parent.set_inheritable(False)
         child.set_inheritable(True)
-        # hand off the pair
-        return parent, child
+        # hand off the pair as labeled endpoints, so the order is part of the contract
+        return cls.ends(parent=parent, child=child)
 
     # interface
     def sendDescriptors(self, descriptors, payload=b"\x00"):

--- a/packages/pyre/ipc/SocketPair.py
+++ b/packages/pyre/ipc/SocketPair.py
@@ -1,0 +1,80 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import socket
+
+# my base class
+from .Socket import Socket
+
+
+# declaration
+class SocketPair(Socket):
+    """
+    A channel implemented over one end of a connected pair of unix domain sockets
+
+    Socket pairs are anonymous: they are born connected, so there is nothing to name, bind to,
+    or accept. They deliver everything {Pipe} does over a single descriptor per side, and add
+    the one trick unique to unix domain sockets: open file descriptors can travel across, so
+    one process can grant another access to a file or socket it has opened
+    """
+
+    # constants
+    family = socket.AF_UNIX
+    type = socket.SOCK_STREAM
+
+    # factories
+    @classmethod
+    def open(cls, **kwds):
+        """
+        Build a pair of connected channels suitable for bidirectional communication between
+        two processes on the same host
+        """
+        # ask the kernel for a connected pair of unix domain stream sockets
+        one, two = socket.socketpair(cls.family, cls.type)
+        # rewrap each raw socket as a channel by stealing its descriptor
+        parent = cls(cls.family, cls.type, 0, fileno=one.detach())
+        child = cls(cls.family, cls.type, 0, fileno=two.detach())
+        # mirror the {Pipe} contract: the parent side does not survive the {exec} family of
+        # spawners, while the child side is inheritable so it can be handed to a new process
+        parent.set_inheritable(False)
+        child.set_inheritable(True)
+        # hand off the pair
+        return parent, child
+
+    # interface
+    def sendDescriptors(self, descriptors, payload=b"\x00"):
+        """
+        Ship copies of the open file {descriptors} to my peer, along with a small {payload}
+
+        The {payload} must be at least one byte long: ancillary data cannot ride on an empty
+        message. The peer receives duplicates, so both processes hold the descriptors open
+        until each closes its own copy
+        """
+        # delegate to the wrapper in the standard library, which speaks {SCM_RIGHTS}
+        return socket.send_fds(self, [payload], descriptors)
+
+    def recvDescriptors(self, limit, maxlen=1):
+        """
+        Receive up to {limit} open file descriptors from my peer, along with up to {maxlen}
+        bytes of the payload of the message that carried them
+        """
+        # delegate to the wrapper in the standard library
+        payload, descriptors, _, _ = socket.recv_fds(self, maxlen, limit)
+        # hand off the payload and the descriptors
+        return payload, list(descriptors)
+
+    # meta-methods
+    def __str__(self):
+        """build a human readable representation"""
+        return f"socket pair endpoint at fd {self.fileno()}"
+
+    # implementation details
+    __slots__ = ()  # socket has it, so why not...
+
+
+# end of file

--- a/packages/pyre/ipc/SocketTCP.py
+++ b/packages/pyre/ipc/SocketTCP.py
@@ -21,56 +21,7 @@ class SocketTCP(Socket):
     # constants
     type = socket.SOCK_STREAM
 
-    # input/output
-    def read(self, minlen=0, maxlen=4 * 1024):
-        """
-        Read {count} bytes from my input channel
-        """
-        # make sure
-        if maxlen < minlen:
-            # that the input parameters are sane
-            maxlen = minlen
-        # reset the byte count
-        total = 0
-        # initialize the packet pile
-        packets = []
-        # for as long as it takes
-        while True:
-            # carefully
-            try:
-                # pull something from the channel
-                packet = self.recv(maxlen - total)
-            # if the peer closed the connection
-            except ConnectionResetError:
-                # bail
-                break
-
-            # otherwise, get the packet length
-            got = len(packet)
-            # if we got nothing, the channel is closed
-            if got == 0:
-                # bail
-                break
-            # otherwise, update the total
-            total += got
-            # and save the packet
-            packets.append(packet)
-            # if we have reached our goal
-            if total >= minlen:
-                # bail
-                break
-
-        # assemble the byte string and return it
-        return b"".join(packets)
-
-    def write(self, bytes):
-        """
-        Write the {bytes} to my output channel
-        """
-        # make sure the entire byte string is delivered
-        self.sendall(bytes)
-        # and return the number of bytes sent
-        return len(bytes)
+    # input/output is inherited from {Socket}, whose implementations assume stream semantics
 
     # meta-methods
     def __str__(self):

--- a/packages/pyre/ipc/Sockets.py
+++ b/packages/pyre/ipc/Sockets.py
@@ -1,0 +1,45 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import pyre
+
+# my protocol
+from .Transport import Transport
+
+# the channel i deal in
+from .SocketPair import SocketPair
+
+
+# declaration
+class Sockets(pyre.component, family="pyre.ipc.transports.socket", implements=Transport):
+    """
+    The transport that connects processes with unix domain socket pairs
+
+    Beyond what pipes offer, these channels can carry open file descriptors between the two
+    processes, and use half the descriptors
+    """
+
+    # interface
+    @pyre.export
+    def open(self, **kwds):
+        """
+        Build a pair of connected channels over a fresh unix domain socket pair
+        """
+        # delegate to the channel
+        return SocketPair.open(**kwds)
+
+    @pyre.export
+    def wrap(self, descriptor, **kwds):
+        """
+        Dress the already open {descriptor} of one end of a connected pair as a channel
+        """
+        # dress it up
+        return SocketPair(SocketPair.family, SocketPair.type, 0, fileno=descriptor, **kwds)
+
+
+# end of file

--- a/packages/pyre/ipc/Transport.py
+++ b/packages/pyre/ipc/Transport.py
@@ -1,0 +1,49 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import pyre
+
+
+# declaration
+class Transport(pyre.protocol, family="pyre.ipc.transports"):
+    """
+    Protocol for components that build the channels over which processes talk to each other
+
+    Transports deal in connected pairs: {open} builds both ends of a fresh conversation, and
+    {wrap} dresses descriptors that already exist, e.g. ones inherited across an {exec} or
+    received from a peer, as a channel
+    """
+
+    # factory for my default implementation
+    @classmethod
+    def pyre_default(cls, **kwds):
+        """
+        The default {Transport} implementation
+        """
+        # pipes are supported everywhere
+        from .Pipes import Pipes
+
+        # so publish them
+        return Pipes
+
+    # interface
+    @pyre.provides
+    def open(self, **kwds):
+        """
+        Build a pair of connected channels suitable for bidirectional communication between
+        two processes on the same host, returned as labeled {ends}
+        """
+
+    @pyre.provides
+    def wrap(self, **kwds):
+        """
+        Dress already open descriptors as a channel; the signature is mechanism specific
+        """
+
+
+# end of file

--- a/packages/pyre/ipc/__init__.py
+++ b/packages/pyre/ipc/__init__.py
@@ -46,6 +46,9 @@ def inet(spec=""):
     return schemata.inet.coerce(value=spec)
 
 
+# my exceptions
+from . import exceptions
+
 # my protocols
 from .Dispatcher import Dispatcher as dispatcher
 from .Marshaler import Marshaler as marshaler

--- a/packages/pyre/ipc/__init__.py
+++ b/packages/pyre/ipc/__init__.py
@@ -30,6 +30,26 @@ def pipe(descriptors=None, **kwds):
     return Pipe.open(**kwds)
 
 
+def socketpair(descriptor=None, **kwds):
+    """
+    If {descriptor} is not {None}, it is expected to be the already open file descriptor of
+    one end of a connected pair, e.g. one inherited across an {exec} or received from a peer;
+    just wrap a channel around it. Otherwise, build a connected pair of unix domain sockets
+    suitable for bidirectional communication between two processes on the same host. Unlike
+    pipes, these channels can also carry open file descriptors between the two processes
+    """
+    # access the channel
+    from .SocketPair import SocketPair
+
+    # if we were handed an already open descriptor
+    if descriptor is not None:
+        # just wrap a channel around it
+        return SocketPair(SocketPair.family, SocketPair.type, 0, fileno=descriptor)
+
+    # build the pair and return it
+    return SocketPair.open(**kwds)
+
+
 def tcp(address):
     """
     Builds a channel over a TCP connection to a server

--- a/packages/pyre/ipc/__init__.py
+++ b/packages/pyre/ipc/__init__.py
@@ -9,47 +9,6 @@ from .. import foundry
 
 
 # channel access
-def pipe(descriptors=None, **kwds):
-    """
-    If {descriptors} is not {None}, it is expected to be a pair ({infd}, {outfd}) of already
-    open file descriptors; just wrap a channel around them. Otherwise, build a pair of pipes
-    suitable for bidirectional communication between two processes on the same host
-
-    """
-    # access the channel
-    from .Pipe import Pipe
-
-    # if we were handed already open descriptors
-    if descriptors:
-        # unpack
-        infd, outfd = descriptors
-        # and go straight to the constructor
-        return Pipe(infd=infd, outfd=outfd, **kwds)
-
-    # build the pair and return it
-    return Pipe.open(**kwds)
-
-
-def socketpair(descriptor=None, **kwds):
-    """
-    If {descriptor} is not {None}, it is expected to be the already open file descriptor of
-    one end of a connected pair, e.g. one inherited across an {exec} or received from a peer;
-    just wrap a channel around it. Otherwise, build a connected pair of unix domain sockets
-    suitable for bidirectional communication between two processes on the same host. Unlike
-    pipes, these channels can also carry open file descriptors between the two processes
-    """
-    # access the channel
-    from .SocketPair import SocketPair
-
-    # if we were handed an already open descriptor
-    if descriptor is not None:
-        # just wrap a channel around it
-        return SocketPair(SocketPair.family, SocketPair.type, 0, fileno=descriptor)
-
-    # build the pair and return it
-    return SocketPair.open(**kwds)
-
-
 def tcp(address):
     """
     Builds a channel over a TCP connection to a server
@@ -90,9 +49,35 @@ def inet(spec=""):
 # my protocols
 from .Dispatcher import Dispatcher as dispatcher
 from .Marshaler import Marshaler as marshaler
+from .Transport import Transport as transport
 
 
 # my component foundries
+@foundry(implements=transport)
+def pipe():
+    """
+    The transport that connects processes with pipes
+    """
+    # grab the component class record
+    from .Pipes import Pipes as pipes
+
+    # and return it
+    return pipes
+
+
+@foundry(implements=transport)
+def socket():
+    """
+    The transport that connects processes with unix domain socket pairs, which can also carry
+    open file descriptors between the two processes
+    """
+    # grab the component class record
+    from .Sockets import Sockets as sockets
+
+    # and return it
+    return sockets
+
+
 @foundry(implements=marshaler)
 def pickler():
     """
@@ -143,6 +128,28 @@ def psl():
 
 
 # my component factories; use to build an actual instance
+def newPipe(**kwds):
+    """
+    The transport that connects processes with pipes
+    """
+    # grab the component class record
+    from .Pipes import Pipes as pipes
+
+    # and instantiate it
+    return pipes(**kwds)
+
+
+def newSocket(**kwds):
+    """
+    The transport that connects processes with unix domain socket pairs
+    """
+    # grab the component class record
+    from .Sockets import Sockets as sockets
+
+    # and instantiate it
+    return sockets(**kwds)
+
+
 def newPickler(**kwds):
     """
     A marshaler that uses native python services to serialize objects

--- a/packages/pyre/ipc/exceptions.py
+++ b/packages/pyre/ipc/exceptions.py
@@ -1,0 +1,46 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# exceptions
+from ..framework.exceptions import FrameworkError
+
+
+# local anchor
+class IPCError(FrameworkError):
+    """
+    Base exception for all error conditions detected by ipc components
+    """
+
+
+# the channel closed mid-conversation
+class EndOfStream(IPCError):
+    """
+    The channel was closed by its peer before a complete message arrived
+
+    Marshalers raise this when a read comes up short: either the channel closed cleanly
+    between messages, or the peer died mid-transmission. Either way, no further messages are
+    coming, and the caller should treat the conversation as over
+    """
+
+    # the message template
+    description = "end of stream: received {0.received} of {0.expected} bytes"
+
+    # metamethods
+    def __init__(self, channel=None, received=0, expected=0, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # the channel that ran dry
+        self.channel = channel
+        # how much of the message made it
+        self.received = received
+        # and how much was promised
+        self.expected = expected
+        # all done
+        return
+
+
+# end of file

--- a/packages/pyre/nexus/Crew.py
+++ b/packages/pyre/nexus/Crew.py
@@ -8,6 +8,12 @@
 # externals
 import functools
 
+# the marker the marshaler raises when its peer dies mid-conversation
+from ..ipc.exceptions import EndOfStream
+
+# the marker for tasks that took their crew member down
+from .exceptions import Casualty
+
 # my base class
 from .Peer import Peer
 
@@ -61,14 +67,26 @@ class Crew(Peer, family="pyre.nexus.peers.crew"):
         """
         # check it's me we are talking about
         assert channel is self.channel
-        # get the status of my twin
-        status = self.marshaler.recv(channel=channel)
-        # and if all is good
+        # carefully, since my twin may have died before its registration arrived
+        try:
+            # get the status of my twin
+            status = self.marshaler.recv(channel=channel)
+        # if the channel delivered a truncated message, my twin is gone
+        except EndOfStream:
+            # clean up; the team decides whether a replacement gets recruited
+            team.bury(crew=self)
+            # and stop listening
+            return False
+        # if all is good
         if status is self.crewcodes.healthy:
             # let the team know
             team.activate(crew=self)
             # and add me to the execution schedule
             team.schedule(crew=self)
+        # otherwise
+        else:
+            # my twin is compromised; clean up, rather than leaking it in the roster
+            team.bury(crew=self)
         # do not reschedule this handler
         return False
 
@@ -89,18 +107,35 @@ class Crew(Peer, family="pyre.nexus.peers.crew"):
         """
         Harvest the task completion status
         """
-        # grab the report
-        memberstatus, taskstatus, result = self.marshaler.recv(channel=channel)
+        # carefully, since my twin may have died mid-task instead of reporting
+        try:
+            # grab the report
+            memberstatus, taskstatus, result = self.harvest(channel=channel)
+        # if the channel delivered a truncated message, my twin is gone
+        except EndOfStream:
+            # a death without a report marks the task as a suspect
+            team.abandon(task=task, error=Casualty(description=f"crew {self.pid} died"))
+            # clean up; the team decides whether a replacement gets recruited
+            team.bury(crew=self)
+            # and stop listening
+            return False
         # show me on the debug channel
         self.debug.log(f"{self.pid}: {memberstatus}, {taskstatus}, {result}")
 
-        # first, let's figure out what to do with the task; if it failed due to some temporary
-        # condition
-        if taskstatus is self.taskcodes.failed:
+        # first, let's figure out what to do with the task; if it ran to completion
+        if taskstatus is self.taskcodes.completed:
+            # deliver the result; the team decides what results are for
+            team.collect(task=task, result=result)
+        # if it failed due to some temporary condition
+        elif taskstatus is self.taskcodes.failed:
             # tell me
             self.reportRecoverableError(team=team, task=task, error=result)
-            # put the task back in the workplan
-            team.workplan.add(task)
+            # the team decides whether it gets another chance
+            team.requeue(task=task, error=result)
+        # otherwise, the task aborted
+        else:
+            # deliver the bad news; the team decides how to break it
+            team.abandon(task=task, error=result)
 
         # now, let's figure out what to do with me; if i'm healthy
         if memberstatus is self.crewcodes.healthy:
@@ -115,6 +150,16 @@ class Crew(Peer, family="pyre.nexus.peers.crew"):
 
         # all done
         return False
+
+    def harvest(self, channel):
+        """
+        Extract a completion report from {channel}
+
+        Subclasses whose reports have trailers, e.g. payloads that travel outside the
+        marshaled byte stream, override this to collect them
+        """
+        # pull the report from the channel
+        return self.marshaler.recv(channel=channel)
 
     def dismissed(self):
         """
@@ -174,8 +219,16 @@ class Crew(Peer, family="pyre.nexus.peers.crew"):
         """
         A notification has arrived that indicates there is a task waiting to be executed
         """
-        # extract the task from the channel
-        task = self.marshaler.recv(channel=channel)
+        # carefully, since a broken channel means the team is gone
+        try:
+            # extract the task from the channel
+            task = self.marshaler.recv(channel=channel)
+        # if the channel delivered a truncated message
+        except EndOfStream:
+            # wind down my event loop
+            self.stop()
+            # and stop listening
+            return False
         # leave a note
         self.debug.log(f"{self.pid}: got {task}")
         # if it's a quit marker

--- a/packages/pyre/nexus/Fork.py
+++ b/packages/pyre/nexus/Fork.py
@@ -21,6 +21,10 @@ class Fork(pyre.component, family="pyre.nexus.recruiters.fork", implements=Recru
     Create worker processes by cloning the current one
     """
 
+    # user configurable state
+    channels = pyre.ipc.transport()
+    channels.doc = "the ipc mechanism that connects the team to its crew members"
+
     # protocol obligations
     @pyre.provides
     def recruit(self, team, **kwds):
@@ -41,9 +45,9 @@ class Fork(pyre.component, family="pyre.nexus.recruiters.fork", implements=Recru
         """
         Create a new {team} member using the {fork} system call
         """
-        # team members communicate with the manager using pipes; the {child} end is destined
-        # for the worker, the {parent} end stays with the team
-        parent, child = pyre.ipc.pipe()
+        # team members communicate with the manager over my transport; the {child} end is
+        # destined for the worker, the {parent} end stays with the team
+        parent, child = self.channels.open()
         # clone the current process
         pid = os.fork()
 

--- a/packages/pyre/nexus/Fork.py
+++ b/packages/pyre/nexus/Fork.py
@@ -41,7 +41,8 @@ class Fork(pyre.component, family="pyre.nexus.recruiters.fork", implements=Recru
         """
         Create a new {team} member using the {fork} system call
         """
-        # team members communicate with the manager using pipes
+        # team members communicate with the manager using pipes; the {child} end is destined
+        # for the worker, the {parent} end stays with the team
         parent, child = pyre.ipc.pipe()
         # clone the current process
         pid = os.fork()
@@ -52,7 +53,7 @@ class Fork(pyre.component, family="pyre.nexus.recruiters.fork", implements=Recru
         # in the worker process
         if pid == 0:
             # make a team member
-            crew = team.crew(pid=os.getpid(), channel=parent, **kwds)
+            crew = team.crew(pid=os.getpid(), channel=child, **kwds)
             # ask it to register with the team
             crew.register()
             # spin up and carry out tasks until there is nothing more to do
@@ -61,7 +62,7 @@ class Fork(pyre.component, family="pyre.nexus.recruiters.fork", implements=Recru
             raise SystemExit(status)
 
         # make a member proxy for the team manager and return it
-        crew = team.crew(pid=pid, channel=child, timer=team.timer)
+        crew = team.crew(pid=pid, channel=parent, timer=team.timer)
         # adjust its support for asynchrony
         crew.dispatcher = team.dispatcher
         # and its message serializer

--- a/packages/pyre/nexus/Fork.py
+++ b/packages/pyre/nexus/Fork.py
@@ -19,6 +19,12 @@ from .Recruiter import Recruiter
 class Fork(pyre.component, family="pyre.nexus.recruiters.fork", implements=Recruiter):
     """
     Create worker processes by cloning the current one
+
+    New team members inherit only what they need: each side of the crew channel closes the end
+    it does not own, so a worker sees end-of-file when the team dies instead of lingering on a
+    channel its own inherited copies hold open; and workers shed everything else the fork
+    handed them that is none of their business, i.e. whatever the shared event loop watches
+    and the channels of the crews deployed before them
     """
 
     # user configurable state
@@ -56,6 +62,11 @@ class Fork(pyre.component, family="pyre.nexus.recruiters.fork", implements=Recru
 
         # in the worker process
         if pid == 0:
+            # the team's end is not mine to hold; release my inherited copy so the channel
+            # closes for real when the team side lets go
+            parent.close()
+            # shed the rest of the connections the fork handed me
+            self.shed(team=team)
             # make a team member
             crew = team.crew(pid=os.getpid(), channel=child, **kwds)
             # ask it to register with the team
@@ -65,6 +76,8 @@ class Fork(pyre.component, family="pyre.nexus.recruiters.fork", implements=Recru
             # at which point, this process must terminate
             raise SystemExit(status)
 
+        # on the team side, release the worker's end for the same reason
+        child.close()
         # make a member proxy for the team manager and return it
         crew = team.crew(pid=pid, channel=parent, timer=team.timer)
         # adjust its support for asynchrony
@@ -81,6 +94,34 @@ class Fork(pyre.component, family="pyre.nexus.recruiters.fork", implements=Recru
         """
         # harvest the status
         status = os.waitpid(crew.pid, 0)
+        # all done
+        return
+
+    # implementation details
+    def shed(self, team):
+        """
+        Close the inherited connections that belong to the {team} side, not to a new crew
+        member
+
+        The parent's open data files are left alone deliberately: closing their descriptors
+        out from under the inherited objects that will finalize them invites descriptor reuse
+        bugs, and holding them is harmless
+        """
+        # collect the channels the shared event loop is watching
+        pile = set(team.dispatcher.channels())
+        # add the channels of every deployed crew; members between tasks may have no armed
+        # handler, so the event loop does not know about them
+        pile |= set(crew.channel for crew in team.crews())
+        # go through the pile
+        for channel in pile:
+            # carefully, since a descriptor may already be gone
+            try:
+                # release my inherited copy
+                channel.close()
+            # dead ones
+            except OSError:
+                # need nothing further
+                continue
         # all done
         return
 

--- a/packages/pyre/nexus/Pool.py
+++ b/packages/pyre/nexus/Pool.py
@@ -109,6 +109,17 @@ class Pool(Peer, family="pyre.nexus.teams.pool", implements=Team):
         return
 
     # implementation details
+    def crews(self):
+        """
+        Generate the current team members, whatever their state
+        """
+        # the ones still checking in
+        yield from self.registered
+        # and the ones that are deployable
+        yield from self.active
+        # all done
+        return
+
     def recruit(self, **kwds):
         """
         Assemble the team

--- a/packages/pyre/nexus/Pool.py
+++ b/packages/pyre/nexus/Pool.py
@@ -7,6 +7,7 @@
 
 # externals
 import functools
+import os
 
 # support
 import pyre
@@ -107,6 +108,62 @@ class Pool(Peer, family="pyre.nexus.teams.pool", implements=Team):
 
         # all done
         return
+
+    # outcome hooks, invoked by crew members as they harvest completion reports
+    def collect(self, task, result):
+        """
+        A crew member has delivered the {result} of {task}
+        """
+        # a batch pool executes for effect; log the result and move on
+        self.debug.log(f"collected {result} from {task}")
+        # all done
+        return self
+
+    def requeue(self, task, error):
+        """
+        A crew member reports that {task} failed with a recoverable {error}
+        """
+        # tell me
+        self.debug.log(f"requeueing {task} after {error}")
+        # put the task back in the workplan so somebody else gets a crack at it
+        self.workplan.add(task)
+        # all done
+        return self
+
+    def abandon(self, task, error):
+        """
+        A crew member reports that {task} is permanently lost to {error}
+        """
+        # log it; the batch completes without this task
+        self.debug.log(f"abandoning {task} after {error}")
+        # all done
+        return self
+
+    def bury(self, crew):
+        """
+        A {crew} member died without a formal dismissal; clean up after it
+        """
+        # remove the member from all rosters
+        self.registered.discard(crew)
+        self.active.discard(crew)
+        # carefully
+        try:
+            # close the team side of its channel
+            crew.channel.close()
+        # tolerating one that is already gone
+        except OSError:
+            # nothing further
+            pass
+        # carefully
+        try:
+            # reap the corpse
+            os.waitpid(crew.pid, 0)
+        # tolerating one that was already collected
+        except (OSError, ChildProcessError):
+            # nothing further
+            pass
+        # all done
+        return self
 
     # implementation details
     def crews(self):

--- a/packages/pyre/nexus/Staff.py
+++ b/packages/pyre/nexus/Staff.py
@@ -1,0 +1,328 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import atexit
+import functools
+import os
+import signal
+
+# support
+import pyre
+import journal
+
+# my base class
+from .Pool import Pool
+
+
+# declaration
+class Staff(Pool, family="pyre.nexus.teams.staff"):
+    """
+    A standing team of persistent worker processes in the service of a long lived application
+
+    Unlike a {Pool}, which drafts workers for a workplan and dismisses them when it drains,
+    a {Staff} keeps its crew members around: idle ones are parked and woken when new work
+    arrives, casualties are noticed and replaced, and task outcomes are delivered to per-task
+    callbacks instead of being logged and discarded. Task failures are not retried: the
+    outcome, good or bad, goes to the callback, and retry policy belongs to the client
+    """
+
+    # types
+    # the marker for failures the client can recover from by asking again
+    from .exceptions import RecoverableError
+
+    # interface
+    def assign(self, task, callback):
+        """
+        Queue {task} for execution and arrange for {callback} to receive the outcome
+
+        The callback is invoked with {result} and {error} keyword arguments, exactly one of
+        which is non-trivial
+        """
+        # a disbanded staff serves nobody
+        if self._disbanded:
+            # so let the caller down right away
+            callback(result=None, error=self.RecoverableError(description="staff disbanded"))
+            # all done
+            return self
+        # register the callback under the task
+        self.pending[task] = callback
+        # and add the task to the workplan
+        self.assemble(workplan={task})
+        # all done
+        return self
+
+    def crews(self):
+        """
+        Generate every current crew member, whatever its state
+        """
+        # chain up for the ones checking in and the ones on a task
+        yield from super().crews()
+        # and add the ones parked on the bench
+        yield from self.idle
+        # all done
+        return
+
+    def recover(self, **kwds):
+        """
+        Restore the staff to full strength after a casualty
+        """
+        # a disbanded staff stays disbanded; a recovery must not resurrect it
+        if self._disbanded:
+            # so it does nothing
+            return None
+        # otherwise, recruit replacements and wake the bench, in case there is work waiting
+        self.assemble(workplan=set())
+        # all done
+        return None
+
+    def disband(self):
+        """
+        Dismiss every crew member; invoked at shutdown so no workers are orphaned
+        """
+        # crew dismissal is a team side activity; forked children that inherited my atexit
+        # registration must not attempt it
+        if os.getpid() != self._manager:
+            # so they bail
+            return self
+        # mark me, so a recovery arriving after this moment cannot resurrect me
+        self._disbanded = True
+        # the parked and still-checking-in members are between tasks and exit on request
+        resting = set(self.idle) | set(self.registered)
+        # members that are mid-task would block writing a report nobody will drain, so a
+        # graceful dismissal can deadlock the exit; they get terminated instead
+        working = set(self.active)
+        # empty the rosters
+        self.idle.clear()
+        self.active.clear()
+        self.registered.clear()
+        self.vigils.clear()
+        # go through the resting members
+        for crew in resting:
+            # carefully, since a member may have died on its own
+            try:
+                # ask each one to exit
+                crew.dismissed()
+                # and reap the process
+                self.recruiter.dismiss(team=self, crew=crew)
+            # dead members raise while being messaged or waited on
+            except (OSError, ChildProcessError):
+                # nothing more to do for them
+                continue
+        # go through the working members
+        for crew in working:
+            # carefully, for the same reason
+            try:
+                # terminate each one; its work is moot at exit
+                os.kill(crew.pid, signal.SIGKILL)
+                # and reap the process
+                os.waitpid(crew.pid, 0)
+            # dead members raise while being signaled or waited on
+            except (OSError, ChildProcessError):
+                # nothing more to do for them
+                continue
+        # tasks still awaiting outcomes will never get one; deliver the bad news so nobody
+        # is left waiting on a promise
+        for task, callback in list(self.pending.items()):
+            # let each one down gently
+            callback(result=None, error=self.RecoverableError(description="staff disbanded"))
+        # and clear the ledger
+        self.pending.clear()
+        # all done
+        return self
+
+    # team protocol obligations
+    @pyre.export
+    def assemble(self, workplan, **kwds):
+        """
+        Add the tasks in {workplan} to my schedule
+        """
+        # extend the workplan
+        self.workplan |= workplan
+        # recruit up to full strength
+        self.recruit()
+        # if there is work to do
+        if self.workplan:
+            # wake the parked crew members; extras just go back to the bench
+            while self.idle:
+                # take each one off the bench
+                crew = self.idle.pop()
+                # return it to duty
+                self.active.add(crew)
+                # and put it back on the schedule
+                self.schedule(crew=crew)
+        # all done
+        return self
+
+    @pyre.export
+    def vacancies(self):
+        """
+        Compute how many recruits are needed to take the staff to full strength
+        """
+        # my crew members are persistent, so aim for full strength regardless of backlog;
+        # everybody counts: the ones checking in, the ones on a task, and the parked ones
+        return self.size - len(self.registered) - len(self.active) - len(self.idle)
+
+    # outcome hooks, invoked by crew members as they harvest completion reports
+    def collect(self, task, result):
+        """
+        A crew member has delivered the {result} of {task}
+        """
+        # look up the callback
+        callback = self.pending.pop(task, None)
+        # a missing entry means the task outcome was already delivered; it's a bug
+        if callback is None:
+            # build a channel
+            firewall = journal.firewall("pyre.nexus.staff")
+            # complain
+            firewall.line(f"duplicate delivery for {task}")
+            firewall.line(f"while collecting a result in {self}")
+            # flush
+            firewall.log()
+            # and bail, in case firewalls aren't fatal
+            return self
+        # hand the callback the result
+        callback(result=result, error=None)
+        # all done
+        return self
+
+    def requeue(self, task, error):
+        """
+        A crew member reports that {task} failed with a recoverable {error}
+        """
+        # a staff does not retry: the client owns retry policy, so even a recoverable
+        # failure is an outcome to deliver
+        return self.abandon(task=task, error=error)
+
+    def abandon(self, task, error):
+        """
+        A crew member reports that {task} is lost to {error}
+        """
+        # look up the callback
+        callback = self.pending.pop(task, None)
+        # a missing entry means the task outcome was already delivered; it's a bug
+        if callback is None:
+            # build a channel
+            firewall = journal.firewall("pyre.nexus.staff")
+            # complain
+            firewall.line(f"duplicate abandonment for {task}: {error}")
+            firewall.line(f"while delivering bad news in {self}")
+            # flush
+            firewall.log()
+            # and bail, in case firewalls aren't fatal
+            return self
+        # hand the callback the bad news
+        callback(result=None, error=error)
+        # all done
+        return self
+
+    def bury(self, crew):
+        """
+        A {crew} member died without a formal dismissal; clean up after it and restore the
+        staff to full strength
+        """
+        # take the member off the bench and cancel its death watch
+        self.idle.discard(crew)
+        self.vigils.discard(crew)
+        # chain up for the rosters, the channel, and the corpse
+        super().bury(crew=crew)
+        # and recruit a replacement
+        self.recover()
+        # all done
+        return self
+
+    def dismiss(self, crew):
+        """
+        Dismiss the {crew} member from the staff
+        """
+        # chain up to send it home
+        super().dismiss(crew=crew)
+        # a standing staff replaces members that leave, e.g. ones damaged by their task
+        self.recover()
+        # all done
+        return self
+
+    # implementation details
+    def submit(self, channel, crew, **kwds):
+        """
+        A crew member has reported ready to accept tasks
+        """
+        # if there is nothing to do at the moment
+        if not self.workplan:
+            # take the crew member off duty
+            self.active.discard(crew)
+            # and park it; a future {assemble} will wake it
+            self.idle.add(crew)
+            # keep an eye on the parked member, so its death gets noticed and its channel
+            # stays visible to the event loop; the watch survives wake/repark rounds, since
+            # it only clears when its handler fires, so arm at most one per member: a member
+            # that was woken but found no work still has its old watch standing
+            if crew not in self.vigils:
+                # mark it
+                self.vigils.add(crew)
+                # and arm the watch
+                self.dispatcher.whenReadReady(
+                    channel=crew.channel, call=functools.partial(self.vigil, crew=crew)
+                )
+            # and don't reschedule this handler
+            return False
+        # otherwise, grab a task
+        task = self.workplan.pop()
+        # carefully, since the member may have died while waiting for work
+        try:
+            # send it off
+            crew.execute(team=self, task=task)
+        # if its channel is broken
+        except OSError:
+            # the task was never attempted, so put it back for somebody else
+            self.workplan.add(task)
+            # and clean up after the member; the replacement will pick the task up
+            self.bury(crew=crew)
+        # the harvesting of the result decides the fate of this crew member
+        return False
+
+    def vigil(self, channel, crew, **kwds):
+        """
+        The channel of a parked {crew} member has activity
+
+        A parked member has nothing to say, so the only possibility is that it died and its
+        end of the channel closed; but if the member has been woken since this watch was set,
+        the activity is a task report and belongs to the harvesting handler
+        """
+        # this watch is spent, whatever happens next; a future park may arm a fresh one
+        self.vigils.discard(crew)
+        # if the member is no longer parked
+        if crew not in self.idle:
+            # this watch is stale; drop it without touching the channel
+            return False
+        # otherwise, the member is gone; clean up after it
+        self.bury(crew=crew)
+        # and drop the watch
+        return False
+
+    # metamethods
+    def __init__(self, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # the bench of parked crew members
+        self.idle = set()
+        # the members with an armed death watch
+        self.vigils = set()
+        # the callbacks awaiting task outcomes, keyed by task
+        self.pending = {}
+        # remember which process manages the staff, so forked members can tell they are not it
+        self._manager = os.getpid()
+        # the marker that i have been sent home for good
+        self._disbanded = False
+        # applications may exit by raising from deep inside the event loop, bypassing any
+        # orderly shutdown; register the cleanup so crews never outlive me
+        atexit.register(self.disband)
+        # all done
+        return
+
+
+# end of file

--- a/packages/pyre/nexus/Staff.py
+++ b/packages/pyre/nexus/Staff.py
@@ -41,7 +41,9 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
         Queue {task} for execution and arrange for {callback} to receive the outcome
 
         The callback is invoked with {result} and {error} keyword arguments, exactly one of
-        which is non-trivial
+        which is non-trivial. Tasks that compare equal are executed once: later requests
+        join the standing one, and every callback receives the shared outcome. A repeated
+        request also renews the task's priority, since work is served newest first
         """
         # a disbanded staff serves nobody
         if self._disbanded:
@@ -49,10 +51,50 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
             callback(result=None, error=self.RecoverableError(description="staff disbanded"))
             # all done
             return self
-        # register the callback under the task
-        self.pending[task] = callback
-        # and add the task to the workplan
-        self.assemble(workplan={task})
+        # look for a standing request for the same work
+        callbacks = self.pending.get(task)
+        # if there is one
+        if callbacks is not None:
+            # join it
+            callbacks.append(callback)
+            # if the task is still waiting for a crew member
+            if task in self.workplan:
+                # renew its priority: work is served newest first
+                del self.workplan[task]
+                self.workplan[task] = None
+            # either way, the standing request covers this one
+            return self
+        # otherwise, open the callback ledger for this task
+        self.pending[task] = [callback]
+        # add the task to the workplan
+        self.workplan[task] = None
+        # and mobilize: recruit up to strength and wake the bench
+        self.assemble(workplan=())
+        # all done
+        return self
+
+    def revoke(self, task, callback):
+        """
+        Withdraw {callback} from the outcome of {task}, e.g. because its requester went away
+
+        When the last interested party withdraws from a task that has not yet been picked up,
+        the task itself is dropped; work already in a crew member's hands runs to completion,
+        and its outcome is quietly discarded
+        """
+        # look up the callback ledger
+        callbacks = self.pending.get(task)
+        # if there is no standing request, or this callback is not part of it
+        if callbacks is None or callback not in callbacks:
+            # there is nothing to withdraw
+            return self
+        # take the callback out
+        callbacks.remove(callback)
+        # if nobody is left waiting and the task is still queued
+        if not callbacks and task in self.workplan:
+            # drop the task
+            del self.workplan[task]
+            # and close its ledger
+            del self.pending[task]
         # all done
         return self
 
@@ -127,9 +169,14 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
                 continue
         # tasks still awaiting outcomes will never get one; deliver the bad news so nobody
         # is left waiting on a promise
-        for task, callback in list(self.pending.items()):
-            # let each one down gently
-            callback(result=None, error=self.RecoverableError(description="staff disbanded"))
+        for task, callbacks in list(self.pending.items()):
+            # go through the subscribers
+            for callback in callbacks:
+                # and let each one down gently
+                callback(
+                    result=None,
+                    error=self.RecoverableError(description="staff disbanded"),
+                )
         # and clear the ledger
         self.pending.clear()
         # all done
@@ -141,8 +188,10 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
         """
         Add the tasks in {workplan} to my schedule
         """
-        # extend the workplan
-        self.workplan |= workplan
+        # go through the incoming tasks
+        for task in workplan:
+            # and extend the workplan; reinsertion renews a queued task's priority
+            self.workplan[task] = None
         # recruit up to full strength
         self.recruit()
         # if there is work to do
@@ -172,10 +221,10 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
         """
         A crew member has delivered the {result} of {task}
         """
-        # look up the callback
-        callback = self.pending.pop(task, None)
-        # a missing entry means the task outcome was already delivered; it's a bug
-        if callback is None:
+        # look up the callback ledger
+        callbacks = self.pending.pop(task, None)
+        # a missing ledger means the task outcome was already delivered; it's a bug
+        if callbacks is None:
             # build a channel
             firewall = journal.firewall("pyre.nexus.staff")
             # complain
@@ -185,8 +234,11 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
             firewall.log()
             # and bail, in case firewalls aren't fatal
             return self
-        # hand the callback the result
-        callback(result=result, error=None)
+        # go through the subscribers; an empty ledger means every interested party withdrew,
+        # and the result is quietly discarded
+        for callback in callbacks:
+            # hand each one the result
+            callback(result=result, error=None)
         # all done
         return self
 
@@ -202,10 +254,10 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
         """
         A crew member reports that {task} is lost to {error}
         """
-        # look up the callback
-        callback = self.pending.pop(task, None)
-        # a missing entry means the task outcome was already delivered; it's a bug
-        if callback is None:
+        # look up the callback ledger
+        callbacks = self.pending.pop(task, None)
+        # a missing ledger means the task outcome was already delivered; it's a bug
+        if callbacks is None:
             # build a channel
             firewall = journal.firewall("pyre.nexus.staff")
             # complain
@@ -215,8 +267,10 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
             firewall.log()
             # and bail, in case firewalls aren't fatal
             return self
-        # hand the callback the bad news
-        callback(result=None, error=error)
+        # go through the subscribers, if any are left
+        for callback in callbacks:
+            # and hand each one the bad news
+            callback(result=None, error=error)
         # all done
         return self
 
@@ -270,8 +324,9 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
                 )
             # and don't reschedule this handler
             return False
-        # otherwise, grab a task
-        task = self.workplan.pop()
+        # otherwise, grab the newest task: under load, the most recent requests are the
+        # ones their requesters are still looking at
+        task, _ = self.workplan.popitem()
         # carefully, since the member may have died while waiting for work
         try:
             # send it off
@@ -279,7 +334,7 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
         # if its channel is broken
         except OSError:
             # the task was never attempted, so put it back for somebody else
-            self.workplan.add(task)
+            self.workplan[task] = None
             # and clean up after the member; the replacement will pick the task up
             self.bury(crew=crew)
         # the harvesting of the result decides the fate of this crew member
@@ -308,6 +363,9 @@ class Staff(Pool, family="pyre.nexus.teams.staff"):
     def __init__(self, **kwds):
         # chain up
         super().__init__(**kwds)
+        # my workplan is an insertion-ordered map that stands in for an ordered set: the
+        # keys are the queued tasks, served newest first, and reinsertion renews priority
+        self.workplan = {}
         # the bench of parked crew members
         self.idle = set()
         # the members with an armed death watch

--- a/packages/pyre/nexus/__init__.py
+++ b/packages/pyre/nexus/__init__.py
@@ -7,6 +7,9 @@
 # support
 import pyre
 
+# the exceptions
+from . import exceptions
+
 # the protocols
 from .Nexus import Nexus as nexus
 from .Service import Service as service
@@ -19,6 +22,9 @@ from .Server import Server as server
 from .Task import Task as task
 from .TaskStatus import TaskStatus as taskcodes
 from .CrewStatus import CrewStatus as crewcodes
+
+# the facilitator of task execution in foreign processes
+from .Crew import Crew as crew
 
 # task distribution protocols
 from .Team import Team as team
@@ -61,6 +67,19 @@ def pool():
 
     # and return it
     return pool
+
+
+@pyre.foundry(implements=team, tip="a standing team of persistent workers")
+def staff():
+    """
+    The manager of a standing team of persistent workers that deliver task outcomes to
+    per-task callbacks
+    """
+    # get the implementation
+    from .Staff import Staff as staff
+
+    # and return it
+    return staff
 
 
 # end of file

--- a/packages/pyre/nexus/exceptions.py
+++ b/packages/pyre/nexus/exceptions.py
@@ -23,6 +23,17 @@ class RecoverableError(NexusError):
     """
 
 
+# a task that took its crew member down with it
+class Casualty(RecoverableError):
+    """
+    A crew member died while carrying a task
+
+    A death without a report means the task itself may be the killer, e.g. a request that
+    crashes native code; such a task must never be retried in the team's own process, whose
+    survival is the whole point of farming work out to crews
+    """
+
+
 # connection reset by peer
 class ConnectionResetError(NexusError):
     """

--- a/packages/pyre/shells/Fork.py
+++ b/packages/pyre/shells/Fork.py
@@ -90,15 +90,17 @@ class Fork(Executive, family="pyre.shells.fork"):
         if not self.capture:
             return (None, None)
 
-        # otherwise, access the pipe factory
+        # otherwise, access the pipe transport
         import pyre.ipc
 
+        # instantiate it
+        transport = pyre.ipc.newPipe()
         # unpack
         stdin, stdout, stderr = pipes
         # turn {stdout} and {stderr} into channels
         # careful to identify the read/write ends correctly
-        stdout = pyre.ipc.pipe(descriptors=(stdout[0], stdin[1]))
-        stderr = pyre.ipc.pipe(descriptors=(stderr[0], stdin[1]))
+        stdout = transport.wrap(infd=stdout[0], outfd=stdin[1])
+        stderr = transport.wrap(infd=stderr[0], outfd=stdin[1])
         # return them
         return stdout, stderr
 
@@ -110,15 +112,17 @@ class Fork(Executive, family="pyre.shells.fork"):
         if not self.capture:
             return (None, None)
 
-        # otherwise, access the pipe factory
+        # otherwise, access the pipe transport
         import pyre.ipc
 
+        # instantiate it
+        transport = pyre.ipc.newPipe()
         # unpack
         stdin, stdout, stderr = pipes
         # convert {stdout} and {stderr} into channels
         # careful to identify the read/write ends correctly
-        stdout = pyre.ipc.pipe(descriptors=(stdin[0], stdout[1]))
-        stderr = pyre.ipc.pipe(descriptors=(stdin[0], stderr[1]))
+        stdout = transport.wrap(infd=stdin[0], outfd=stdout[1])
+        stderr = transport.wrap(infd=stdin[0], outfd=stderr[1])
         # and return them
         return stdout, stderr
 

--- a/packages/pyre/shells/Web.py
+++ b/packages/pyre/shells/Web.py
@@ -23,6 +23,9 @@ class Web(Script, family="pyre.shells.web"):
     auto = pyre.properties.bool(default=True)
     auto.doc = "controls whether to automatically launch the browser"
 
+    service = pyre.properties.str(default="http")
+    service.doc = "the specification of the component that fields web requests"
+
     # a marker that enables applications to deduce the type of shell that is hosting them
     model = pyre.properties.str(default="web")
     model.doc = "the programming model"
@@ -48,8 +51,9 @@ class Web(Script, family="pyre.shells.web"):
         nexus = pyre.nexus.node(name=f"{application.pyre_name}.nexus")
         # attach it to the application
         application.nexus = nexus
-        # register it with the nexus
-        nexus.services["web"] = "http"
+        # register my web service; the slot resolves the spec into a component instance whose
+        # configuration lives under '{application}.nexus.services.web'
+        nexus.services["web"] = self.service
         # activate
         nexus.prepare(app=application)
         # get the web server

--- a/tests/pyre.lib/grid/index_from_shape.cc
+++ b/tests/pyre.lib/grid/index_from_shape.cc
@@ -1,0 +1,55 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+#include <cassert>
+// get the grid
+#include <pyre/grid.h>
+
+
+// the types under test
+using index_t = pyre::grid::index_t<2>;
+using shape_t = pyre::grid::shape_t<2>;
+
+
+// exercise the constructor that reads the extents of a shape as coordinates
+int
+main(int argc, char * argv[])
+{
+    // initialize the journal
+    pyre::journal::init(argc, argv);
+    // attribute whatever gets logged to this test
+    pyre::journal::application("index_from_shape");
+    // make a channel
+    pyre::journal::debug_t channel("pyre.grid.index");
+
+    // make a shape
+    constexpr shape_t shape { 3, 5 };
+    // read its extents as coordinates
+    constexpr index_t idx { shape };
+    // show me
+    channel << pyre::journal::at() << "idx: " << idx << pyre::journal::endl;
+    // the extents survive the trip
+    static_assert(idx[0] == 3);
+    static_assert(idx[1] == 5);
+
+    // the motivating use: anchor a grid so the shape is centered at the origin
+    constexpr index_t origin { -shape / 2 };
+    // show me
+    channel << pyre::journal::at() << "origin: " << origin << pyre::journal::endl;
+    // the coordinates reflect the halved extents, mirrored through the origin
+    static_assert(origin[0] == -1);
+    static_assert(origin[1] == -2);
+    // and displacing the origin by the shape steps past the far corner
+    static_assert((origin + shape) == index_t { 2, 3 });
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.pkg/http/deferred.py
+++ b/tests/pyre.pkg/http/deferred.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a deferred response parks the connection and delivers its document on resolution
+"""
+
+# the server under test
+from pyre.http.Server import Server
+
+# the document that eventually gets delivered
+from pyre.http.documents import OK
+
+# the transport that stands in for the client connection
+import pyre.ipc
+
+# to peek at the wire without blocking
+import select
+
+
+# a document that carries a body, so the delivery has something recognizable to ship
+class Page(OK):
+    """
+    An {OK} response with a fixed payload
+    """
+
+    # hand back a known body
+    def render(self, **kwds):
+        """
+        Generate the payload
+        """
+        # a fixed page
+        return b"<html>hi</html>"
+
+
+def test():
+    # build a server; no port is bound until activation, which this test never triggers
+    server = Server(name="test.http.deferred")
+    # and a connection, with the parent end playing the server side
+    connection, client = pyre.ipc.newSocket().open()
+
+    # make a response placeholder
+    deferred = server.deferred()
+    # hand it to the server in place of a document
+    parked = server.respond(channel=connection, request=None, response=deferred)
+    # the server keeps the connection open
+    assert parked is True
+    # and has installed its delivery hook
+    assert deferred.deliver is not None
+    # without writing anything to the wire yet
+    ready, _, _ = select.select([client], [], [], 0)
+    assert not ready
+
+    # now the actual document becomes available
+    page = Page(server=server)
+    # deliver it
+    deferred.resolve(response=page)
+    # the client receives a complete response
+    wire = client.read(minlen=15)
+    # with the status line
+    assert wire.startswith(b"HTTP/1.1 200 OK\r\n")
+    # and the body
+    assert wire.endswith(b"<html>hi</html>")
+
+    # all done
+    return server
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/http/deferred_cancel.py
+++ b/tests/pyre.pkg/http/deferred_cancel.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a peer hangup cancels the response parked on its connection, and that delivery
+clears the parking registry
+"""
+
+# externals
+import journal
+
+# the server under test
+from pyre.http.Server import Server
+
+# the document that gets delivered in the happy case
+from pyre.http.documents import OK
+
+# the transport that stands in for the client connection
+import pyre.ipc
+
+
+# the minimal application surface the server consults while processing traffic
+class App:
+    """
+    A stand-in for the hosting application
+    """
+
+    # the diagnostic channel the server logs to
+    debug = journal.debug("test.http.cancel")
+
+
+# a document that carries a body
+class Page(OK):
+    """
+    An {OK} response with a fixed payload
+    """
+
+    # hand back a known body
+    def render(self, **kwds):
+        """
+        Generate the payload
+        """
+        # a fixed page
+        return b"<html>hi</html>"
+
+
+def test():
+    # build a server; no port is bound until activation, which this test never triggers
+    server = Server(name="test.http.deferred.cancel")
+    # give it an application to talk to
+    server.application = App()
+
+    # the hangup scenario
+    connection, client = pyre.ipc.newSocket().open()
+    # make a response placeholder
+    deferred = server.deferred()
+    # the record of cancellations
+    fired = []
+    # install the producer's cancellation hook
+    deferred.abandoned = lambda: fired.append(True)
+    # park it
+    assert server.respond(channel=connection, request=None, response=deferred) is True
+    # the server remembers the parked response
+    assert server.parked[connection] is deferred
+    # the peer hangs up
+    client.close()
+    # the server processes the hangup
+    keep = server.process(channel=connection)
+    # and stops watching the connection
+    assert keep is False
+    # the producer heard about it
+    assert fired == [True]
+    # and the parking registry is clean
+    assert connection not in server.parked
+
+    # the happy scenario: delivery also clears the registry
+    connection, client = pyre.ipc.newSocket().open()
+    # park a fresh placeholder
+    deferred = server.deferred()
+    server.respond(channel=connection, request=None, response=deferred)
+    assert connection in server.parked
+    # the document becomes available and is delivered
+    deferred.resolve(response=Page(server=server))
+    # the registry is clean
+    assert connection not in server.parked
+    # and the client received the response
+    wire = client.read(minlen=15)
+    assert wire.startswith(b"HTTP/1.1 200 OK\r\n")
+    assert wire.endswith(b"<html>hi</html>")
+
+    # all done
+    return server
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/pickler_end_of_stream.py
+++ b/tests/pyre.pkg/ipc/pickler_end_of_stream.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that the pickler reports a dead peer with {EndOfStream}, and that message framing
+survives fragmented and back-to-back arrivals
+"""
+
+# externals
+import os
+import struct
+import time
+
+# access the package
+import pyre.ipc
+
+# the exception under test
+from pyre.ipc.exceptions import EndOfStream
+
+
+def test():
+    # build the marshaler
+    m = pyre.ipc.newPickler()
+
+    # a channel that closes cleanly between messages: no header at all
+    parent, child = pyre.ipc.newSocket().open()
+    child.close()
+    # attempt to
+    try:
+        # read from the dead channel
+        m.recv(channel=parent)
+        # which must not succeed
+        assert False
+    # the marshaler reports the end of the stream
+    except EndOfStream as error:
+        # with nothing received
+        assert error.received == 0
+        # of a header's worth expected
+        assert error.expected == m.headerSize
+
+    # a peer that dies mid-header
+    parent, child = pyre.ipc.newSocket().open()
+    # two bytes of a four byte header
+    child.write(bytes=b"\x10\x00")
+    # and gone
+    child.close()
+    # attempt to
+    try:
+        # read the truncated header
+        m.recv(channel=parent)
+        # which must not succeed
+        assert False
+    # the marshaler reports the end of the stream
+    except EndOfStream as error:
+        # with the fragment accounted for
+        assert error.received == 2
+        assert error.expected == m.headerSize
+
+    # a peer that dies mid-body
+    parent, child = pyre.ipc.newSocket().open()
+    # a header that promises much more than what follows
+    child.write(bytes=struct.pack(m.packing, 100) + b"stub")
+    # and gone
+    child.close()
+    # attempt to
+    try:
+        # read the truncated message
+        m.recv(channel=parent)
+        # which must not succeed
+        assert False
+    # the marshaler reports the end of the stream
+    except EndOfStream as error:
+        # with the fragment accounted for
+        assert error.received == 4
+        assert error.expected == 100
+
+    # a healthy peer whose message arrives in fragments that split the header
+    parent, child = pyre.ipc.newSocket().open()
+    # fork a dribbler
+    pid = os.fork()
+    # in the child process
+    if pid == 0:
+        # assemble a complete message
+        import pickle
+
+        body = pickle.dumps("dribbled")
+        message = struct.pack(m.packing, len(body)) + body
+        # send the first two bytes, splitting the header
+        child.write(bytes=message[:2])
+        # let the reader wake up on the fragment
+        time.sleep(0.2)
+        # send the rest
+        child.write(bytes=message[2:])
+        # and leave
+        os._exit(0)
+    # in the parent, the read blocks until the message completes
+    assert m.recv(channel=parent) == "dribbled"
+    # harvest the dribbler and verify it exited cleanly
+    _, status = os.waitpid(pid, 0)
+    assert status == 0
+
+    # back-to-back messages must not bleed into each other: the first read takes exactly
+    # its own message, even with the second already buffered
+    parent, child = pyre.ipc.newSocket().open()
+    m.send(item="first", channel=child)
+    m.send(item="second", channel=child)
+    assert m.recv(channel=parent) == "first"
+    assert m.recv(channel=parent) == "second"
+
+    # all done
+    return m
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/pickler_over_pipe.py
+++ b/tests/pyre.pkg/ipc/pickler_over_pipe.py
@@ -21,7 +21,7 @@ def test():
     # make a pickler
     m = pyre.ipc.newPickler()
     # and a pair of pipes
-    parent, child = pyre.ipc.pipe()
+    parent, child = pyre.ipc.newPipe().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/pickler_over_socketpair.py
+++ b/tests/pyre.pkg/ipc/pickler_over_socketpair.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Build two processes that communicate using pickler over a socket pair
+"""
+
+
+def test():
+    # externals
+    import os
+
+    # access the package
+    import pyre.ipc
+
+    # make a pickler
+    m = pyre.ipc.newPickler()
+    # and a pair of connected channels
+    parent, child = pyre.ipc.socketpair()
+
+    # fork
+    pid = os.fork()
+    # in the parent process
+    if pid > 0:
+        # invoke the parent behavior
+        return onParent(child_pid=pid, marshaler=m, channel=parent)
+    # in the child
+    return onChild(marshaler=m, channel=child)
+
+
+# the trivial messages
+hello = "hello"
+goodbye = "goodbye"
+
+
+def onParent(child_pid, marshaler, channel):
+    """Send a simple message and wait for the response"""
+    # externals
+    import os
+
+    # send a message
+    marshaler.send(hello, channel)
+    # get the response
+    response = marshaler.recv(channel)
+    # check it
+    assert response == goodbye
+    # harvest the child and verify it exited cleanly
+    _, status = os.waitpid(child_pid, 0)
+    assert status == 0
+    # and return
+    return
+
+
+def onChild(marshaler, channel):
+    """Wait for a message and send a response"""
+    # get the message
+    message = marshaler.recv(channel)
+    # check it
+    assert message == hello
+    # send the response
+    marshaler.send(goodbye, channel)
+    # and return
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/pickler_over_socketpair.py
+++ b/tests/pyre.pkg/ipc/pickler_over_socketpair.py
@@ -21,7 +21,7 @@ def test():
     # make a pickler
     m = pyre.ipc.newPickler()
     # and a pair of connected channels
-    parent, child = pyre.ipc.socketpair()
+    parent, child = pyre.ipc.newSocket().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/pickler_over_tcp.py
+++ b/tests/pyre.pkg/ipc/pickler_over_tcp.py
@@ -31,7 +31,7 @@ def test():
     # make a pickler
     m = pyre.ipc.newPickler()
     # and a pair of pipes
-    parent, child = pyre.ipc.pipe()
+    parent, child = pyre.ipc.newPipe().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/pipe.py
+++ b/tests/pyre.pkg/ipc/pipe.py
@@ -16,7 +16,15 @@ def test():
     import pyre.ipc
 
     # make a pair of pipes
-    return pyre.ipc.pipe()
+    ends = pyre.ipc.pipe()
+    # the pair unpacks in a fixed order
+    parent, child = ends
+    # that matches its named endpoints
+    assert ends.parent is parent
+    assert ends.child is child
+
+    # and hand it back
+    return ends
 
 
 # main

--- a/tests/pyre.pkg/ipc/pipe.py
+++ b/tests/pyre.pkg/ipc/pipe.py
@@ -7,7 +7,7 @@
 
 
 """
-Sanity check: verify that the pipe factory is accessible
+Sanity check: verify that the pipe transport builds channel pairs
 """
 
 
@@ -16,7 +16,7 @@ def test():
     import pyre.ipc
 
     # make a pair of pipes
-    ends = pyre.ipc.pipe()
+    ends = pyre.ipc.newPipe().open()
     # the pair unpacks in a fixed order
     parent, child = ends
     # that matches its named endpoints

--- a/tests/pyre.pkg/ipc/psl_channels.py
+++ b/tests/pyre.pkg/ipc/psl_channels.py
@@ -27,23 +27,23 @@ def test():
     assert list(s.channels()) == []
 
     # make a pipe pair, whose endpoints are raw descriptors
-    pin, pout = pyre.ipc.pipe()
+    pipe = pyre.ipc.pipe()
     # and a socket pair, whose endpoints are socket objects
-    sin, sout = pyre.ipc.socketpair()
+    sock = pyre.ipc.socketpair()
 
-    # register read interest on one end of the pipe
-    s.whenReadReady(channel=pin, call=idle)
+    # register read interest on the parent end of the pipe
+    s.whenReadReady(channel=pipe.parent, call=idle)
     # and write interest on the same channel, to exercise deduplication
-    s.whenWriteReady(channel=pin, call=idle)
-    # register read interest on one end of the socket pair
-    s.whenReadReady(channel=sout, call=idle)
+    s.whenWriteReady(channel=pipe.parent, call=idle)
+    # register read interest on the child end of the socket pair
+    s.whenReadReady(channel=sock.child, call=idle)
 
     # collect the watch list
     watched = list(s.channels())
     # each channel shows up exactly once, regardless of how many interests it holds
     assert len(watched) == 2
     # and the list contains precisely the registered channels
-    assert set(watched) == {pin, sout}
+    assert set(watched) == {pipe.parent, sock.child}
 
     # all done
     return s

--- a/tests/pyre.pkg/ipc/psl_channels.py
+++ b/tests/pyre.pkg/ipc/psl_channels.py
@@ -27,9 +27,9 @@ def test():
     assert list(s.channels()) == []
 
     # make a pipe pair, whose endpoints are raw descriptors
-    pipe = pyre.ipc.pipe()
+    pipe = pyre.ipc.newPipe().open()
     # and a socket pair, whose endpoints are socket objects
-    sock = pyre.ipc.socketpair()
+    sock = pyre.ipc.newSocket().open()
 
     # register read interest on the parent end of the pipe
     s.whenReadReady(channel=pipe.parent, call=idle)

--- a/tests/pyre.pkg/ipc/psl_channels.py
+++ b/tests/pyre.pkg/ipc/psl_channels.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a PSL selector can report the channels it is currently watching
+"""
+
+
+def idle(channel, **kwds):
+    """A do-nothing handler"""
+    # decline to be rescheduled
+    return False
+
+
+def test():
+    # access the package
+    import pyre.ipc
+
+    # make a selector
+    s = pyre.ipc.newPSL()
+    # a fresh selector watches nothing
+    assert list(s.channels()) == []
+
+    # make a pipe pair, whose endpoints are raw descriptors
+    pin, pout = pyre.ipc.pipe()
+    # and a socket pair, whose endpoints are socket objects
+    sin, sout = pyre.ipc.socketpair()
+
+    # register read interest on one end of the pipe
+    s.whenReadReady(channel=pin, call=idle)
+    # and write interest on the same channel, to exercise deduplication
+    s.whenWriteReady(channel=pin, call=idle)
+    # register read interest on one end of the socket pair
+    s.whenReadReady(channel=sout, call=idle)
+
+    # collect the watch list
+    watched = list(s.channels())
+    # each channel shows up exactly once, regardless of how many interests it holds
+    assert len(watched) == 2
+    # and the list contains precisely the registered channels
+    assert set(watched) == {pin, sout}
+
+    # all done
+    return s
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/psl_close_reuse.py
+++ b/tests/pyre.pkg/ipc/psl_close_reuse.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a PSL selector survives descriptor number reuse within a single dispatch cycle
+
+A handler closes its own channel, opens a fresh one that the kernel gives the same descriptor
+number, and registers interest with the same event mask; the fresh registration must be live,
+not a phantom left behind by stale bookkeeping
+"""
+
+# externals
+import pyre.ipc
+
+# the unit of time for the safety net
+from pyre.units.SI import second
+
+
+def scenario(transport):
+    """
+    Run the close-and-reuse scenario over channels built by {transport}
+    """
+    # build a selector
+    s = pyre.ipc.newPSL()
+    # and the original pair of channels
+    parent, child = transport.open()
+    # remember the descriptor number of the watched end
+    old = parent.inbound if isinstance(parent.inbound, int) else parent.fileno()
+    # the record of what fired
+    fired = []
+    # and a parking spot for the replacement pair, so it outlives the handler
+    replacement = {}
+
+    # the handler that springs the trap
+    def killer(channel, **kwds):
+        """
+        Close the dispatched channel and reincarnate its descriptor number
+        """
+        # drain the byte that woke us
+        channel.read(minlen=1, maxlen=1)
+        # close both ends, freeing their descriptor numbers
+        parent.close()
+        child.close()
+        # open a fresh pair; the kernel hands back the lowest free numbers
+        p, c = transport.open()
+        # park them
+        replacement["pair"] = (p, c)
+        # find the end that reincarnated the old number
+        fresh = p if (p.inbound if isinstance(p.inbound, int) else p.fileno()) == old else c
+        other = c if fresh is p else p
+        # this scenario is about number reuse; insist it actually happened
+        freshfd = fresh.inbound if isinstance(fresh.inbound, int) else fresh.fileno()
+        assert freshfd == old
+        # register interest with the same mask as the channel just closed
+        s.whenReadReady(channel=fresh, call=survivor)
+        # and make the fresh channel readable right away
+        other.write(bytes=b"x")
+        # this handler is done
+        return False
+
+    # the handler that must fire despite the reuse
+    def survivor(channel, **kwds):
+        """
+        Prove the fresh registration is live
+        """
+        # drain the byte
+        channel.read(minlen=1, maxlen=1)
+        # make a record
+        fired.append(True)
+        # and wind down
+        s.stop()
+        # all done
+        return False
+
+    # the safety net: a wedged selector must not hang the test
+    def expire(timestamp):
+        """
+        Give up
+        """
+        # wind down
+        s.stop()
+        # and don't reschedule
+        return None
+
+    # arm the trap
+    s.whenReadReady(channel=parent, call=killer)
+    # make the original channel readable
+    child.write(bytes=b"!")
+    # set the safety net
+    s.alarm(interval=1 * second, call=expire)
+    # spin
+    s.watch()
+
+    # the fresh registration must have fired
+    assert fired, f"phantom registration: the reused descriptor never fired"
+    # all done
+    return
+
+
+def test():
+    # the scenario must hold over socket pairs, whose table keys are channel objects
+    scenario(transport=pyre.ipc.newSocket())
+    # and over pipes, whose table keys are raw descriptor numbers
+    scenario(transport=pyre.ipc.newPipe())
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/psl_pickler_over_pipe.py
+++ b/tests/pyre.pkg/ipc/psl_pickler_over_pipe.py
@@ -26,7 +26,7 @@ def test():
     # build the marshaler
     m = pyre.ipc.newPickler()
     # and the communication channels
-    parent, child = pyre.ipc.pipe()
+    parent, child = pyre.ipc.newPipe().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/psl_pickler_over_pipe.py
+++ b/tests/pyre.pkg/ipc/psl_pickler_over_pipe.py
@@ -33,10 +33,10 @@ def test():
     # in the parent process
     if pid > 0:
         # invoke the parent behavior
-        return onParent(child_pid=pid, marshaler=m, channel=child)
+        return onParent(child_pid=pid, marshaler=m, channel=parent)
 
     # in the child process
-    return onChild(marshaler=m, channel=parent)
+    return onChild(marshaler=m, channel=child)
 
 
 def onParent(child_pid, marshaler, channel):

--- a/tests/pyre.pkg/ipc/psl_pickler_over_socketpair.py
+++ b/tests/pyre.pkg/ipc/psl_pickler_over_socketpair.py
@@ -27,7 +27,7 @@ def test():
     # build the marshaler
     m = pyre.ipc.newPickler()
     # and the communication channels
-    parent, child = pyre.ipc.socketpair()
+    parent, child = pyre.ipc.newSocket().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/psl_pickler_over_socketpair.py
+++ b/tests/pyre.pkg/ipc/psl_pickler_over_socketpair.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise a PSL selector watching over the ends of a socket pair
+"""
+
+# externals
+import os
+import pyre.ipc
+
+# if necessary
+import journal
+
+parentdbg = journal.debug("psl.parent")
+# parentdbg.active = True
+childdbg = journal.debug("psl.child")
+# childdbg.active = True
+
+
+def test():
+    # build the marshaler
+    m = pyre.ipc.newPickler()
+    # and the communication channels
+    parent, child = pyre.ipc.socketpair()
+
+    # fork
+    pid = os.fork()
+    # in the parent process
+    if pid > 0:
+        # invoke the parent behavior
+        return onParent(child_pid=pid, marshaler=m, channel=parent)
+
+    # in the child process
+    return onChild(marshaler=m, channel=child)
+
+
+def onParent(child_pid, marshaler, channel):
+    # instantiate a selector
+    parentdbg.log("parent: building a selector")
+    s = pyre.ipc.newPSL()
+
+    # write-ready handler
+    def parent_send(channel, **kwds):
+        """send a string to the child"""
+
+        # register the response handler; do this early to avoid race conditions
+        parentdbg.log("parent: registering the response handler")
+        s.whenReadReady(channel=channel, call=parent_get)
+
+        parentdbg.log("parent: preparing the message")
+        # prepare the message
+        message = f"Hello {child_pid}!"
+
+        # send the message
+        parentdbg.log("parent: sending the message")
+        marshaler.send(item=message, channel=channel)
+        parentdbg.log("parent: done sending the message")
+
+        # and return {False} so the selector stops watching the output channel
+        return False
+
+    # read-ready handler
+    def parent_get(channel, **kwds):
+        """receive the response from the child"""
+
+        parentdbg.log("parent: getting response from child")
+        # get the response
+        message = marshaler.recv(channel)
+        parentdbg.log(f"message={message!r}")
+        # check it
+        parentdbg.log("parent: checking child response")
+        assert message == f"Goodbye from {child_pid}!"
+        parentdbg.log("parent: all good")
+        # and return {False} so the selector stops watching the input channel
+        return False
+
+    # let me know when my channel TO the child is ready for writing
+    parentdbg.log("parent: registering the child response handler")
+    s.whenWriteReady(channel=channel, call=parent_send)
+    # invoke the selector
+    parentdbg.log("parent: initiating exchange")
+    s.watch()
+    # harvest the child and verify it exited cleanly
+    _, status = os.waitpid(child_pid, 0)
+    assert status == 0
+    parentdbg.log("parent: all done; exiting")
+    # all done
+    return
+
+
+def onChild(marshaler, channel):
+    # instantiate a selector
+    childdbg.log("child: building a selector")
+    s = pyre.ipc.newPSL()
+
+    # get my pid
+    child_pid = os.getpid()
+
+    # read-ready handler
+    def child_get(channel, **kwds):
+        """receive a message from my parent"""
+        childdbg.log("child: receiving message from parent")
+        message = marshaler.recv(channel)
+        childdbg.log(f"message={message!r}")
+        # check it
+        childdbg.log("child: checking it")
+        assert message == f"Hello {child_pid}!"
+        childdbg.log("child: all good")
+        # register the response handler
+        childdbg.log("child: registering the response sender")
+        s.whenWriteReady(channel=channel, call=child_send)
+        # and return {False} so the selector stops watching the input channel
+        return False
+
+    def child_send(channel, **kwds):
+        """send a response to my parent"""
+
+        childdbg.log("child: preparing the response")
+        # create the payload
+        message = f"Goodbye from {child_pid}!"
+
+        # send the message
+        childdbg.log("child: sending the response")
+        marshaler.send(item=message, channel=channel)
+        childdbg.log("child: done sending the response")
+
+        # and return {False} so the selector stops watching the output channel
+        return False
+
+    # let me know when my channel FROM my parent is ready for reading
+    childdbg.log("child: registering the child response handler")
+    s.whenReadReady(channel=channel, call=child_get)
+    # invoke the selector
+    childdbg.log("child: waiting for exchange")
+    s.watch()
+    childdbg.log("child: all done; exiting")
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/psl_pickler_over_tcp.py
+++ b/tests/pyre.pkg/ipc/psl_pickler_over_tcp.py
@@ -26,20 +26,20 @@ def test():
     # build the marshaler
     m = pyre.ipc.newPickler()
     # and the communication channels
-    server, client = pyre.ipc.pipe()
+    parent, child = pyre.ipc.pipe()
 
     # fork
     pid = os.fork()
     # in the server process
     if pid > 0:
         # invoke the server behavior
-        return onServer(clientPid=pid, marshaler=m, pipe=client)
+        return onServer(clientPid=pid, marshaler=m, pipe=parent)
 
     # in the client process
     # get my pid
     clientPid = os.getpid()
     # invoke the behavior
-    return onClient(clientPid=clientPid, marshaler=m, pipe=server)
+    return onClient(clientPid=clientPid, marshaler=m, pipe=child)
 
 
 def onServer(clientPid, marshaler, pipe):

--- a/tests/pyre.pkg/ipc/psl_pickler_over_tcp.py
+++ b/tests/pyre.pkg/ipc/psl_pickler_over_tcp.py
@@ -26,7 +26,7 @@ def test():
     # build the marshaler
     m = pyre.ipc.newPickler()
     # and the communication channels
-    parent, child = pyre.ipc.pipe()
+    parent, child = pyre.ipc.newPipe().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/psl_rearm_during_dispatch.py
+++ b/tests/pyre.pkg/ipc/psl_rearm_during_dispatch.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that interest registered on a channel while its own pile is being dispatched is
+neither invoked prematurely nor lost
+
+The successor's wakeup is delivered only after the current dispatch pass, so a selector that
+invokes it early finds an empty channel, and one that drops it never delivers the record
+"""
+
+# externals
+import select
+
+# access the package
+import pyre.ipc
+
+# the unit of time
+from pyre.units.SI import second
+
+
+def test():
+    # build a selector
+    s = pyre.ipc.newPSL()
+    # and a pair of channels
+    parent, child = pyre.ipc.newSocket().open()
+    # the record of what fired, in order
+    log = []
+
+    # the handler that re-arms the same channel while being dispatched
+    def first(channel, **kwds):
+        """
+        Consume the wakeup and register a successor on the same channel and direction
+        """
+        # drain the byte that woke us
+        channel.read(minlen=1, maxlen=1)
+        # make a record
+        log.append("first")
+        # register the successor on the same channel, same direction
+        s.whenReadReady(channel=channel, call=successor)
+        # deliver its wakeup only after this dispatch pass completes
+        s.alarm(interval=0.05 * second, call=wake)
+        # this handler is done
+        return False
+
+    # the successor
+    def successor(channel, **kwds):
+        """
+        Fire on a later dispatch pass, once the wakeup has been delivered
+        """
+        # a premature invocation finds nothing to read
+        ready, _, _ = select.select([channel], [], [], 0)
+        # record it as such
+        if not ready:
+            # so the final check can tell the story
+            log.append("premature")
+            # and bail without blocking
+            return False
+        # otherwise, drain the byte
+        channel.read(minlen=1, maxlen=1)
+        # make a record
+        log.append("second")
+        # and wind down
+        s.stop()
+        # all done
+        return False
+
+    # the deferred wakeup
+    def wake(timestamp):
+        """
+        Make the channel readable, one dispatch pass after the successor was registered
+        """
+        # send the byte
+        child.write(bytes=b"2")
+        # don't reschedule
+        return None
+
+    # the safety net: a lost registration must not hang the test
+    def expire(timestamp):
+        """
+        Give up
+        """
+        # wind down
+        s.stop()
+        # and don't reschedule
+        return None
+
+    # arm the first handler
+    s.whenReadReady(channel=parent, call=first)
+    # wake it
+    child.write(bytes=b"1")
+    # set the safety net
+    s.alarm(interval=1 * second, call=expire)
+    # spin
+    s.watch()
+
+    # the successor must have fired exactly once, on its own pass
+    assert log == ["first", "second"], f"broken dispatch: {log}"
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/selector_channels.py
+++ b/tests/pyre.pkg/ipc/selector_channels.py
@@ -27,23 +27,23 @@ def test():
     assert list(s.channels()) == []
 
     # make a pipe pair, whose endpoints are raw descriptors
-    pin, pout = pyre.ipc.pipe()
+    pipe = pyre.ipc.pipe()
     # and a socket pair, whose endpoints are socket objects
-    sin, sout = pyre.ipc.socketpair()
+    sock = pyre.ipc.socketpair()
 
-    # register read interest on one end of the pipe
-    s.whenReadReady(channel=pin, call=idle)
+    # register read interest on the parent end of the pipe
+    s.whenReadReady(channel=pipe.parent, call=idle)
     # and write interest on the same channel, to exercise deduplication
-    s.whenWriteReady(channel=pin, call=idle)
-    # register read interest on one end of the socket pair
-    s.whenReadReady(channel=sout, call=idle)
+    s.whenWriteReady(channel=pipe.parent, call=idle)
+    # register read interest on the child end of the socket pair
+    s.whenReadReady(channel=sock.child, call=idle)
 
     # collect the watch list
     watched = list(s.channels())
     # each channel shows up exactly once, regardless of how many interests it holds
     assert len(watched) == 2
     # and the list contains precisely the registered channels
-    assert set(watched) == {pin, sout}
+    assert set(watched) == {pipe.parent, sock.child}
 
     # all done
     return s

--- a/tests/pyre.pkg/ipc/selector_channels.py
+++ b/tests/pyre.pkg/ipc/selector_channels.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a selector can report the channels it is currently watching
+"""
+
+
+def idle(channel, **kwds):
+    """A do-nothing handler"""
+    # decline to be rescheduled
+    return False
+
+
+def test():
+    # access the package
+    import pyre.ipc
+
+    # make a selector
+    s = pyre.ipc.newSelector()
+    # a fresh selector watches nothing
+    assert list(s.channels()) == []
+
+    # make a pipe pair, whose endpoints are raw descriptors
+    pin, pout = pyre.ipc.pipe()
+    # and a socket pair, whose endpoints are socket objects
+    sin, sout = pyre.ipc.socketpair()
+
+    # register read interest on one end of the pipe
+    s.whenReadReady(channel=pin, call=idle)
+    # and write interest on the same channel, to exercise deduplication
+    s.whenWriteReady(channel=pin, call=idle)
+    # register read interest on one end of the socket pair
+    s.whenReadReady(channel=sout, call=idle)
+
+    # collect the watch list
+    watched = list(s.channels())
+    # each channel shows up exactly once, regardless of how many interests it holds
+    assert len(watched) == 2
+    # and the list contains precisely the registered channels
+    assert set(watched) == {pin, sout}
+
+    # all done
+    return s
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/selector_channels.py
+++ b/tests/pyre.pkg/ipc/selector_channels.py
@@ -27,9 +27,9 @@ def test():
     assert list(s.channels()) == []
 
     # make a pipe pair, whose endpoints are raw descriptors
-    pipe = pyre.ipc.pipe()
+    pipe = pyre.ipc.newPipe().open()
     # and a socket pair, whose endpoints are socket objects
-    sock = pyre.ipc.socketpair()
+    sock = pyre.ipc.newSocket().open()
 
     # register read interest on the parent end of the pipe
     s.whenReadReady(channel=pipe.parent, call=idle)

--- a/tests/pyre.pkg/ipc/selector_close_reuse.py
+++ b/tests/pyre.pkg/ipc/selector_close_reuse.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a selector survives descriptor number reuse within a single dispatch cycle
+
+A handler closes its own channel, opens a fresh one that the kernel gives the same descriptor
+number, and registers interest with the same event mask; the fresh registration must be live,
+not a phantom left behind by stale bookkeeping
+"""
+
+# externals
+import pyre.ipc
+
+# the unit of time for the safety net
+from pyre.units.SI import second
+
+
+def scenario(transport):
+    """
+    Run the close-and-reuse scenario over channels built by {transport}
+    """
+    # build a selector
+    s = pyre.ipc.newSelector()
+    # and the original pair of channels
+    parent, child = transport.open()
+    # remember the descriptor number of the watched end
+    old = parent.inbound if isinstance(parent.inbound, int) else parent.fileno()
+    # the record of what fired
+    fired = []
+    # and a parking spot for the replacement pair, so it outlives the handler
+    replacement = {}
+
+    # the handler that springs the trap
+    def killer(channel, **kwds):
+        """
+        Close the dispatched channel and reincarnate its descriptor number
+        """
+        # drain the byte that woke us
+        channel.read(minlen=1, maxlen=1)
+        # close both ends, freeing their descriptor numbers
+        parent.close()
+        child.close()
+        # open a fresh pair; the kernel hands back the lowest free numbers
+        p, c = transport.open()
+        # park them
+        replacement["pair"] = (p, c)
+        # find the end that reincarnated the old number
+        fresh = p if (p.inbound if isinstance(p.inbound, int) else p.fileno()) == old else c
+        other = c if fresh is p else p
+        # this scenario is about number reuse; insist it actually happened
+        freshfd = fresh.inbound if isinstance(fresh.inbound, int) else fresh.fileno()
+        assert freshfd == old
+        # register interest with the same mask as the channel just closed
+        s.whenReadReady(channel=fresh, call=survivor)
+        # and make the fresh channel readable right away
+        other.write(bytes=b"x")
+        # this handler is done
+        return False
+
+    # the handler that must fire despite the reuse
+    def survivor(channel, **kwds):
+        """
+        Prove the fresh registration is live
+        """
+        # drain the byte
+        channel.read(minlen=1, maxlen=1)
+        # make a record
+        fired.append(True)
+        # and wind down
+        s.stop()
+        # all done
+        return False
+
+    # the safety net: a wedged selector must not hang the test
+    def expire(timestamp):
+        """
+        Give up
+        """
+        # wind down
+        s.stop()
+        # and don't reschedule
+        return None
+
+    # arm the trap
+    s.whenReadReady(channel=parent, call=killer)
+    # make the original channel readable
+    child.write(bytes=b"!")
+    # set the safety net
+    s.alarm(interval=1 * second, call=expire)
+    # spin
+    s.watch()
+
+    # the fresh registration must have fired
+    assert fired, f"phantom registration: the reused descriptor never fired"
+    # all done
+    return
+
+
+def test():
+    # the scenario must hold over socket pairs, whose table keys are channel objects
+    scenario(transport=pyre.ipc.newSocket())
+    # and over pipes, whose table keys are raw descriptor numbers
+    scenario(transport=pyre.ipc.newPipe())
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/selector_dead_registration.py
+++ b/tests/pyre.pkg/ipc/selector_dead_registration.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a selector survives a registration whose channel was closed behind its back,
+and keeps serving the live ones
+"""
+
+# access the package
+import pyre.ipc
+
+# the unit of time for the safety net
+from pyre.units.SI import second
+
+
+def scenario(factory):
+    """
+    Run the dead-registration scenario on a dispatcher built by {factory}
+    """
+    # build a selector
+    s = factory()
+    # a pair of channels that will die
+    doomedParent, doomedChild = pyre.ipc.newSocket().open()
+    # and a pair that stays alive
+    parent, child = pyre.ipc.newSocket().open()
+    # the record of what fired
+    fired = []
+
+    # the handler for the dead channel; it must never fire
+    def ghost(channel, **kwds):
+        """
+        A handler stranded on a dead channel
+        """
+        # make a record, so the check below can complain
+        fired.append("ghost")
+        # and don't reschedule
+        return False
+
+    # the handler for the live channel
+    def live(channel, **kwds):
+        """
+        Prove the live channel is still served
+        """
+        # drain the byte
+        channel.read(minlen=1, maxlen=1)
+        # make a record
+        fired.append("live")
+        # and wind down
+        s.stop()
+        # all done
+        return False
+
+    # the safety net
+    def expire(timestamp):
+        """
+        Give up
+        """
+        # wind down
+        s.stop()
+        # and don't reschedule
+        return None
+
+    # register both
+    s.whenReadReady(channel=doomedParent, call=ghost)
+    s.whenReadReady(channel=parent, call=live)
+    # kill the doomed pair behind the selector's back
+    doomedParent.close()
+    doomedChild.close()
+    # make the live channel readable
+    child.write(bytes=b"!")
+    # set the safety net
+    s.alarm(interval=1 * second, call=expire)
+    # spin; a fragile selector crashes or wedges here
+    s.watch()
+
+    # the live channel was served, and the ghost stayed quiet
+    assert fired == ["live"], f"dead registration disrupted service: {fired}"
+    # all done
+    return
+
+
+def test():
+    # the scenario must hold on the classic selector
+    scenario(factory=pyre.ipc.newSelector)
+    # and on the psl flavor
+    scenario(factory=pyre.ipc.newPSL)
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/selector_pickler_over_pipe.py
+++ b/tests/pyre.pkg/ipc/selector_pickler_over_pipe.py
@@ -34,10 +34,10 @@ def test():
     # in the parent process
     if pid > 0:
         # invoke the parent behavior
-        return onParent(child_pid=pid, marshaler=m, channel=child)
+        return onParent(child_pid=pid, marshaler=m, channel=parent)
 
     # in the child process
-    return onChild(marshaler=m, channel=parent)
+    return onChild(marshaler=m, channel=child)
 
 
 def onParent(child_pid, marshaler, channel):

--- a/tests/pyre.pkg/ipc/selector_pickler_over_pipe.py
+++ b/tests/pyre.pkg/ipc/selector_pickler_over_pipe.py
@@ -27,7 +27,7 @@ def test():
     # build the marshaler
     m = pyre.ipc.newPickler()
     # and the communication channels
-    parent, child = pyre.ipc.pipe()
+    parent, child = pyre.ipc.newPipe().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/selector_pickler_over_socketpair.py
+++ b/tests/pyre.pkg/ipc/selector_pickler_over_socketpair.py
@@ -27,7 +27,7 @@ def test():
     # build the marshaler
     m = pyre.ipc.newPickler()
     # and the communication channels
-    parent, child = pyre.ipc.socketpair()
+    parent, child = pyre.ipc.newSocket().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/selector_pickler_over_socketpair.py
+++ b/tests/pyre.pkg/ipc/selector_pickler_over_socketpair.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise a selector watching over the ends of a socket pair
+"""
+
+# externals
+import os
+import pyre.ipc
+
+# if necessary
+import journal
+
+parentdbg = journal.debug("selector.parent")
+# parentdbg.active = True
+childdbg = journal.debug("selector.child")
+# childdbg.active = True
+
+
+def test():
+    # build the marshaler
+    m = pyre.ipc.newPickler()
+    # and the communication channels
+    parent, child = pyre.ipc.socketpair()
+
+    # fork
+    pid = os.fork()
+    # in the parent process
+    if pid > 0:
+        # invoke the parent behavior
+        return onParent(child_pid=pid, marshaler=m, channel=parent)
+
+    # in the child process
+    return onChild(marshaler=m, channel=child)
+
+
+def onParent(child_pid, marshaler, channel):
+    # observe the parent selector at work
+    # journal.debug("pyre.ipc.selector").active = True
+
+    # instantiate a selector
+    parentdbg.log("parent: building a selector")
+    s = pyre.ipc.newSelector()
+
+    # write-ready handler
+    def parent_send(channel, **kwds):
+        """send a string to the child"""
+
+        # register the response handler; do this early to avoid race conditions
+        parentdbg.log("parent: registering the response handler")
+        s.whenReadReady(channel=channel, call=parent_get)
+
+        parentdbg.log("parent: preparing the message")
+        # prepare the message
+        message = f"Hello {child_pid}!"
+
+        # send the message
+        parentdbg.log("parent: sending the message")
+        marshaler.send(item=message, channel=channel)
+        parentdbg.log("parent: done sending the message")
+
+        # and return {False} so the selector stops watching the output channel
+        return False
+
+    # read-ready handler
+    def parent_get(channel, **kwds):
+        """receive the response from the child"""
+
+        parentdbg.log("parent: getting response from child")
+        # get the response
+        message = marshaler.recv(channel)
+        parentdbg.log(f"message={message!r}")
+        # check it
+        parentdbg.log("parent: checking child response")
+        assert message == f"Goodbye from {child_pid}!"
+        parentdbg.log("parent: all good")
+        # and return {False} so the selector stops watching the input channel
+        return False
+
+    # let me know when my channel TO the child is ready for writing
+    parentdbg.log("parent: registering the child response handler")
+    s.whenWriteReady(channel=channel, call=parent_send)
+    # invoke the selector
+    parentdbg.log("parent: initiating exchange")
+    s.watch()
+    # harvest the child and verify it exited cleanly
+    _, status = os.waitpid(child_pid, 0)
+    assert status == 0
+    parentdbg.log("parent: all done; exiting")
+    # all done
+    return
+
+
+def onChild(marshaler, channel):
+
+    # observe the child selector at work
+    # journal.debug("pyre.ipc.selector").active = True
+
+    # instantiate a selector
+    childdbg.log("child: building a selector")
+    s = pyre.ipc.newSelector()
+
+    # get my pid
+    child_pid = os.getpid()
+
+    # read-ready handler
+    def child_get(channel, **kwds):
+        """receive a message from my parent"""
+        childdbg.log("child: receiving message from parent")
+        message = marshaler.recv(channel)
+        childdbg.log(f"message={message!r}")
+        # check it
+        childdbg.log("child: checking it")
+        assert message == f"Hello {child_pid}!"
+        childdbg.log("child: all good")
+        # register the response handler
+        childdbg.log("child: registering the response sender")
+        s.whenWriteReady(channel=channel, call=child_send)
+        # and return {False} so the selector stops watching the input channel
+        return False
+
+    def child_send(channel, **kwds):
+        """send a response to my parent"""
+
+        childdbg.log("child: preparing the response")
+        # create the payload
+        message = f"Goodbye from {child_pid}!"
+
+        # send the message
+        childdbg.log("child: sending the response")
+        marshaler.send(item=message, channel=channel)
+        childdbg.log("child: done sending the response")
+
+        # and return {False} so the selector stops watching the output channel
+        return False
+
+    # let me know when my channel FROM my parent is ready for reading
+    childdbg.log("child: registering the child response handler")
+    s.whenReadReady(channel=channel, call=child_get)
+    # invoke the selector
+    childdbg.log("child: waiting for exchange")
+    s.watch()
+    childdbg.log("child: all done; exiting")
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/selector_pickler_over_tcp.py
+++ b/tests/pyre.pkg/ipc/selector_pickler_over_tcp.py
@@ -27,20 +27,20 @@ def test():
     # build the marshaler
     m = pyre.ipc.newPickler()
     # and the communication channels
-    server, client = pyre.ipc.pipe()
+    parent, child = pyre.ipc.pipe()
 
     # fork
     pid = os.fork()
     # in the server process
     if pid > 0:
         # invoke the server behavior
-        return onServer(clientPid=pid, marshaler=m, pipe=client)
+        return onServer(clientPid=pid, marshaler=m, pipe=parent)
 
     # in the client process
     # get my pid
     clientPid = os.getpid()
     # invoke the behavior
-    return onClient(clientPid=clientPid, marshaler=m, pipe=server)
+    return onClient(clientPid=clientPid, marshaler=m, pipe=child)
 
 
 def onServer(clientPid, marshaler, pipe):

--- a/tests/pyre.pkg/ipc/selector_pickler_over_tcp.py
+++ b/tests/pyre.pkg/ipc/selector_pickler_over_tcp.py
@@ -27,7 +27,7 @@ def test():
     # build the marshaler
     m = pyre.ipc.newPickler()
     # and the communication channels
-    parent, child = pyre.ipc.pipe()
+    parent, child = pyre.ipc.newPipe().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/selector_rearm_during_dispatch.py
+++ b/tests/pyre.pkg/ipc/selector_rearm_during_dispatch.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that interest registered on a channel while its own pile is being dispatched is
+neither invoked prematurely nor lost
+
+The successor's wakeup is delivered only after the current dispatch pass, so a selector that
+invokes it early finds an empty channel, and one that drops it never delivers the record
+"""
+
+# externals
+import select
+
+# access the package
+import pyre.ipc
+
+# the unit of time
+from pyre.units.SI import second
+
+
+def test():
+    # build a selector
+    s = pyre.ipc.newSelector()
+    # and a pair of channels
+    parent, child = pyre.ipc.newSocket().open()
+    # the record of what fired, in order
+    log = []
+
+    # the handler that re-arms the same channel while being dispatched
+    def first(channel, **kwds):
+        """
+        Consume the wakeup and register a successor on the same channel and direction
+        """
+        # drain the byte that woke us
+        channel.read(minlen=1, maxlen=1)
+        # make a record
+        log.append("first")
+        # register the successor on the same channel, same direction
+        s.whenReadReady(channel=channel, call=successor)
+        # deliver its wakeup only after this dispatch pass completes
+        s.alarm(interval=0.05 * second, call=wake)
+        # this handler is done
+        return False
+
+    # the successor
+    def successor(channel, **kwds):
+        """
+        Fire on a later dispatch pass, once the wakeup has been delivered
+        """
+        # a premature invocation finds nothing to read
+        ready, _, _ = select.select([channel], [], [], 0)
+        # record it as such
+        if not ready:
+            # so the final check can tell the story
+            log.append("premature")
+            # and bail without blocking
+            return False
+        # otherwise, drain the byte
+        channel.read(minlen=1, maxlen=1)
+        # make a record
+        log.append("second")
+        # and wind down
+        s.stop()
+        # all done
+        return False
+
+    # the deferred wakeup
+    def wake(timestamp):
+        """
+        Make the channel readable, one dispatch pass after the successor was registered
+        """
+        # send the byte
+        child.write(bytes=b"2")
+        # don't reschedule
+        return None
+
+    # the safety net: a lost registration must not hang the test
+    def expire(timestamp):
+        """
+        Give up
+        """
+        # wind down
+        s.stop()
+        # and don't reschedule
+        return None
+
+    # arm the first handler
+    s.whenReadReady(channel=parent, call=first)
+    # wake it
+    child.write(bytes=b"1")
+    # set the safety net
+    s.alarm(interval=1 * second, call=expire)
+    # spin
+    s.watch()
+
+    # the successor must have fired exactly once, on its own pass
+    assert log == ["first", "second"], f"broken dispatch: {log}"
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/socketpair.py
+++ b/tests/pyre.pkg/ipc/socketpair.py
@@ -16,7 +16,12 @@ def test():
     import pyre.ipc
 
     # make a pair of connected channels
-    parent, child = pyre.ipc.socketpair()
+    ends = pyre.ipc.socketpair()
+    # the pair unpacks in a fixed order
+    parent, child = ends
+    # that matches its named endpoints
+    assert ends.parent is parent
+    assert ends.child is child
     # both ends are live
     assert parent.fileno() >= 0
     assert child.fileno() >= 0
@@ -25,7 +30,7 @@ def test():
     assert parent.outbound is parent
 
     # and hand them back
-    return parent, child
+    return ends
 
 
 # main

--- a/tests/pyre.pkg/ipc/socketpair.py
+++ b/tests/pyre.pkg/ipc/socketpair.py
@@ -7,7 +7,7 @@
 
 
 """
-Sanity check: verify that the socketpair factory is accessible
+Sanity check: verify that the socket transport builds channel pairs
 """
 
 
@@ -16,7 +16,7 @@ def test():
     import pyre.ipc
 
     # make a pair of connected channels
-    ends = pyre.ipc.socketpair()
+    ends = pyre.ipc.newSocket().open()
     # the pair unpacks in a fixed order
     parent, child = ends
     # that matches its named endpoints

--- a/tests/pyre.pkg/ipc/socketpair.py
+++ b/tests/pyre.pkg/ipc/socketpair.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Sanity check: verify that the socketpair factory is accessible
+"""
+
+
+def test():
+    # get the package
+    import pyre.ipc
+
+    # make a pair of connected channels
+    parent, child = pyre.ipc.socketpair()
+    # both ends are live
+    assert parent.fileno() >= 0
+    assert child.fileno() >= 0
+    # each end serves as both the inbound and the outbound endpoint
+    assert parent.inbound is parent
+    assert parent.outbound is parent
+
+    # and hand them back
+    return parent, child
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/socketpair_bulk.py
+++ b/tests/pyre.pkg/ipc/socketpair_bulk.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Push a payload much larger than the socket buffers through a socket pair
+
+This exercises the reassembly loop in the channel {read}: the payload arrives in many packets
+and the marshaler must collect them all before unpickling
+"""
+
+# a deterministic payload of one megabyte
+payload = bytes(range(256)) * (1024 * 4)
+
+
+def test():
+    # externals
+    import os
+
+    # access the package
+    import pyre.ipc
+
+    # make a pickler
+    m = pyre.ipc.newPickler()
+    # and a pair of connected channels
+    parent, child = pyre.ipc.socketpair()
+
+    # fork
+    pid = os.fork()
+    # in the parent process
+    if pid > 0:
+        # invoke the parent behavior
+        return onParent(child_pid=pid, marshaler=m, channel=parent)
+    # in the child
+    return onChild(marshaler=m, channel=child)
+
+
+def onParent(child_pid, marshaler, channel):
+    """Send the bulk payload and verify the echo"""
+    # externals
+    import os
+
+    # send the payload
+    marshaler.send(payload, channel)
+    # get the echo
+    echo = marshaler.recv(channel)
+    # verify it survived the round trip intact
+    assert echo == payload
+    # harvest the child and verify it exited cleanly
+    _, status = os.waitpid(child_pid, 0)
+    assert status == 0
+    # all done
+    return
+
+
+def onChild(marshaler, channel):
+    """Echo whatever arrives back to the sender"""
+    # get the payload
+    incoming = marshaler.recv(channel)
+    # and bounce it back
+    marshaler.send(incoming, channel)
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/socketpair_bulk.py
+++ b/tests/pyre.pkg/ipc/socketpair_bulk.py
@@ -27,7 +27,7 @@ def test():
     # make a pickler
     m = pyre.ipc.newPickler()
     # and a pair of connected channels
-    parent, child = pyre.ipc.socketpair()
+    parent, child = pyre.ipc.newSocket().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/socketpair_descriptors.py
+++ b/tests/pyre.pkg/ipc/socketpair_descriptors.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Grant a child process access to an open file by shipping its descriptor over a socket pair
+
+This is the capability that distinguishes socket pairs from pipes: the descriptor crosses the
+process boundary through {SCM_RIGHTS}, not through fork inheritance, so it works for files
+opened long after the child was spawned
+"""
+
+# what the child writes into the borrowed file
+marker = b"delivered by descriptor passing"
+
+
+def test():
+    # externals
+    import os
+
+    # access the package
+    import pyre.ipc
+
+    # make a pair of connected channels
+    parent, child = pyre.ipc.socketpair()
+
+    # fork
+    pid = os.fork()
+    # in the parent process
+    if pid > 0:
+        # invoke the parent behavior
+        return onParent(child_pid=pid, channel=parent)
+    # in the child
+    return onChild(channel=child)
+
+
+def onParent(child_pid, channel):
+    """Open a scratch file after the fork and lend its descriptor to the child"""
+    # externals
+    import os
+    import tempfile
+
+    # make a scratch file; the child cannot have inherited it since it does not exist yet
+    document = tempfile.TemporaryFile()
+    # lend its descriptor to the child
+    channel.sendDescriptors(descriptors=[document.fileno()])
+    # wait for the child to finish writing and verify it exited cleanly
+    _, status = os.waitpid(child_pid, 0)
+    assert status == 0
+    # rewind the file
+    document.seek(0)
+    # and verify the child's writes landed in it
+    assert document.read() == marker
+    # all done
+    return
+
+
+def onChild(channel):
+    """Receive the descriptor and write through it"""
+    # externals
+    import os
+
+    # receive the descriptor and the payload that carried it
+    payload, descriptors = channel.recvDescriptors(limit=1)
+    # the default payload is a single null byte
+    assert payload == b"\x00"
+    # exactly one descriptor made the trip
+    assert len(descriptors) == 1
+    # write the marker through the borrowed descriptor
+    os.write(descriptors[0], marker)
+    # and return my copy to the kernel; the parent still holds its own
+    os.close(descriptors[0])
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/socketpair_descriptors.py
+++ b/tests/pyre.pkg/ipc/socketpair_descriptors.py
@@ -26,7 +26,7 @@ def test():
     import pyre.ipc
 
     # make a pair of connected channels
-    parent, child = pyre.ipc.socketpair()
+    parent, child = pyre.ipc.newSocket().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/ipc/socketpair_descriptors_socket.py
+++ b/tests/pyre.pkg/ipc/socketpair_descriptors_socket.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Delegate a client connection to a worker process
+
+The parent holds a connection to a client and a channel to a worker; it ships the connection's
+descriptor to the worker, which then responds to the client directly, without the parent ever
+touching the payload. This is the pattern that lets a server offload response generation to
+worker processes
+"""
+
+# the response the worker sends to the client
+response = b"served directly by the worker"
+
+
+def test():
+    # externals
+    import os
+
+    # access the package
+    import pyre.ipc
+
+    # the command channel between the server and the worker
+    parent, child = pyre.ipc.socketpair()
+    # and a second pair that stands in for a client connection to the server
+    client, connection = pyre.ipc.socketpair()
+
+    # fork
+    pid = os.fork()
+    # in the parent process
+    if pid > 0:
+        # invoke the server behavior
+        return onServer(worker_pid=pid, channel=parent, client=client, connection=connection)
+    # in the child
+    return onWorker(channel=child, client=client, connection=connection)
+
+
+def onServer(worker_pid, channel, client, connection):
+    """Hand the client connection to the worker and read the response as the client"""
+    # externals
+    import os
+
+    # ship the connection's descriptor to the worker
+    channel.sendDescriptors(descriptors=[connection.fileno()])
+    # and retire my copy; the worker owns the conversation now
+    connection.close()
+    # play the client: read the response, which comes from the worker, not from me
+    incoming = client.read(minlen=len(response))
+    # check it
+    assert incoming == response
+    # harvest the worker and verify it exited cleanly
+    _, status = os.waitpid(worker_pid, 0)
+    assert status == 0
+    # all done
+    return
+
+
+def onWorker(channel, client, connection):
+    """Receive the client connection and respond to it directly"""
+    # access the package
+    import pyre.ipc
+
+    # the fork duplicated the parent's endpoints in me; retire the copies so descriptor
+    # ownership stays with the processes that speak through them
+    client.close()
+    connection.close()
+
+    # receive the connection's descriptor
+    _, descriptors = channel.recvDescriptors(limit=1)
+    # exactly one made the trip
+    assert len(descriptors) == 1
+    # wrap it in a channel
+    delegated = pyre.ipc.socketpair(descriptor=descriptors[0])
+    # respond to the client directly
+    delegated.write(bytes=response)
+    # and close the conversation
+    delegated.close()
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/socketpair_descriptors_socket.py
+++ b/tests/pyre.pkg/ipc/socketpair_descriptors_socket.py
@@ -27,9 +27,9 @@ def test():
     import pyre.ipc
 
     # the command channel between the server and the worker
-    parent, child = pyre.ipc.socketpair()
+    parent, child = pyre.ipc.newSocket().open()
     # and a second pair that stands in for a client connection to the server
-    client, connection = pyre.ipc.socketpair()
+    client, connection = pyre.ipc.newSocket().open()
 
     # fork
     pid = os.fork()
@@ -76,7 +76,7 @@ def onWorker(channel, client, connection):
     # exactly one made the trip
     assert len(descriptors) == 1
     # wrap it in a channel
-    delegated = pyre.ipc.socketpair(descriptor=descriptors[0])
+    delegated = pyre.ipc.newSocket().wrap(descriptor=descriptors[0])
     # respond to the client directly
     delegated.write(bytes=response)
     # and close the conversation

--- a/tests/pyre.pkg/ipc/socketpair_inheritance.py
+++ b/tests/pyre.pkg/ipc/socketpair_inheritance.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that the two ends of a socket pair honor the {Pipe} inheritance contract
+"""
+
+
+def test():
+    # get the package
+    import pyre.ipc
+
+    # make a pair of connected channels
+    parent, child = pyre.ipc.socketpair()
+    # the parent end must not survive an {exec}
+    assert parent.get_inheritable() is False
+    # while the child end must, so it can be handed to a freshly spawned process
+    assert child.get_inheritable() is True
+
+    # all done
+    return parent, child
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/socketpair_inheritance.py
+++ b/tests/pyre.pkg/ipc/socketpair_inheritance.py
@@ -16,7 +16,7 @@ def test():
     import pyre.ipc
 
     # make a pair of connected channels
-    parent, child = pyre.ipc.socketpair()
+    parent, child = pyre.ipc.newSocket().open()
     # the parent end must not survive an {exec}
     assert parent.get_inheritable() is False
     # while the child end must, so it can be handed to a freshly spawned process

--- a/tests/pyre.pkg/ipc/transport.py
+++ b/tests/pyre.pkg/ipc/transport.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Sanity check: verify that the transport protocol resolves its implementations
+"""
+
+
+def test():
+    # get the package
+    import pyre.ipc
+
+    # the default transport is the pipe flavor
+    assert pyre.ipc.transport.pyre_default() is pyre.ipc.pipe()
+    # the foundries resolve to the expected components
+    assert pyre.ipc.pipe().pyre_family() == "pyre.ipc.transports.pipe"
+    assert pyre.ipc.socket().pyre_family() == "pyre.ipc.transports.socket"
+    # user configuration specs resolve through the protocol
+    assert pyre.ipc.transport.pyre_resolveSpecification(spec="pipe") is pyre.ipc.pipe()
+    assert pyre.ipc.transport.pyre_resolveSpecification(spec="socket") is pyre.ipc.socket()
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/transport_pipe.py
+++ b/tests/pyre.pkg/ipc/transport_pipe.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the pipe transport: build a pair, exchange a message, wrap raw descriptors
+"""
+
+
+def test():
+    # externals
+    import os
+
+    # get the package
+    import pyre.ipc
+
+    # instantiate the transport
+    transport = pyre.ipc.newPipe()
+    # build a pair of connected channels
+    parent, child = transport.open()
+    # push a message through, parent to child
+    parent.write(bytes=b"ping")
+    assert child.read(minlen=4) == b"ping"
+    # and back
+    child.write(bytes=b"pong")
+    assert parent.read(minlen=4) == b"pong"
+
+    # make a raw pipe
+    infd, outfd = os.pipe()
+    # dress its descriptors as a channel that talks to itself
+    loop = transport.wrap(infd=infd, outfd=outfd)
+    # push a message through it
+    loop.write(bytes=b"loop")
+    assert loop.read(minlen=4) == b"loop"
+
+    # all done
+    return transport
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/ipc/transport_socket.py
+++ b/tests/pyre.pkg/ipc/transport_socket.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the socket transport: build a pair, exchange a message, wrap a received descriptor
+"""
+
+
+def test():
+    # get the package
+    import pyre.ipc
+
+    # instantiate the transport
+    transport = pyre.ipc.newSocket()
+    # build a pair of connected channels
+    parent, child = transport.open()
+    # push a message through, parent to child
+    parent.write(bytes=b"ping")
+    assert child.read(minlen=4) == b"ping"
+    # and back
+    child.write(bytes=b"pong")
+    assert parent.read(minlen=4) == b"pong"
+
+    # build a second pair, standing in for a conversation whose descriptor changes hands
+    other = transport.open()
+    # ship one end's descriptor over the first pair
+    parent.sendDescriptors(descriptors=[other.child.fileno()])
+    # receive it on the far side
+    _, descriptors = child.recvDescriptors(limit=1)
+    # dress it as a channel
+    borrowed = transport.wrap(descriptor=descriptors[0])
+    # and verify it is connected to the other pair's parent end
+    borrowed.write(bytes=b"knock")
+    assert other.parent.read(minlen=5) == b"knock"
+
+    # all done
+    return transport
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/node_signals.py
+++ b/tests/pyre.pkg/nexus/node_signals.py
@@ -33,13 +33,13 @@ def test():
         infd = int(ns["infd"])
         outfd = int(ns["outfd"])
         # convert them into a channel
-        channel = pyre.ipc.pipe(descriptors=(infd, outfd))
+        channel = pyre.ipc.newPipe().wrap(infd=infd, outfd=outfd)
         # invoke the child behavior
         return onChild(channel=channel)
 
     # otherwise, set the parent/child process context
     # build the communication channels
-    parent, child = pyre.ipc.pipe()
+    parent, child = pyre.ipc.newPipe().open()
 
     # fork
     pid = os.fork()

--- a/tests/pyre.pkg/nexus/pool_crews.py
+++ b/tests/pyre.pkg/nexus/pool_crews.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a pool can report its current crew members
+"""
+
+# support
+import pyre
+
+
+# my task
+class Task(pyre.nexus.task):
+    """
+    A trivial task with a recognizable result
+    """
+
+    # interface
+    def execute(self):
+        """
+        The body of the task
+        """
+        # hand back a marker
+        return "done"
+
+
+def test():
+    # get the pool component from its foundry and build a team
+    team = pyre.nexus.pool()(name="test.pool.crews")
+    # a fresh team has no members
+    assert list(team.crews()) == []
+
+    # make a small workplan
+    workplan = {Task() for _ in range(4)}
+    # set it up for execution; this recruits crew members
+    team.assemble(workplan=workplan)
+    # collect the roster
+    members = set(team.crews())
+    # every recruit is accounted for
+    assert members == team.registered | team.active
+    # and somebody was actually recruited
+    assert members
+
+    # enter the event loop; the team retires when the workplan drains
+    team.run()
+
+    # the workplan was fully executed
+    assert len(team.workplan) == 0
+    # and everybody has retired, so the roster is empty again
+    assert list(team.crews()) == []
+
+    # all done
+    return team
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/pool_over_sockets.py
+++ b/tests/pyre.pkg/nexus/pool_over_sockets.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a pool can be configured to manage its crew over the socket transport
+"""
+
+# support
+import pyre
+
+
+# my task
+class Task(pyre.nexus.task):
+    """
+    A trivial task with a recognizable result
+    """
+
+    # interface
+    def execute(self):
+        """
+        The body of the task
+        """
+        # hand back a marker
+        return "done"
+
+
+def test():
+    # get the pool component from its foundry and build a team
+    team = pyre.nexus.pool()(name="test.pool.sockets")
+    # ask its recruiter to manage the crew over the socket transport
+    team.recruiter.channels = "socket"
+    # verify the selection stuck
+    assert team.recruiter.channels.pyre_family() == "pyre.ipc.transports.socket"
+
+    # make a small workplan
+    workplan = {Task() for _ in range(4)}
+    # set it up for execution
+    team.assemble(workplan=workplan)
+    # and enter the event loop; the team retires when the workplan drains
+    team.run()
+
+    # the workplan was fully executed
+    assert len(team.workplan) == 0
+    # no crew members are still on the clock
+    assert len(team.active) == 0
+
+    # all done
+    return team
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff.py
+++ b/tests/pyre.pkg/nexus/staff.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a staff executes assigned tasks, delivers their outcomes to callbacks, and keeps
+its crew members between assignments
+"""
+
+# support
+import pyre
+
+# the unit of time
+from pyre.units.SI import second
+
+
+# a task with a recognizable result
+class Echo(pyre.nexus.task):
+    """
+    A task that computes something trivial
+    """
+
+    # metamethods
+    def __init__(self, tag, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save my tag
+        self.tag = tag
+        # all done
+        return
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # hand back a marker
+        return f"echo-{self.tag}"
+
+
+def test():
+    # build a staff of one, so member persistence is observable
+    staff = pyre.nexus.staff()(name="test.staff.basic")
+    staff.size = 1
+    # the outcome drop box
+    outcomes = []
+
+    # the delivery callback
+    def deliver(result, error):
+        """
+        Record the outcome and stop the event loop
+        """
+        # file the report
+        outcomes.append((result, error))
+        # and wind down
+        staff.dispatcher.stop()
+        # all done
+        return
+
+    # the passive delivery callback
+    def record(result, error):
+        """
+        Record the outcome; leave the loop running so the member gets parked
+        """
+        # file the report
+        outcomes.append((result, error))
+        # all done
+        return
+
+    # the alarm that winds down the event loop
+    def expire(timestamp):
+        """
+        Stop the event loop
+        """
+        # ask the dispatcher to stop
+        staff.dispatcher.stop()
+        # and don't reschedule
+        return None
+
+    # assign a first task; let the loop run past the delivery so the member gets parked
+    staff.assign(task=Echo(tag=1), callback=record)
+    staff.dispatcher.alarm(interval=1 * second, call=expire)
+    staff.dispatcher.watch()
+    # the outcome arrived
+    assert outcomes[0] == ("echo-1", None)
+    # and the member survived its assignment, parked on the bench
+    assert len(staff.idle) == 1
+    # remember who it is
+    (veteran,) = staff.idle
+
+    # assign a second task
+    staff.assign(task=Echo(tag=2), callback=deliver)
+    staff.dispatcher.watch()
+    # the outcome arrived
+    assert outcomes[1] == ("echo-2", None)
+    # served by the same member, not a fresh recruit
+    assert set(staff.crews()) == {veteran}
+
+    # send everybody home
+    staff.disband()
+    # which empties the rosters
+    assert list(staff.crews()) == []
+
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_bench.py
+++ b/tests/pyre.pkg/nexus/staff_bench.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that the death of a parked crew member is noticed: the watch buries it and a
+replacement is recruited
+"""
+
+# externals
+import os
+import signal
+
+# support
+import pyre
+
+# the unit of time
+from pyre.units.SI import second
+
+
+# a well behaved task
+class Echo(pyre.nexus.task):
+    """
+    A task with a recognizable result
+    """
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # hand back a marker
+        return "echo"
+
+
+def test():
+    # build a staff of one
+    staff = pyre.nexus.staff()(name="test.staff.bench")
+    staff.size = 1
+    # the outcome drop box
+    outcomes = []
+
+    # the passive delivery callback
+    def record(result, error):
+        """
+        Record the outcome; leave the loop running so the member gets parked
+        """
+        # file the report
+        outcomes.append((result, error))
+        # all done
+        return
+
+    # the alarm that winds down the event loop
+    def expire(timestamp):
+        """
+        Stop the event loop
+        """
+        # ask the dispatcher to stop
+        staff.dispatcher.stop()
+        # and don't reschedule
+        return None
+
+    # assign a task
+    staff.assign(task=Echo(), callback=record)
+    # let the loop run long enough for the member to finish and get parked
+    staff.dispatcher.alarm(interval=1 * second, call=expire)
+    staff.dispatcher.watch()
+    # the task was delivered and the member is parked
+    assert outcomes and outcomes[0] == ("echo", None)
+    assert len(staff.idle) == 1
+
+    # get the parked member
+    (crew,) = staff.idle
+    # and kill it behind the staff's back
+    os.kill(crew.pid, signal.SIGKILL)
+
+    # let the loop notice
+    staff.dispatcher.alarm(interval=1 * second, call=expire)
+    staff.dispatcher.watch()
+
+    # the casualty was buried
+    assert crew not in set(staff.crews())
+    # and a replacement took its place, so the staff is back at full strength
+    assert len(list(staff.crews())) == 1
+
+    # send everybody home
+    staff.disband()
+
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_casualty.py
+++ b/tests/pyre.pkg/nexus/staff_casualty.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a staff survives the death of a crew member mid-task: the callback gets the bad
+news, and a replacement serves the next assignment
+"""
+
+# externals
+import os
+
+# support
+import pyre
+
+
+# a task that kills its worker
+class Boom(pyre.nexus.task):
+    """
+    A task whose execution takes down the crew member abruptly, report unsent
+    """
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # die without a trace
+        os._exit(1)
+
+
+# a well behaved task
+class Echo(pyre.nexus.task):
+    """
+    A task with a recognizable result
+    """
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # hand back a marker
+        return "echo"
+
+
+def test():
+    # build a staff of one, so the casualty is the member that must be replaced
+    staff = pyre.nexus.staff()(name="test.staff.casualty")
+    staff.size = 1
+    # the outcome drop box
+    outcomes = []
+
+    # the delivery callback
+    def deliver(result, error):
+        """
+        Record the outcome and stop the event loop
+        """
+        # file the report
+        outcomes.append((result, error))
+        # and wind down
+        staff.dispatcher.stop()
+        # all done
+        return
+
+    # assign the lethal task and spin until the outcome is delivered
+    staff.assign(task=Boom(), callback=deliver)
+    staff.dispatcher.watch()
+    # the task produced nothing
+    result, error = outcomes[0]
+    assert result is None
+    # and the failure was reported as a casualty, marking the task as a suspect
+    assert isinstance(error, pyre.nexus.exceptions.Casualty)
+
+    # assign a normal task; the replacement crew member should handle it
+    staff.assign(task=Echo(), callback=deliver)
+    staff.dispatcher.watch()
+    # this one succeeded
+    assert outcomes[1] == ("echo", None)
+
+    # send everybody home
+    staff.disband()
+
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_dedup.py
+++ b/tests/pyre.pkg/nexus/staff_dedup.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that tasks that compare equal are executed once, with every requester receiving the
+shared outcome
+"""
+
+# support
+import pyre
+
+
+# a task whose identity is its tag
+class Fetch(pyre.nexus.task):
+    """
+    A task that stamps its result with an execution-unique marker
+    """
+
+    # metamethods
+    def __init__(self, tag, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save my tag
+        self.tag = tag
+        # all done
+        return
+
+    def __hash__(self):
+        # my identity is my tag
+        return hash(self.tag)
+
+    def __eq__(self, other):
+        # two fetches of the same tag are the same work
+        return type(other) is type(self) and other.tag == self.tag
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # a marker minted fresh per execution
+        import uuid
+
+        # so identical results prove a shared execution
+        return (self.tag, str(uuid.uuid1()))
+
+
+def test():
+    # build a staff of one
+    staff = pyre.nexus.staff()(name="test.staff.dedup")
+    staff.size = 1
+    # the outcome drop box
+    outcomes = []
+
+    # the delivery callback factory
+    def deliver(label):
+        """
+        Build a callback that records under {label}
+        """
+
+        # the callback
+        def callback(result, error):
+            """
+            Record the outcome, and stop once both subscribers are served
+            """
+            # every task succeeds
+            assert error is None
+            # record
+            outcomes.append((label, result))
+            # once both subscribers hear back
+            if len(outcomes) == 2:
+                # wind down
+                staff.dispatcher.stop()
+            # all done
+            return
+
+        # hand it off
+        return callback
+
+    # two equal requests from two different subscribers
+    staff.assign(task=Fetch(tag="tile"), callback=deliver(label="first"))
+    staff.assign(task=Fetch(tag="tile"), callback=deliver(label="second"))
+    # the second joined the first: only one task is queued
+    assert len(staff.workplan) == 1
+    # with both subscribers on its ledger
+    assert len(staff.pending) == 1
+
+    # spin until both are served
+    staff.dispatcher.watch()
+
+    # both subscribers heard back
+    assert {label for label, _ in outcomes} == {"first", "second"}
+    # with the identical result, proving a single execution
+    first, second = (result for _, result in outcomes)
+    assert first == second
+
+    # send everybody home
+    staff.disband()
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_misfire.py
+++ b/tests/pyre.pkg/nexus/staff_misfire.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a task assigned to a crew member that died while parked is re-queued and
+completed by the replacement
+"""
+
+# externals
+import os
+import signal
+
+# support
+import pyre
+
+# the unit of time
+from pyre.units.SI import second
+
+
+# a well behaved task
+class Echo(pyre.nexus.task):
+    """
+    A task with a recognizable result
+    """
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # hand back a marker
+        return "echo"
+
+
+def test():
+    # build a staff of one
+    staff = pyre.nexus.staff()(name="test.staff.misfire")
+    staff.size = 1
+    # the outcome drop box
+    outcomes = []
+
+    # the passive delivery callback
+    def record(result, error):
+        """
+        Record the outcome; leave the loop running so the member gets parked
+        """
+        # file the report
+        outcomes.append((result, error))
+        # all done
+        return
+
+    # the delivery callback that also stops the loop
+    def deliver(result, error):
+        """
+        Record the outcome and stop the event loop
+        """
+        # file the report
+        outcomes.append((result, error))
+        # and wind down
+        staff.dispatcher.stop()
+        # all done
+        return
+
+    # the alarm that winds down the event loop
+    def expire(timestamp):
+        """
+        Stop the event loop
+        """
+        # ask the dispatcher to stop
+        staff.dispatcher.stop()
+        # and don't reschedule
+        return None
+
+    # phase 1: get a crew member parked
+    staff.assign(task=Echo(), callback=record)
+    # let the loop run long enough for the member to finish and get parked
+    staff.dispatcher.alarm(interval=1 * second, call=expire)
+    staff.dispatcher.watch()
+    # the task was delivered and the member is parked
+    assert outcomes[0] == ("echo", None)
+    assert len(staff.idle) == 1
+
+    # phase 2: kill the parked member and, before the loop can notice, hand it more work
+    (crew,) = staff.idle
+    # kill it behind the staff's back
+    os.kill(crew.pid, signal.SIGKILL)
+    # the signal is asynchronous; wait until the member is fully dead, so its end of the
+    # channel is certainly closed and the submission is guaranteed to misfire; this also
+    # reaps the corpse, which the eventual burial tolerates
+    while True:
+        # check on it
+        corpse, _ = os.waitpid(crew.pid, os.WNOHANG)
+        # once it is gone
+        if corpse == crew.pid:
+            # move on
+            break
+    # assign a task; this wakes the corpse and schedules it, so the submission will misfire
+    staff.assign(task=Echo(), callback=deliver)
+    # spin; the submission fails, the task is re-queued, and the replacement delivers it
+    staff.dispatcher.watch()
+
+    # the outcome arrived despite the casualty
+    assert outcomes[1] == ("echo", None)
+    # and the casualty is off the rosters
+    assert crew not in set(staff.crews())
+
+    # send everybody home
+    staff.disband()
+
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_priority.py
+++ b/tests/pyre.pkg/nexus/staff_priority.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a staff serves its workplan newest first: under load, the most recent requests
+are the ones their requesters are still looking at
+"""
+
+# support
+import pyre
+
+
+# a task with a recognizable result
+class Echo(pyre.nexus.task):
+    """
+    A task that reports its tag
+    """
+
+    # metamethods
+    def __init__(self, tag, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save my tag
+        self.tag = tag
+        # all done
+        return
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # hand back my tag
+        return self.tag
+
+
+def test():
+    # build a staff of one, so the queue drains strictly sequentially
+    staff = pyre.nexus.staff()(name="test.staff.priority")
+    staff.size = 1
+    # the record of deliveries, in order
+    served = []
+
+    # the delivery callback
+    def deliver(result, error):
+        """
+        Record the outcome, and stop once everybody has been served
+        """
+        # every task succeeds
+        assert error is None
+        # record the tag
+        served.append(result)
+        # if all four are in
+        if len(served) == 4:
+            # wind down
+            staff.dispatcher.stop()
+        # all done
+        return
+
+    # queue four tasks before the event loop runs, so they pile up
+    for tag in (1, 2, 3, 4):
+        # each with the shared callback
+        staff.assign(task=Echo(tag=tag), callback=deliver)
+    # spin until all four are delivered
+    staff.dispatcher.watch()
+
+    # the queue drained newest first
+    assert served == [4, 3, 2, 1], f"out of order: {served}"
+
+    # send everybody home
+    staff.disband()
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_resurrection.py
+++ b/tests/pyre.pkg/nexus/staff_resurrection.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a disbanded staff stays disbanded: recoveries do not resurrect it, and new work
+is refused immediately
+"""
+
+# support
+import pyre
+
+
+# a well behaved task
+class Echo(pyre.nexus.task):
+    """
+    A task with a recognizable result
+    """
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # hand back a marker
+        return "echo"
+
+
+def test():
+    # build a staff of one
+    staff = pyre.nexus.staff()(name="test.staff.resurrection")
+    staff.size = 1
+    # the outcome drop box
+    outcomes = []
+
+    # the delivery callback
+    def deliver(result, error):
+        """
+        Record the outcome and stop the event loop
+        """
+        # file the report
+        outcomes.append((result, error))
+        # and wind down
+        staff.dispatcher.stop()
+        # all done
+        return
+
+    # assign a task and spin until it is delivered
+    staff.assign(task=Echo(), callback=deliver)
+    staff.dispatcher.watch()
+    # the task succeeded
+    assert outcomes[0] == ("echo", None)
+
+    # send everybody home
+    staff.disband()
+    # nobody is left
+    assert list(staff.crews()) == []
+
+    # a recovery arriving after disband must not resurrect the staff
+    staff.recover()
+    # still nobody
+    assert list(staff.crews()) == []
+
+    # and new work is refused on the spot
+    staff.assign(task=Echo(), callback=deliver)
+    # with the bad news delivered synchronously
+    result, error = outcomes[1]
+    assert result is None
+    assert error is not None
+    # and no crews were recruited for it
+    assert list(staff.crews()) == []
+
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_revoke.py
+++ b/tests/pyre.pkg/nexus/staff_revoke.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that revocation withdraws a subscriber: the last withdrawal drops a queued task, and
+the outcome of work already in flight is quietly discarded
+"""
+
+# support
+import pyre
+
+
+# a task with a recognizable result
+class Echo(pyre.nexus.task):
+    """
+    A task that reports its tag
+    """
+
+    # metamethods
+    def __init__(self, tag, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save my tag
+        self.tag = tag
+        # all done
+        return
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # hand back my tag
+        return self.tag
+
+
+def test():
+    # build a staff of one
+    staff = pyre.nexus.staff()(name="test.staff.revoke")
+    staff.size = 1
+    # the record of deliveries
+    served = []
+
+    # the delivery callback factory
+    def deliver(expected):
+        """
+        Build a callback that records a delivery, stopping when {expected} are in
+        """
+
+        # the callback
+        def callback(result, error):
+            """
+            Record the outcome
+            """
+            # every surviving task succeeds
+            assert error is None
+            # record
+            served.append(result)
+            # once the survivors are all in
+            if len(served) == expected:
+                # wind down
+                staff.dispatcher.stop()
+            # all done
+            return
+
+        # hand it off
+        return callback
+
+    # a callback that must never fire
+    def betrayed(result, error):
+        """
+        The callback of a revoked request
+        """
+        # getting here is the failure
+        assert False, "a revoked callback fired"
+
+    # queue three tasks; the middle one will be revoked before the loop runs
+    a = Echo(tag="a")
+    b = Echo(tag="b")
+    c = Echo(tag="c")
+    keeper = deliver(expected=2)
+    staff.assign(task=a, callback=keeper)
+    staff.assign(task=b, callback=betrayed)
+    staff.assign(task=c, callback=keeper)
+    # withdraw the middle request; it was queued, so the task is dropped outright
+    staff.revoke(task=b, callback=betrayed)
+    # the workplan shrank
+    assert len(staff.workplan) == 2
+    # and so did the ledger
+    assert len(staff.pending) == 2
+
+    # revoking something never assigned is a quiet no-op
+    staff.revoke(task=Echo(tag="ghost"), callback=betrayed)
+
+    # spin until the survivors are served
+    staff.dispatcher.watch()
+    # newest first, without the revoked task
+    assert served == ["c", "a"], f"unexpected service: {served}"
+
+    # now the in-flight story: withdraw from a task that a crew member already picked up
+    d = Echo(tag="d")
+    staff.assign(task=d, callback=betrayed)
+    # simulate the pickup: the task leaves the queue, its ledger remains
+    picked, _ = staff.workplan.popitem()
+    assert picked is d
+    # the requester goes away
+    staff.revoke(task=d, callback=betrayed)
+    # the ledger survives, empty, awaiting the in-flight outcome
+    assert staff.pending[d] == []
+    # the outcome arrives and is quietly discarded: no firewall, no callback
+    staff.collect(task=d, result="d")
+    # and the ledger is settled
+    assert d not in staff.pending
+
+    # send everybody home
+    staff.disband()
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_stillborn.py
+++ b/tests/pyre.pkg/nexus/staff_stillborn.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a crew member that dies or misbehaves before checking in gets buried instead of
+crashing the event loop or leaking in the registration roster
+"""
+
+# externals
+import os
+
+# support
+import pyre
+
+
+def stillborn(staff):
+    """
+    Build a team side proxy whose worker end closed without a word
+    """
+    # make a child that dies immediately, so there is a real corpse to reap
+    pid = os.fork()
+    # in the child
+    if pid == 0:
+        # die on the spot
+        os._exit(1)
+    # make the channel
+    parent, child = pyre.ipc.newSocket().open()
+    # the worker end closes without ever writing the registration
+    child.close()
+    # build the team side proxy
+    crew = pyre.nexus.crew(pid=pid, channel=parent)
+    # wire it the way the recruiter does
+    crew.dispatcher = staff.dispatcher
+    crew.marshaler = staff.marshaler
+    # and hand it off
+    return crew
+
+
+def test():
+    # build a staff of one
+    staff = pyre.nexus.staff()(name="test.staff.stillborn")
+    staff.size = 1
+
+    # scenario 1: the registration never arrives
+    crew = stillborn(staff=staff)
+    # enroll the member the way {join} does
+    staff.registered.add(crew)
+    # fire the registration handler; it finds a closed channel
+    keep = crew.activate(channel=crew.channel, team=staff)
+    # the handler winds down quietly
+    assert keep is False
+    # the member was buried and a replacement recruited on the spot
+    survivors = list(staff.crews())
+    assert crew not in survivors
+    assert len(survivors) == 1
+    # and the corpse was reaped
+    try:
+        # so a second wait
+        os.waitpid(crew.pid, 0)
+        # must not find it
+        assert False
+    # because it was already collected
+    except ChildProcessError:
+        # as expected
+        pass
+
+    # scenario 2: the registration arrives but does not vouch for a healthy member
+    pid = os.fork()
+    # in the child
+    if pid == 0:
+        # die on the spot
+        os._exit(1)
+    # make the channel
+    parent, child = pyre.ipc.newSocket().open()
+    # the worker end sends garbage instead of a clean bill of health
+    staff.marshaler.send(item="garbage", channel=child)
+    # and closes
+    child.close()
+    # build the team side proxy
+    crew = pyre.nexus.crew(pid=pid, channel=parent)
+    # wire it
+    crew.dispatcher = staff.dispatcher
+    crew.marshaler = staff.marshaler
+    # enroll it
+    staff.registered.add(crew)
+    # fire the registration handler; it finds a compromised member
+    keep = crew.activate(channel=parent, team=staff)
+    # the handler winds down quietly
+    assert keep is False
+    # and the member was buried, with the staff back at full strength
+    survivors = list(staff.crews())
+    assert crew not in survivors
+    assert len(survivors) == 1
+
+    # send everybody home
+    staff.disband()
+
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_truncated.py
+++ b/tests/pyre.pkg/nexus/staff_truncated.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that messages cut short mid-body are treated as a death, on both sides of the channel
+"""
+
+# externals
+import os
+import struct
+
+# support
+import pyre
+
+
+def test():
+    # scenario 1: the worker side {perform} finds a truncated task
+    # make a channel
+    parent, child = pyre.ipc.newSocket().open()
+    # build a worker side member; nothing gets reaped here, so my own pid will do
+    worker = pyre.nexus.crew(pid=os.getpid(), channel=child)
+    # hand-craft a message whose header promises far more than what follows
+    parent.write(bytes=struct.pack("<L", 100) + b"stub")
+    # and hang up
+    parent.close()
+    # fire the task handler; it finds the stub
+    keep = worker.perform(channel=child)
+    # and winds down quietly instead of raising
+    assert keep is False
+
+    # scenario 2: the team side {assess} finds a truncated report
+    # build a staff of one
+    staff = pyre.nexus.staff()(name="test.staff.truncated")
+    staff.size = 1
+    # make a child that dies immediately, so there is a real corpse to reap
+    pid = os.fork()
+    # in the child
+    if pid == 0:
+        # die on the spot
+        os._exit(1)
+    # make the channel
+    parent, child = pyre.ipc.newSocket().open()
+    # build the team side proxy
+    crew = pyre.nexus.crew(pid=pid, channel=parent)
+    # wire it the way the recruiter does
+    crew.dispatcher = staff.dispatcher
+    crew.marshaler = staff.marshaler
+    # the member is mid-task
+    staff.active.add(crew)
+    # with a task whose outcome somebody is waiting for
+    task = pyre.nexus.task()
+    # the outcome drop box
+    outcomes = []
+
+    # the delivery callback
+    def deliver(result, error):
+        """
+        Record the outcome
+        """
+        # file the report
+        outcomes.append((result, error))
+        # all done
+        return
+
+    # register the callback
+    staff.pending[task] = deliver
+    # the worker dies mid-report: a header, a fragment of the body, then nothing
+    child.write(bytes=struct.pack("<L", 64) + b"partial")
+    # and the channel closes
+    child.close()
+    # fire the harvesting handler; it finds the fragment
+    keep = crew.assess(channel=parent, team=staff, task=task)
+    # the handler winds down quietly
+    assert keep is False
+    # the bad news was delivered as a casualty
+    result, error = outcomes[0]
+    assert result is None
+    assert isinstance(error, pyre.nexus.exceptions.Casualty)
+    # and the member was buried, with the staff back at full strength
+    survivors = list(staff.crews())
+    assert crew not in survivors
+    assert len(survivors) == 1
+
+    # send everybody home
+    staff.disband()
+
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_truncated.py
+++ b/tests/pyre.pkg/nexus/staff_truncated.py
@@ -68,7 +68,7 @@ def test():
         return
 
     # register the callback
-    staff.pending[task] = deliver
+    staff.pending[task] = [deliver]
     # the worker dies mid-report: a header, a fragment of the body, then nothing
     child.write(bytes=struct.pack("<L", 64) + b"partial")
     # and the channel closes

--- a/tests/pyre.pkg/shells/web_service_spec.py
+++ b/tests/pyre.pkg/shells/web_service_spec.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that the web shell's service specification is configurable and resolves through the
+nexus service slot the way {launch} wires it
+"""
+
+
+def test():
+    # get access to the framework
+    import pyre
+
+    # get the web shell
+    from pyre.shells.Web import Web
+
+    # instantiate one
+    shell = Web(name="test.shells.web")
+    # out of the box, it fields requests with the stock http server
+    assert shell.service == "http"
+
+    # a hosting application can point the shell at its own flavor; this import spec stands in
+    # for one, resolving to the stock server through a different route
+    shell.service = "import:pyre.http.Server.Server"
+
+    # mirror the wiring in {launch}: build a nexus
+    nexus = pyre.nexus.node(name="test.shells.web.nexus")
+    # and register the web service using the shell's specification
+    nexus.services["web"] = shell.service
+    # the slot resolves the spec into a live component
+    web = nexus.services["web"]
+    # of the expected pedigree
+    assert web.pyre_family() == "pyre.nexus.servers.http"
+    # named within the nexus namespace, so its configuration, e.g. the address, lives at the
+    # conventional location
+    assert web.pyre_name == "test.shells.web.nexus.services.web"
+
+    # all done
+    return shell
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file


### PR DESCRIPTION
Support for pools of persistent worker processes. A team can now hold on to its workers across tasks, deliver each outcome to the callbacks that asked for it, and survive the death of its members; the ipc layer that carries the traffic gains a socket-based channel flavor, a configurable transport abstraction, exact message framing, and hardened dispatchers; the http server learns to park a connection until its document is ready. The work spans `pyre.ipc`, `pyre.http`, `pyre.nexus`, and `pyre.shells`, with test drivers for each layer, plus an incidental `pyre::grid` convenience.

## pyre.ipc

- **Socketpair channels.** A new channel flavor built over `socketpair(2)`, alongside the existing pipes. Socket channels can carry open file descriptors across process boundaries via `SCM_RIGHTS`, portably on linux and macos, which enables handing a worker a file — or a live client connection — without copying.
- **Labeled endpoints.** Channel factories return a named pair `(parent, child)`, making the inheritance contract part of the api: the parent end is non-inheritable, the child end survives `exec`.
- **Transports as components.** The choice of ipc mechanism is a configurable trait: `pipes` and `sockets` are components satisfying a new `transport` protocol, and the channel factories are foundries. Anything that recruits workers can be pointed at either mechanism from the configuration store.
- **Exact framing and end-of-stream.** The pickler reads exactly one frame per message: the header and body reads are bounded on both sides, so a fragmented header no longer trips the decoder and a small body can no longer swallow the beginning of the next message — an overread that could silently discard descriptors in flight on socket channels. A peer that hangs up now surfaces as a dedicated `EndOfStream` exception from the new `pyre.ipc.exceptions`, replacing ad hoc empty-read handling.
- **Dispatcher hardening.** Both selector flavors survive descriptor reuse, registrations made mid-dispatch, and dead channels. The piles are the single source of truth for what is being watched: the kernel-backed selector re-arms its registrations from them, dispatch works off a snapshot and merges survivors with mid-dispatch additions, and the classic selector culls corpses instead of crashing on the first bad descriptor. Dispatchers can also enumerate the channels they watch, so a forked child can shed every connection that is not its own.

## pyre.http

A `deferred` response parks its connection until the document is ready: the handler returns a placeholder, the server keeps the connection registered, and delivery happens when the placeholder is resolved. The server tracks its parked connections, so a peer that hangs up while waiting cancels the associated response through a dedicated hook instead of leaking it.

## pyre.nexus

- **Staff.** A new team flavor whose workers are persistent: instead of dismissing a member when its task is done, the staff parks it on a bench and wakes it for the next assignment. Work arrives via `assign(task, callback)`; the workplan serves newest first; tasks that compare equal join a single execution and every subscriber receives the outcome; `revoke` withdraws one subscriber and drops a queued task when the last one leaves. Casualties — including a worker that dies mid-task — are buried and replaced on the spot without losing assigned work; disbanding puts down active workers, retires resting ones gracefully, fails whatever is still pending, and is guarded against re-entry and against inherited registrations in forked children.
- **Crew hardening.** The stock crew guards its activation, its assessment of reports, and its task execution against the end of the stream, and exposes a `harvest` seam for trailers that follow a report — descriptors, for example. Outcome delivery flows through team hooks — collect, requeue, abandon, bury — so team flavors can define their own policies without replacing the crew.
- **Pool.** A pool reports its roster, and newly forked members shed the connections that belong to their siblings.

## pyre.shells

- The fork shell wraps its inherited descriptors through the transport protocol.
- The web shell's service specification is configurable: applications can substitute their own service flavor for the stock http server, from code or from the configuration store.

## pyre::grid

An `index` can now be constructed explicitly from a `shape`, reading the extents as coordinates. Among other things, this supports the centering idiom `index { -shape / 2 }`.

## Tests

Each layer comes with drivers under `tests/pyre.pkg` and `tests/pyre.lib`: channel framing, bulk reassembly, and descriptor passing; transport-parameterized recruitment; dispatcher lifecycle hazards, including descriptor reuse and re-arming during dispatch; the deferred response life cycle, cancellation included; and the staff across its full life — assignment, priority, joined executions, revocations, casualties, stillborn and truncated reports, misfires, resurrection attempts after disbanding — plus the web service specification and its slot resolution.
