### PR TITLE
Close the coverage gaps in the pyre::h5 dataset interface

### DIFF
--- a/.cmake/pyre_h5.cmake
+++ b/.cmake/pyre_h5.cmake
@@ -107,6 +107,7 @@ function(pyre_h5Module)
       extensions/h5/__init__.cc
       extensions/h5/api.cc
       extensions/h5/Attribute.cc
+      extensions/h5/Chunk.cc
       extensions/h5/DataSet.cc
       extensions/h5/DataSpace.cc
       extensions/h5/enums.cc

--- a/.cmake/pyre_tests_h5_ext.cmake
+++ b/.cmake/pyre_tests_h5_ext.cmake
@@ -1,0 +1,48 @@
+# -*- cmake -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+#
+# h5 extension: these drivers import the {libh5} bindings directly, so a failure isolates the
+# binding layer from the {pyre.h5} package shim above it
+#
+# sanity
+pyre_test_python_testcase(tests/h5.ext/sanity.py)
+# the property lists, each proving that what it was told is what it reports
+pyre_test_python_testcase(tests/h5.ext/acpl.py)
+pyre_test_python_testcase(tests/h5.ext/dcpl_fill.py)
+pyre_test_python_testcase(tests/h5.ext/fapl.py)
+pyre_test_python_testcase(tests/h5.ext/fcpl.py)
+pyre_test_python_testcase(tests/h5.ext/gcpl.py)
+pyre_test_python_testcase(tests/h5.ext/lcpl.py)
+# the out-of-core mosaic
+pyre_test_python_testcase(tests/h5.ext/mosaic.py)
+# the raw data chunk cache: that it is consulted, and that an access list can size it
+pyre_test_python_testcase(tests/h5.ext/read_chunk_cache.py)
+pyre_test_python_testcase(tests/h5.ext/dapl_chunk_cache.py)
+# the chunk table, and moving a chunk in the form it is stored in
+pyre_test_python_testcase(tests/h5.ext/chunk_table.py)
+pyre_test_python_testcase(tests/h5.ext/direct_chunk.py)
+# a tile that skips cells, and one that is transformed on its way across
+pyre_test_python_testcase(tests/h5.ext/strided_tile.py)
+pyre_test_python_testcase(tests/h5.ext/transfer_list.py)
+
+# the drivers leave their scratch products behind so they can be inspected; the harness
+# sweeps them, each after the driver that makes it
+pyre_test_python_cleanup(h5_ext_acpl.h5 tests/h5.ext/acpl.py)
+pyre_test_python_cleanup(h5_ext_dcpl_fill.h5 tests/h5.ext/dcpl_fill.py)
+pyre_test_python_cleanup(h5_ext_fapl.h5 tests/h5.ext/fapl.py)
+pyre_test_python_cleanup(h5_ext_fcpl.h5 tests/h5.ext/fcpl.py)
+pyre_test_python_cleanup(h5_ext_gcpl.h5 tests/h5.ext/gcpl.py)
+pyre_test_python_cleanup(h5_ext_lcpl.h5 tests/h5.ext/lcpl.py)
+pyre_test_python_cleanup(h5_ext_mosaic.h5 tests/h5.ext/mosaic.py)
+pyre_test_python_cleanup(read_chunk_cache.h5 tests/h5.ext/read_chunk_cache.py)
+pyre_test_python_cleanup(dapl_chunk_cache.h5 tests/h5.ext/dapl_chunk_cache.py)
+pyre_test_python_cleanup(chunk_table.h5 tests/h5.ext/chunk_table.py)
+pyre_test_python_cleanup(direct_chunk.h5 tests/h5.ext/direct_chunk.py)
+pyre_test_python_cleanup(strided_tile.h5 tests/h5.ext/strided_tile.py)
+pyre_test_python_cleanup(transfer_list.h5 tests/h5.ext/transfer_list.py)
+
+
+# end of file

--- a/.cmake/pyre_tests_h5_lib.cmake
+++ b/.cmake/pyre_tests_h5_lib.cmake
@@ -1,0 +1,35 @@
+# -*- cmake -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+#
+# h5 library: these drivers exercise the {pyre::h5} wrappers over the hdf5 c api without ever
+# loading python, so a failure isolates the c++ layer from its bindings
+#
+# the plain {pyre_test_driver} is enough here: {libpyre} links hdf5 with the plain signature,
+# so every driver inherits the headers and the library through the export interface
+#
+# sanity
+pyre_test_driver(tests/h5.lib/sanity.cc)
+# the datatype vocabulary the wrappers trade in
+pyre_test_driver(tests/h5.lib/datatypes.cc)
+# a dataspace describing its extent in the {pyre::grid} vocabulary
+pyre_test_driver(tests/h5.lib/dataspace_packing.cc)
+# a dataset's chunking, as the tiled layout a mosaic is assembled over
+pyre_test_driver(tests/h5.lib/dataset_tiling.cc)
+# reading and writing a tile that visits only every n-th cell along each axis
+pyre_test_driver(tests/h5.lib/dataset_strided.cc)
+# the out-of-core mosaic, in each direction
+pyre_test_driver(tests/h5.lib/dataset_mosaic_write.cc)
+pyre_test_driver(tests/h5.lib/dataset_mosaic_read.cc)
+
+# the drivers leave their scratch products behind so they can be inspected; the harness
+# sweeps them, each after the driver that makes it
+pyre_test_driver_cleanup(dataset_tiling.h5 tests/h5.lib/dataset_tiling.cc)
+pyre_test_driver_cleanup(dataset_strided.h5 tests/h5.lib/dataset_strided.cc)
+pyre_test_driver_cleanup(dataset_mosaic_write.h5 tests/h5.lib/dataset_mosaic_write.cc)
+pyre_test_driver_cleanup(dataset_mosaic_read.h5 tests/h5.lib/dataset_mosaic_read.cc)
+
+
+# end of file

--- a/.mm/pyre-h5.ext.tests
+++ b/.mm/pyre-h5.ext.tests
@@ -21,6 +21,7 @@ tests.h5.ext.lcpl.clean := h5_ext_lcpl.h5
 tests.h5.ext.acpl.clean := h5_ext_acpl.h5
 tests.h5.ext.read_chunk_cache.clean := read_chunk_cache.h5
 tests.h5.ext.dapl_chunk_cache.clean := dapl_chunk_cache.h5
+tests.h5.ext.chunk_table.clean := chunk_table.h5
 
 
 # end of file

--- a/.mm/pyre-h5.ext.tests
+++ b/.mm/pyre-h5.ext.tests
@@ -22,6 +22,7 @@ tests.h5.ext.acpl.clean := h5_ext_acpl.h5
 tests.h5.ext.read_chunk_cache.clean := read_chunk_cache.h5
 tests.h5.ext.dapl_chunk_cache.clean := dapl_chunk_cache.h5
 tests.h5.ext.chunk_table.clean := chunk_table.h5
+tests.h5.ext.direct_chunk.clean := direct_chunk.h5
 
 
 # end of file

--- a/.mm/pyre-h5.ext.tests
+++ b/.mm/pyre-h5.ext.tests
@@ -20,6 +20,7 @@ tests.h5.ext.fapl.clean := h5_ext_fapl.h5
 tests.h5.ext.lcpl.clean := h5_ext_lcpl.h5
 tests.h5.ext.acpl.clean := h5_ext_acpl.h5
 tests.h5.ext.read_chunk_cache.clean := read_chunk_cache.h5
+tests.h5.ext.dapl_chunk_cache.clean := dapl_chunk_cache.h5
 
 
 # end of file

--- a/.mm/pyre-h5.ext.tests
+++ b/.mm/pyre-h5.ext.tests
@@ -19,6 +19,7 @@ tests.h5.ext.fcpl.clean := h5_ext_fcpl.h5
 tests.h5.ext.fapl.clean := h5_ext_fapl.h5
 tests.h5.ext.lcpl.clean := h5_ext_lcpl.h5
 tests.h5.ext.acpl.clean := h5_ext_acpl.h5
+tests.h5.ext.read_chunk_cache.clean := read_chunk_cache.h5
 
 
 # end of file

--- a/.mm/pyre-h5.ext.tests
+++ b/.mm/pyre-h5.ext.tests
@@ -23,6 +23,8 @@ tests.h5.ext.read_chunk_cache.clean := read_chunk_cache.h5
 tests.h5.ext.dapl_chunk_cache.clean := dapl_chunk_cache.h5
 tests.h5.ext.chunk_table.clean := chunk_table.h5
 tests.h5.ext.direct_chunk.clean := direct_chunk.h5
+tests.h5.ext.strided_tile.clean := strided_tile.h5
+tests.h5.ext.transfer_list.clean := transfer_list.h5
 
 
 # end of file

--- a/.mm/pyre-h5.lib.tests
+++ b/.mm/pyre-h5.lib.tests
@@ -20,6 +20,7 @@ pyre-h5.lib.tests.c++.flags += -Wall $(pyre.lib.c++.flags)
 tests.h5.lib.dataset_tiling.clean := dataset_tiling.h5
 tests.h5.lib.dataset_mosaic_read.clean := dataset_mosaic_read.h5
 tests.h5.lib.dataset_mosaic_write.clean := dataset_mosaic_write.h5
+tests.h5.lib.dataset_strided.clean := dataset_strided.h5
 
 
 # end of file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,12 @@ if(PYRE_BUILD_TESTING)
     include(pyre_tests_postgres_lib)
     include(pyre_tests_postgres_ext)
   endif()
+
+  # if we have hdf5 support
+  if(HDF5_FOUND)
+    include(pyre_tests_h5_lib)
+    include(pyre_tests_h5_ext)
+  endif()
 endif()
 
 

--- a/extensions/h5/Chunk.cc
+++ b/extensions/h5/Chunk.cc
@@ -1,0 +1,77 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// one chunk of a chunked dataset, as it exists in the file
+void
+pyre::h5::py::chunk(py::module & m)
+{
+    // add bindings for the record
+    auto cls = py::class_<Chunk>(
+        // in scope
+        m,
+        // class name
+        "Chunk",
+        // docstring
+        "one chunk of a chunked dataset, as it exists in the file");
+
+    // constructor; every field is named, so a call site says what its values mean
+    cls.def(
+        // the implementation
+        py::init<index_t, unsigned int, haddr_t, hsize_t>(),
+        // the signature
+        "origin"_a, "filterMask"_a, "address"_a, "bytes"_a,
+        // the docstring
+        "describe a chunk that exists in the file");
+
+    // where my first cell sits in the dataset's index space
+    cls.def_readwrite(
+        // the name
+        "origin",
+        // the field
+        &Chunk::origin,
+        // the docstring
+        "where my first cell sits in the dataset's index space");
+
+    // which stages of the filter pipeline were skipped when i was written
+    cls.def_readwrite(
+        // the name
+        "filterMask",
+        // the field
+        &Chunk::filterMask,
+        // the docstring
+        "which stages of the filter pipeline were skipped when i was written");
+
+    // where i live in the file
+    cls.def_readwrite(
+        // the name
+        "address",
+        // the field
+        &Chunk::address,
+        // the docstring
+        "where i live in the file");
+
+    // how much room i take up there, after the pipeline had its way with me
+    cls.def_readwrite(
+        // the name
+        "bytes",
+        // the field
+        &Chunk::bytes,
+        // the docstring
+        "my size on disk, after the filter pipeline had its way with me");
+
+    // all done
+    return;
+}
+
+
+// end of file

--- a/extensions/h5/DataSet.cc
+++ b/extensions/h5/DataSet.cc
@@ -25,10 +25,36 @@ namespace pyre::h5::py {
     {
         // ask the buffer for writable access to its block
         auto info = data.request(true);
-        // address it as a flat run of cells
-        hsize_t memsize = info.size;
-        // an in-memory dataspace matching it, one dimensional
-        auto memspace = dataspace_t(shape_t { memsize });
+        // work out how many cells the tile holds
+        hsize_t cells = 1;
+        for (auto extent : shape) {
+            cells *= extent;
+        }
+        // the block has to be able to hold them
+        if (static_cast<hsize_t>(info.size) < cells) {
+            // if it cannot, make a channel
+            auto channel = pyre::journal::error_t("pyre.h5");
+            // complain
+            channel
+                // what
+                << "the destination is too small for the tile"
+                << pyre::journal::newline
+                // details
+                << "it holds " << info.size << " cells, and the tile has " << cells
+                // where
+                << pyre::journal::endl(__HERE__);
+            // and bail, rather than let the library write past the end of somebody's array
+            return;
+        }
+        // describe the destination with the SHAPE of the tile, rather than as a flat run of
+        // the same number of cells. the two hold the same elements and the library accepts
+        // either, so this looks like a matter of taste -- it is not. a destination whose
+        // rank does not match the source's cannot be filled by the path that hands over a
+        // whole chunk, so the library falls back to a general scatter and inflates the chunk
+        // again on every read, however much of it is already sitting in the chunk cache.
+        // measured against a compressed NISAR product, that is the difference between
+        // repeating a read in 0.05ms and repeating it in 5ms
+        auto memspace = dataspace_t(shape);
         // the source, restricted to the requested tile
         auto filespace = self.dataspace();
         filespace.slab(origin, shape);

--- a/extensions/h5/DataSet.cc
+++ b/extensions/h5/DataSet.cc
@@ -40,7 +40,8 @@ namespace pyre::h5::py {
                 << "the destination is too small for the tile"
                 << pyre::journal::newline
                 // details
-                << "it holds " << info.size << " cells, and the tile has " << cells
+                << "it holds " << info.size << " cells, and the tile has "
+                << cells
                 // where
                 << pyre::journal::endl(__HERE__);
             // and bail, rather than let the library write past the end of somebody's array
@@ -138,6 +139,65 @@ pyre::h5::py::dataset(py::module & m)
         },
         // the docstring
         "get my access property list");
+
+    // the chunk table: which of the chunks my tiling describes have actually been written
+    cls.def_property_readonly(
+        // the name
+        "chunks",
+        // the implementation
+        [](const DataSet & self) -> py::object {
+            // ask
+            auto count = self.chunks();
+            // a dataset that is not stored as chunks has no table at all
+            if (!count) {
+                // and says so
+                return py::none();
+            }
+            // otherwise, hand back the tally
+            return py::cast(*count);
+        },
+        // the docstring
+        "the number of chunks i hold, or {None} when i am not stored as chunks");
+
+    cls.def(
+        // the name
+        "chunk",
+        // the implementation
+        [](const DataSet & self, hsize_t index) -> py::object {
+            // ask
+            auto chunk = self.chunk(index);
+            // an index that names nothing
+            if (!chunk) {
+                // comes back empty
+                return py::none();
+            }
+            // otherwise, hand back the description
+            return py::cast(*chunk);
+        },
+        // the signature
+        "index"_a,
+        // the docstring
+        "the chunk at {index} of my table, in the logical order of chunk origins");
+
+    cls.def(
+        // the name
+        "chunkAt",
+        // the implementation
+        [](const DataSet & self, const index_t & origin) -> py::object {
+            // ask
+            auto chunk = self.chunkAt(origin);
+            // a chunk nobody ever wrote
+            if (!chunk) {
+                // comes back empty, which is how a caller learns the region is pure fill
+                return py::none();
+            }
+            // otherwise, hand back the description
+            return py::cast(*chunk);
+        },
+        // the signature
+        "origin"_a,
+        // the docstring
+        "the chunk that holds the cell at {origin}, or {None} if it has never been written");
 
     // creation property list
     cls.def_property_readonly(

--- a/extensions/h5/DataSet.cc
+++ b/extensions/h5/DataSet.cc
@@ -199,6 +199,54 @@ pyre::h5::py::dataset(py::module & m)
         // the docstring
         "the chunk that holds the cell at {origin}, or {None} if it has never been written");
 
+    // direct chunk access: moving a chunk in the form it is stored in, without decoding it
+    cls.def(
+        // the name
+        "readChunk",
+        // the implementation
+        [](const DataSet & self, const index_t & origin) -> py::object {
+            // somewhere to put the stored bytes; the dataset sizes it
+            auto buffer = bytes_t();
+            // pull the chunk
+            auto filterMask = self.readChunk(origin, buffer);
+            // a chunk that was never written has nothing to hand over
+            if (!filterMask) {
+                // and says so
+                return py::none();
+            }
+            // otherwise, hand back the mask alongside the bytes, since a caller that means
+            // to lay these down elsewhere needs both
+            return py::make_tuple(*filterMask, py::bytes(buffer.data(), buffer.size()));
+        },
+        // the signature
+        "origin"_a,
+        // the docstring
+        "the stored bytes of the chunk holding {origin}, as a {(filterMask, bytes)} pair, or "
+        "{None} if it has never been written");
+
+    cls.def(
+        // the name
+        "writeChunk",
+        // the implementation
+        [](const DataSet & self, const index_t & origin, unsigned int filterMask,
+           const py::buffer & data) -> void {
+            // ask the source for read access to its block
+            auto info = data.request(false);
+            // measure it, in bytes rather than in whatever it thinks its cells are
+            auto span = static_cast<std::size_t>(info.size * info.itemsize);
+            // take a copy, since the library wants a contiguous run it can hand to the file
+            auto first = static_cast<const char *>(info.ptr);
+            auto buffer = bytes_t(first, first + span);
+            // and lay it down
+            self.writeChunk(origin, filterMask, buffer);
+            // all done
+            return;
+        },
+        // the signature
+        "origin"_a, "filterMask"_a, "data"_a,
+        // the docstring
+        "lay {data}, already in stored form, down as the chunk that holds {origin}");
+
     // creation property list
     cls.def_property_readonly(
         // the name

--- a/extensions/h5/DataSet.cc
+++ b/extensions/h5/DataSet.cc
@@ -15,10 +15,6 @@
 // helpers
 namespace pyre::h5::py {
 
-    // read a tile from {self} into any writable python buffer
-    // a pyre grid, a pyre memory buffer, and a numpy array all present the python buffer
-    // protocol, so a single entry point serves them all; the grid family no longer needs its
-    // cross product of instantiations bound here
     // restrict {filespace} to the tile at {origin} of the given {shape}, visiting only every
     // {stride}-th cell along each axis when a stride is given at all. an empty stride asks
     // for the solid block, which is the overwhelmingly common case and the cheaper selection
@@ -59,9 +55,14 @@ namespace pyre::h5::py {
         return true;
     }
 
+    // read a tile from {self} into any writable python buffer
+    // a pyre grid, a pyre memory buffer, and a numpy array all present the python buffer
+    // protocol, so a single entry point serves them all; the grid family no longer needs its
+    // cross product of instantiations bound here
     inline auto readInto(
         const DataSet & self, const py::buffer & data, const datatype_t & memtype,
-        const shape_t & origin, const shape_t & shape, const shape_t & stride) -> void
+        const shape_t & origin, const shape_t & shape, const shape_t & stride, const DXPL & dxpl)
+        -> void
     {
         // ask the buffer for writable access to its block
         auto info = data.request(true);
@@ -94,9 +95,9 @@ namespace pyre::h5::py {
         // whole chunk, so the library falls back to a general scatter and inflates the chunk
         // again on every read, however much of it is already sitting in the chunk cache.
         // measured against a compressed NISAR product, that is the difference between
-        // repeating a read in 0.05ms and repeating it in 5ms
-        // the samples arrive packed whether or not any were skipped on the way, so the
-        // destination is shaped like the sample grid, not like the region it was drawn from
+        // repeating a read in 0.05ms and repeating it in 5ms. note that the samples arrive
+        // packed even when a stride skipped over most of the region, so the shape that
+        // matters here is the sample grid and not the region it was drawn from
         auto memspace = dataspace_t(shape);
         // the source, about to be restricted to the requested tile
         auto filespace = self.dataspace();
@@ -105,14 +106,15 @@ namespace pyre::h5::py {
             // the complaint has already been lodged, so leave the buffer untouched
             return;
         }
-        // fill the block; {memtype} is a pyre wrapper, so hand over its raw ids
-        self.read(memtype.id(), info.ptr, memspace.id(), filespace.id());
+        // fill the block; everything here is a pyre wrapper, so hand over the raw ids
+        self.read(memtype.id(), info.ptr, memspace.id(), filespace.id(), dxpl.id());
     }
 
     // write the contents of any python buffer out to a tile of {self}
     inline auto writeFrom(
         const DataSet & self, const py::buffer & data, const datatype_t & memtype,
-        const shape_t & origin, const shape_t & shape, const shape_t & stride) -> void
+        const shape_t & origin, const shape_t & shape, const shape_t & stride, const DXPL & dxpl)
+        -> void
     {
         // ask the buffer for read access to its block
         auto info = data.request(false);
@@ -126,8 +128,8 @@ namespace pyre::h5::py {
             // the complaint has already been lodged, so leave the file untouched
             return;
         }
-        // hand the block to the write
-        self.write(memtype.id(), info.ptr, memspace.id(), filespace.id());
+        // hand the block to the write; everything here is a pyre wrapper, so pass raw ids
+        self.write(memtype.id(), info.ptr, memspace.id(), filespace.id(), dxpl.id());
     }
 
 } // namespace pyre::h5::py
@@ -743,19 +745,25 @@ pyre::h5::py::dataset(py::module & m)
         "read",
         // the implementation
         &readInto,
-        // the signature; an empty stride asks for every cell of a solid block
+        // the signature; an empty stride asks for every cell of a solid block, and the
+        // default transfer list leaves the cells alone on their way across
         "data"_a, "memtype"_a, "origin"_a, "shape"_a, "stride"_a = shape_t(),
+        "dxpl"_a = DXPL::theDefault(),
         // the docstring
-        "fill {data} with the tile @{origin}+{shape}, taking every {stride}-th cell");
+        "fill {data} with the tile @{origin}+{shape}, taking every {stride}-th cell and "
+        "transferring it under {dxpl}");
     cls.def(
         // the name
         "write",
         // the implementation
         &writeFrom,
-        // the signature; an empty stride lays down every cell of a solid block
+        // the signature; an empty stride lays down every cell of a solid block, and the
+        // default transfer list leaves the cells alone on their way across
         "data"_a, "memtype"_a, "origin"_a, "shape"_a, "stride"_a = shape_t(),
+        "dxpl"_a = DXPL::theDefault(),
         // the docstring
-        "write {data} to the tile @{origin}+{shape}, at every {stride}-th cell");
+        "write {data} to the tile @{origin}+{shape}, at every {stride}-th cell, transferring "
+        "it under {dxpl}");
 
     // the out-of-core mosaic factories
     bindMosaics(cls);

--- a/extensions/h5/DataSet.cc
+++ b/extensions/h5/DataSet.cc
@@ -19,9 +19,49 @@ namespace pyre::h5::py {
     // a pyre grid, a pyre memory buffer, and a numpy array all present the python buffer
     // protocol, so a single entry point serves them all; the grid family no longer needs its
     // cross product of instantiations bound here
+    // restrict {filespace} to the tile at {origin} of the given {shape}, visiting only every
+    // {stride}-th cell along each axis when a stride is given at all. an empty stride asks
+    // for the solid block, which is the overwhelmingly common case and the cheaper selection
+    inline auto select(
+        dataspace_t & filespace, const shape_t & origin, const shape_t & shape,
+        const shape_t & stride) -> bool
+    {
+        // no stride means every cell of a solid block
+        if (stride.empty()) {
+            // so make the simple selection
+            filespace.slab(origin, shape);
+            // and report that it took
+            return true;
+        }
+        // a stride has to say something about every axis, or there is no telling which ones
+        // it meant
+        if (stride.size() != shape.size()) {
+            // make a channel
+            auto channel = pyre::journal::error_t("pyre.h5");
+            // complain
+            channel
+                // what
+                << "the stride does not match the shape of the tile"
+                << pyre::journal::newline
+                // details
+                << "the stride has " << stride.size() << " entries, and the tile has "
+                << shape.size()
+                // where
+                << pyre::journal::endl(__HERE__);
+            // and decline to select anything
+            return false;
+        }
+        // each selected coordinate stands for a single cell, not a run of them
+        shape_t block(shape.size(), 1);
+        // so the selection is {shape} blocks of one cell, spaced {stride} apart
+        filespace.slab(H5S_SELECT_SET, origin, block, stride, shape);
+        // all done
+        return true;
+    }
+
     inline auto readInto(
         const DataSet & self, const py::buffer & data, const datatype_t & memtype,
-        const shape_t & origin, const shape_t & shape) -> void
+        const shape_t & origin, const shape_t & shape, const shape_t & stride) -> void
     {
         // ask the buffer for writable access to its block
         auto info = data.request(true);
@@ -55,10 +95,16 @@ namespace pyre::h5::py {
         // again on every read, however much of it is already sitting in the chunk cache.
         // measured against a compressed NISAR product, that is the difference between
         // repeating a read in 0.05ms and repeating it in 5ms
+        // the samples arrive packed whether or not any were skipped on the way, so the
+        // destination is shaped like the sample grid, not like the region it was drawn from
         auto memspace = dataspace_t(shape);
-        // the source, restricted to the requested tile
+        // the source, about to be restricted to the requested tile
         auto filespace = self.dataspace();
-        filespace.slab(origin, shape);
+        // narrow it to the cells we actually want; a stride that makes no sense stops us here
+        if (!select(filespace, origin, shape, stride)) {
+            // the complaint has already been lodged, so leave the buffer untouched
+            return;
+        }
         // fill the block; {memtype} is a pyre wrapper, so hand over its raw ids
         self.read(memtype.id(), info.ptr, memspace.id(), filespace.id());
     }
@@ -66,15 +112,20 @@ namespace pyre::h5::py {
     // write the contents of any python buffer out to a tile of {self}
     inline auto writeFrom(
         const DataSet & self, const py::buffer & data, const datatype_t & memtype,
-        const shape_t & origin, const shape_t & shape) -> void
+        const shape_t & origin, const shape_t & shape, const shape_t & stride) -> void
     {
         // ask the buffer for read access to its block
         auto info = data.request(false);
-        // the in-memory dataspace matches the tile
+        // the cells leave packed whether or not they are about to be scattered, so the
+        // source is shaped like the sample grid, not like the region it lands in
         auto memspace = dataspace_t(shape);
-        // the destination, restricted to the requested tile
+        // the destination, about to be restricted to the requested tile
         auto filespace = self.dataspace();
-        filespace.slab(origin, shape);
+        // narrow it to the cells we mean to overwrite; a bad stride stops us here
+        if (!select(filespace, origin, shape, stride)) {
+            // the complaint has already been lodged, so leave the file untouched
+            return;
+        }
         // hand the block to the write
         self.write(memtype.id(), info.ptr, memspace.id(), filespace.id());
     }
@@ -692,19 +743,19 @@ pyre::h5::py::dataset(py::module & m)
         "read",
         // the implementation
         &readInto,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
+        // the signature; an empty stride asks for every cell of a solid block
+        "data"_a, "memtype"_a, "origin"_a, "shape"_a, "stride"_a = shape_t(),
         // the docstring
-        "fill {data} with the tile @{origin}+{shape}");
+        "fill {data} with the tile @{origin}+{shape}, taking every {stride}-th cell");
     cls.def(
         // the name
         "write",
         // the implementation
         &writeFrom,
-        // the signature
-        "data"_a, "memtype"_a, "origin"_a, "shape"_a,
+        // the signature; an empty stride lays down every cell of a solid block
+        "data"_a, "memtype"_a, "origin"_a, "shape"_a, "stride"_a = shape_t(),
         // the docstring
-        "write {data} to the tile @{origin}+{shape}");
+        "write {data} to the tile @{origin}+{shape}, at every {stride}-th cell");
 
     // the out-of-core mosaic factories
     bindMosaics(cls);

--- a/extensions/h5/Group.cc
+++ b/extensions/h5/Group.cc
@@ -141,14 +141,14 @@ pyre::h5::py::group(py::module & m)
         // the name
         "dataset",
         // the implementation
-        [](const Group & self, string_t path) -> DataSet {
+        [](const Group & self, string_t path, const DAPL & dapl) -> DataSet {
             // open the dataset and return it
-            return self.openDataSet(path);
+            return self.openDataSet(path, dapl);
         },
         // the signature
-        "path"_a,
+        "path"_a, "dapl"_a = DAPL::theDefault(),
         // the docstring
-        "open a dataset given its {path}");
+        "open a dataset given its {path}, with the access property list {dapl}");
 
     // open one of my subgroups
     cls.def(
@@ -210,8 +210,8 @@ pyre::h5::py::group(py::module & m)
             return self.createDataSet(path, type, space, lcpl, dcpl, dapl);
         },
         // the signature
-        "path"_a, "type"_a, "space"_a, "lcpl"_a = LCPL::theDefault(),
-        "dcpl"_a = DCPL::theDefault(), "dapl"_a = DAPL::theDefault(),
+        "path"_a, "type"_a, "space"_a, "lcpl"_a = LCPL::theDefault(), "dcpl"_a = DCPL::theDefault(),
+        "dapl"_a = DAPL::theDefault(),
         // the docstring
         "create a new dataset at the given {name} given its {type} and data {space}, with "
         "property lists {lcpl}, {dcpl}, and {dapl}");

--- a/extensions/h5/__init__.cc
+++ b/extensions/h5/__init__.cc
@@ -34,6 +34,8 @@ PYBIND11_MODULE(h5, m)
     // object bindings
     pyre::h5::py::dataspace(m);
     pyre::h5::py::attribute(m);
+    // the chunk record, before the dataset that hands it out
+    pyre::h5::py::chunk(m);
     pyre::h5::py::dataset(m);
     pyre::h5::py::group(m);
     pyre::h5::py::file(m);

--- a/extensions/h5/external.h
+++ b/extensions/h5/external.h
@@ -107,6 +107,8 @@ namespace pyre::h5::py {
     using File = pyre::h5::File;
     // datasets derive from {Location}
     using DataSet = pyre::h5::DataSet;
+    // one chunk of a chunked dataset, as it exists in the file
+    using Chunk = pyre::h5::Chunk;
     // datatypes: now pyre-owned wrappers over the hdf5 c api, living in {pyre::h5::types}; the
     // binding-facing names keep their {*Type} spelling so the registered python classes are stable
     using DataType = pyre::h5::types::Datatype;

--- a/extensions/h5/forward.h
+++ b/extensions/h5/forward.h
@@ -20,6 +20,7 @@ namespace pyre::h5::py {
     void attribute(py::module &);
     // datasets
     void dataspace(py::module &);
+    void chunk(py::module &);
     void dataset(py::module &);
     // structural
     void group(py::module &);

--- a/lib/h5/Chunk.h
+++ b/lib/h5/Chunk.h
@@ -1,0 +1,56 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// set up the namespace
+#include "forward.h"
+
+
+// one chunk of a chunked dataset, as it exists in the file
+// a chunk that was never written has no entry in the chunk table and therefore no instance of
+// this: the dataset reports its absence rather than handing back a hollow record, so every
+// chunk described here is one that can actually be read
+class pyre::h5::Chunk {
+    // types
+public:
+    // me
+    using self_type = Chunk;
+
+    // metamethods
+public:
+    // describe a chunk that exists in the file
+    Chunk(index_t origin, unsigned int filterMask, haddr_t address, hsize_t bytes);
+    // the full set of special members
+    Chunk(const Chunk &) = default;
+    Chunk(Chunk &&) noexcept = default;
+    Chunk & operator=(const Chunk &) = default;
+    Chunk & operator=(Chunk &&) noexcept = default;
+    ~Chunk() = default;
+
+    // data
+public:
+    // where my first cell sits in the dataset's index space; always a multiple of the chunk
+    // shape, since chunks tile the extent from the origin outwards
+    index_t origin;
+    // which stages of the dataset's filter pipeline were skipped when i was written; a set
+    // bit means that filter did not run on me, so i am not necessarily shaped like my
+    // siblings and anyone reading me raw has to honor it
+    unsigned int filterMask;
+    // where i live in the file
+    haddr_t address;
+    // how much room i take up there, after the pipeline had its way with me; this is the
+    // compressed size, not the size of the cells i decode into
+    hsize_t bytes;
+};
+
+
+// the inline definitions
+#include "Chunk.icc"
+
+
+// end of file

--- a/lib/h5/Chunk.icc
+++ b/lib/h5/Chunk.icc
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// my declarations
+#include "Chunk.h"
+
+
+// describe a chunk that exists in the file
+inline pyre::h5::Chunk::Chunk(
+    index_t origin, unsigned int filterMask, haddr_t address, hsize_t bytes) :
+    // record where my first cell sits
+    origin(origin),
+    // then which filters were skipped when i was written
+    filterMask(filterMask),
+    // then where i live in the file
+    address(address),
+    // and finally how much room i take up there
+    bytes(bytes)
+{}
+
+
+// end of file

--- a/lib/h5/DataSet.cc
+++ b/lib/h5/DataSet.cc
@@ -475,11 +475,12 @@ pyre::h5::DataSet::dcpl() const -> properties::DCPL
 
 // fill {buffer}, interpreted as {memtype}, from the selected region
 auto
-pyre::h5::DataSet::read(id_type memtype, void * buffer, id_type memspace, id_type filespace) const
-    -> void
+pyre::h5::DataSet::read(
+    id_type memtype, void * buffer, id_type memspace, id_type filespace, id_type dxpl) const -> void
 {
-    // hand it to the library
-    H5Dread(id(), memtype, memspace, filespace, H5P_DEFAULT, buffer);
+    // hand it to the library, along with whatever the caller wants done to the cells in
+    // flight; {dxpl} is the only place a data transform or a transfer buffer can be named
+    H5Dread(id(), memtype, memspace, filespace, dxpl, buffer);
     // all done
     return;
 }
@@ -488,10 +489,12 @@ pyre::h5::DataSet::read(id_type memtype, void * buffer, id_type memspace, id_typ
 // write {buffer}, interpreted as {memtype}, into the selected region
 auto
 pyre::h5::DataSet::write(
-    id_type memtype, const void * buffer, id_type memspace, id_type filespace) const -> void
+    id_type memtype, const void * buffer, id_type memspace, id_type filespace, id_type dxpl) const
+    -> void
 {
-    // hand it to the library
-    H5Dwrite(id(), memtype, memspace, filespace, H5P_DEFAULT, buffer);
+    // hand it to the library, along with whatever the caller wants done to the cells in
+    // flight; {dxpl} is the only place a data transform or a transfer buffer can be named
+    H5Dwrite(id(), memtype, memspace, filespace, dxpl, buffer);
     // all done
     return;
 }

--- a/lib/h5/DataSet.cc
+++ b/lib/h5/DataSet.cc
@@ -282,18 +282,18 @@ pyre::h5::DataSet::chunk(hsize_t index) const -> std::optional<Chunk>
 }
 
 
-// the chunk that holds the cell at {origin}
+// the corner of the chunk that holds the cell at {origin}
 auto
-pyre::h5::DataSet::chunkAt(const index_t & origin) const -> std::optional<Chunk>
+pyre::h5::DataSet::_corner(const index_t & origin) const -> std::optional<index_t>
 {
-    // there is no chunk to find unless i am stored as chunks
+    // there are no chunks to speak of unless i am stored as chunks
     if (dcpl().layout() != H5D_CHUNKED) {
-        // so say so
+        // so there is no corner to hand back
         return {};
     }
-    // my extent, which the coordinate has to fit inside
+    // my extent, which the cell has to lie inside
     auto box = packing().shape();
-    // a coordinate of the wrong rank cannot be checked, let alone used
+    // a cell of the wrong rank cannot be checked, let alone used
     if (origin.size() != box.size()) {
         // make a channel
         auto channel = pyre::journal::error_t("pyre.h5");
@@ -305,11 +305,15 @@ pyre::h5::DataSet::chunkAt(const index_t & origin) const -> std::optional<Chunk>
         // and decline to answer
         return {};
     }
-    // the library does not bounds check this call: an impossible coordinate comes back
-    // looking exactly like a chunk nobody ever wrote, so check it here or the two answers
-    // become indistinguishable
+    // my chunk shape, which says where the corners fall
+    auto chunk = dcpl().chunk();
+    // make room for the corner
+    auto corner = index_t(origin.size(), 0);
+    // go through the axes
     for (std::size_t axis = 0; axis < origin.size(); ++axis) {
-        // if this coordinate lies outside my extent
+        // the library does not bounds check the calls this feeds: an impossible cell comes
+        // back looking exactly like a chunk nobody ever wrote, so check here or the two
+        // answers become indistinguishable
         if (origin[axis] >= static_cast<hsize_t>(box[axis])) {
             // make a channel
             auto channel = pyre::journal::error_t("pyre.h5");
@@ -321,13 +325,32 @@ pyre::h5::DataSet::chunkAt(const index_t & origin) const -> std::optional<Chunk>
             // and decline to answer
             return {};
         }
+        // otherwise, round the coordinate down to the nearest multiple of the chunk extent
+        corner[axis] = origin[axis] - origin[axis] % chunk[axis];
+    }
+    // hand back the anchor of the chunk that holds the cell
+    return corner;
+}
+
+
+// the chunk that holds the cell at {origin}
+auto
+pyre::h5::DataSet::chunkAt(const index_t & origin) const -> std::optional<Chunk>
+{
+    // work out which chunk the cell belongs to; this screens the layout, the rank, and the
+    // bounds, and has already complained if any of them was wrong
+    auto corner = _corner(origin);
+    // if there is no such chunk
+    if (!corner) {
+        // there is nothing to describe
+        return {};
     }
     // make room for what the library reports
     unsigned int filterMask = 0;
     haddr_t address = 0;
     hsize_t bytes = 0;
-    // ask; any cell of a chunk names it, so the coordinate needs no snapping on our part
-    auto status = H5Dget_chunk_info_by_coord(id(), origin.data(), &filterMask, &address, &bytes);
+    // ask; this call takes any cell of a chunk, so the snapped corner suits it fine
+    auto status = H5Dget_chunk_info_by_coord(id(), corner->data(), &filterMask, &address, &bytes);
     // if the library balked
     if (status < 0) {
         // make a channel
@@ -344,18 +367,91 @@ pyre::h5::DataSet::chunkAt(const index_t & origin) const -> std::optional<Chunk>
         // report the absence
         return {};
     }
-    // otherwise, work out which chunk actually answered by snapping the cell down to its
-    // chunk's corner, so the caller gets the chunk's own origin rather than its own probe
-    auto chunk = dcpl().chunk();
-    // make room for the corner
-    auto corner = index_t(origin.size(), 0);
-    // go through the axes
-    for (std::size_t axis = 0; axis < origin.size(); ++axis) {
-        // and round the coordinate down to the nearest multiple of the chunk extent
-        corner[axis] = origin[axis] - origin[axis] % chunk[axis];
+    // assemble the description, anchored at the chunk's own corner rather than at the cell
+    // the caller happened to probe with
+    return Chunk(*corner, filterMask, address, bytes);
+}
+
+
+// read the chunk that holds the cell at {origin} in its stored form
+auto
+pyre::h5::DataSet::readChunk(const index_t & origin, bytes_t & buffer) const
+    -> std::optional<unsigned int>
+{
+    // find out whether there is a chunk there at all, and how much room its stored form
+    // needs; this screens the layout, the rank and the bounds on our behalf
+    auto chunk = chunkAt(origin);
+    // a chunk that was never written has no bytes to hand over
+    if (!chunk) {
+        // so say so; this is the answer, not a failure
+        return {};
     }
-    // assemble the description
-    return Chunk(corner, filterMask, address, bytes);
+    // size the destination from what the library says the chunk occupies, so that the
+    // caller cannot get it wrong and the read cannot run past the end of the buffer
+    buffer.resize(chunk->bytes);
+    // make room for the mask of filters the chunk was spared
+    uint32_t filterMask = 0;
+    // the direct read insists on the chunk's own corner, unlike the table lookup above,
+    // which is why the corner rather than the caller's cell goes in here
+#if H5_VERSION_GE(2, 0, 0)
+    // hdf5 2.0 takes the room available and reports the bytes it used, so the buffer is
+    // guarded by the library as well as by us
+    auto room = buffer.size();
+    auto status =
+        H5Dread_chunk(id(), H5P_DEFAULT, chunk->origin.data(), &filterMask, buffer.data(), &room);
+#else
+    // older libraries take the caller's word for it, which is safe here only because the
+    // buffer was sized from the chunk's own storage size a moment ago
+    auto status =
+        H5Dread_chunk(id(), H5P_DEFAULT, chunk->origin.data(), &filterMask, buffer.data());
+#endif
+    // if the library balked
+    if (status < 0) {
+        // make a channel
+        auto channel = pyre::journal::error_t("pyre.h5");
+        // complain
+        channel << "while reading a chunk of '" << name() << "' in its stored form"
+                << pyre::journal::newline << "the library refused" << pyre::journal::endl(__HERE__);
+        // leave nothing misleading behind
+        buffer.clear();
+        // and decline to answer
+        return {};
+    }
+    // hand back the filters this chunk was spared, which is what a caller needs in order to
+    // lay these same bytes down somewhere else
+    return filterMask;
+}
+
+
+// lay {buffer} down as the chunk that holds the cell at {origin}
+auto
+pyre::h5::DataSet::writeChunk(
+    const index_t & origin, unsigned int filterMask, const bytes_t & buffer) const -> void
+{
+    // work out which chunk the cell belongs to; the direct write insists on the chunk's own
+    // corner, and this screens the layout, the rank and the bounds besides
+    auto corner = _corner(origin);
+    // if there is no such chunk
+    if (!corner) {
+        // the complaint has already been lodged, so just stop
+        return;
+    }
+    // hand the bytes over exactly as they are; nothing is converted, selected, or filtered
+    // on the way in, so whatever the caller supplies is what ends up in the file
+    auto status =
+        H5Dwrite_chunk(id(), H5P_DEFAULT, filterMask, corner->data(), buffer.size(), buffer.data());
+    // if the library balked
+    if (status < 0) {
+        // make a channel
+        auto channel = pyre::journal::error_t("pyre.h5");
+        // complain
+        channel << "while writing a chunk of '" << name() << "' in its stored form"
+                << pyre::journal::newline << "the library refused" << pyre::journal::endl(__HERE__);
+        // and bail
+        return;
+    }
+    // all done
+    return;
 }
 
 

--- a/lib/h5/DataSet.cc
+++ b/lib/h5/DataSet.cc
@@ -9,6 +9,7 @@
 #include "DataSet.h"
 // the wrappers i hand back
 #include "types/Datatype.h"
+#include "Chunk.h"
 #include "DataSpace.h"
 #include "properties/DAPL.h"
 #include "properties/DCPL.h"
@@ -200,6 +201,161 @@ pyre::h5::DataSet::memorySize() const -> std::size_t
     H5Tclose(type);
     // the total is the product
     return static_cast<std::size_t>(points) * size;
+}
+
+
+// how many chunks i hold
+auto
+pyre::h5::DataSet::chunks() const -> std::optional<hsize_t>
+{
+    // the chunk table only exists for datasets that are stored as chunks; the library
+    // rejects the question for any other layout, so screen it here rather than let an
+    // error stack unwind at the caller
+    if (dcpl().layout() != H5D_CHUNKED) {
+        // there is no table to count
+        return {};
+    }
+    // make room for the answer
+    hsize_t count = 0;
+    // ask the library about the whole of me, rather than some selected part
+    auto status = H5Dget_num_chunks(id(), H5S_ALL, &count);
+    // if the library balked
+    if (status < 0) {
+        // make a channel
+        auto channel = pyre::journal::error_t("pyre.h5");
+        // complain
+        channel << "while counting the chunks of '" << name() << "'" << pyre::journal::newline
+                << "the library refused" << pyre::journal::endl(__HERE__);
+        // and decline to answer
+        return {};
+    }
+    // hand back the tally
+    return count;
+}
+
+
+// the chunk at {index} of my table
+auto
+pyre::h5::DataSet::chunk(hsize_t index) const -> std::optional<Chunk>
+{
+    // find out how many chunks there are to walk; this also screens out the layouts that
+    // have no chunk table at all
+    auto total = chunks();
+    // if there is no table
+    if (!total) {
+        // there is nothing at any index
+        return {};
+    }
+    // an index past the end is a caller mistake, and one worth naming: the library would
+    // reject it too, but silently, and the table shrinks and grows as chunks are written
+    if (index >= *total) {
+        // make a channel
+        auto channel = pyre::journal::error_t("pyre.h5");
+        // complain
+        channel << "while looking up chunk " << index << " of '" << name() << "'"
+                << pyre::journal::newline << "only " << *total << " chunks have been written"
+                << pyre::journal::endl(__HERE__);
+        // and decline to answer
+        return {};
+    }
+    // make room for the origin, one coordinate per axis of my extent
+    auto origin = index_t(packing().rank(), 0);
+    // and for the rest of what the library reports
+    unsigned int filterMask = 0;
+    haddr_t address = 0;
+    hsize_t bytes = 0;
+    // ask
+    auto status =
+        H5Dget_chunk_info(id(), H5S_ALL, index, origin.data(), &filterMask, &address, &bytes);
+    // if the library balked
+    if (status < 0) {
+        // make a channel
+        auto channel = pyre::journal::error_t("pyre.h5");
+        // complain
+        channel << "while looking up chunk " << index << " of '" << name() << "'"
+                << pyre::journal::newline << "the library refused" << pyre::journal::endl(__HERE__);
+        // and decline to answer
+        return {};
+    }
+    // assemble the description
+    return Chunk(origin, filterMask, address, bytes);
+}
+
+
+// the chunk that holds the cell at {origin}
+auto
+pyre::h5::DataSet::chunkAt(const index_t & origin) const -> std::optional<Chunk>
+{
+    // there is no chunk to find unless i am stored as chunks
+    if (dcpl().layout() != H5D_CHUNKED) {
+        // so say so
+        return {};
+    }
+    // my extent, which the coordinate has to fit inside
+    auto box = packing().shape();
+    // a coordinate of the wrong rank cannot be checked, let alone used
+    if (origin.size() != box.size()) {
+        // make a channel
+        auto channel = pyre::journal::error_t("pyre.h5");
+        // complain
+        channel << "while looking for the chunk of '" << name() << "' at a given cell"
+                << pyre::journal::newline << "the cell has " << origin.size()
+                << " coordinates, but the dataset has rank " << box.size()
+                << pyre::journal::endl(__HERE__);
+        // and decline to answer
+        return {};
+    }
+    // the library does not bounds check this call: an impossible coordinate comes back
+    // looking exactly like a chunk nobody ever wrote, so check it here or the two answers
+    // become indistinguishable
+    for (std::size_t axis = 0; axis < origin.size(); ++axis) {
+        // if this coordinate lies outside my extent
+        if (origin[axis] >= static_cast<hsize_t>(box[axis])) {
+            // make a channel
+            auto channel = pyre::journal::error_t("pyre.h5");
+            // complain
+            channel << "while looking for the chunk of '" << name() << "' at a given cell"
+                    << pyre::journal::newline << "coordinate " << axis << " is " << origin[axis]
+                    << ", which is outside my extent of " << box[axis]
+                    << pyre::journal::endl(__HERE__);
+            // and decline to answer
+            return {};
+        }
+    }
+    // make room for what the library reports
+    unsigned int filterMask = 0;
+    haddr_t address = 0;
+    hsize_t bytes = 0;
+    // ask; any cell of a chunk names it, so the coordinate needs no snapping on our part
+    auto status = H5Dget_chunk_info_by_coord(id(), origin.data(), &filterMask, &address, &bytes);
+    // if the library balked
+    if (status < 0) {
+        // make a channel
+        auto channel = pyre::journal::error_t("pyre.h5");
+        // complain
+        channel << "while looking for the chunk of '" << name() << "' at a given cell"
+                << pyre::journal::newline << "the library refused" << pyre::journal::endl(__HERE__);
+        // and decline to answer
+        return {};
+    }
+    // a chunk nobody has written has no address; that is not a failure, it is the answer,
+    // and it says the region is pure fill
+    if (address == HADDR_UNDEF) {
+        // report the absence
+        return {};
+    }
+    // otherwise, work out which chunk actually answered by snapping the cell down to its
+    // chunk's corner, so the caller gets the chunk's own origin rather than its own probe
+    auto chunk = dcpl().chunk();
+    // make room for the corner
+    auto corner = index_t(origin.size(), 0);
+    // go through the axes
+    for (std::size_t axis = 0; axis < origin.size(); ++axis) {
+        // and round the coordinate down to the nearest multiple of the chunk extent
+        corner[axis] = origin[axis] - origin[axis] % chunk[axis];
+    }
+    // assemble the description
+    return Chunk(corner, filterMask, address, bytes);
 }
 
 

--- a/lib/h5/DataSet.h
+++ b/lib/h5/DataSet.h
@@ -90,6 +90,19 @@ public:
     auto storageSize() const -> hsize_t;
     // my in-memory size, in bytes
     auto memorySize() const -> std::size_t;
+
+    // the chunk table: which of the chunks my tiling describes have actually been written
+    // how many chunks i hold; nothing at all when i am not stored as chunks, which is a
+    // different answer from being chunked with nothing written into me yet
+    auto chunks() const -> std::optional<hsize_t>;
+    // the chunk at {index} of my table; the table lists only the chunks that exist, in the
+    // logical order of their origins, so an index is a cursor and not a durable address:
+    // writing a chunk that sorts earlier renumbers everything behind it
+    auto chunk(hsize_t index) const -> std::optional<Chunk>;
+    // the chunk that holds the cell at {origin}; any cell of a chunk names it, not just its
+    // corner. nothing comes back when that chunk has never been written, which is the cheap
+    // way to know a region is pure fill and not worth reading
+    auto chunkAt(const index_t & origin) const -> std::optional<Chunk>;
     // my access property list, as a fresh owned wrapper
     auto dapl() const -> properties::DAPL;
     // my creation property list, as a fresh owned wrapper

--- a/lib/h5/DataSet.h
+++ b/lib/h5/DataSet.h
@@ -130,15 +130,16 @@ public:
     template <class valueT>
     auto fillValue() const -> std::optional<valueT>;
 
-    // raw value access; {memspace}/{filespace} default to the whole extent
+    // raw value access; {memspace}/{filespace} default to the whole extent, and {dxpl} to
+    // the library's own transfer settings
     // fill {buffer}, interpreted as {memtype}, from the selected region
     auto read(
-        id_type memtype, void * buffer, id_type memspace = H5S_ALL,
-        id_type filespace = H5S_ALL) const -> void;
+        id_type memtype, void * buffer, id_type memspace = H5S_ALL, id_type filespace = H5S_ALL,
+        id_type dxpl = H5P_DEFAULT) const -> void;
     // write {buffer}, interpreted as {memtype}, into the selected region
     auto write(
         id_type memtype, const void * buffer, id_type memspace = H5S_ALL,
-        id_type filespace = H5S_ALL) const -> void;
+        id_type filespace = H5S_ALL, id_type dxpl = H5P_DEFAULT) const -> void;
     // read my contents as a string, trimming the persisted padding
     auto readString(id_type memspace = H5S_ALL, id_type filespace = H5S_ALL) const -> string_t;
     // write {value} into me as a string

--- a/lib/h5/DataSet.h
+++ b/lib/h5/DataSet.h
@@ -103,6 +103,20 @@ public:
     // corner. nothing comes back when that chunk has never been written, which is the cheap
     // way to know a region is pure fill and not worth reading
     auto chunkAt(const index_t & origin) const -> std::optional<Chunk>;
+
+    // direct chunk access: moving a chunk in the form it is stored in, without decoding it
+    // read the chunk that holds the cell at {origin} into {buffer}, which is resized to the
+    // chunk's stored size, so no caller can get the size wrong. the bytes arrive exactly as
+    // they sit in the file, filter pipeline and all, and what comes back is the mask of the
+    // filters that were skipped when the chunk was written; nothing comes back when there is
+    // no such chunk to read
+    auto readChunk(const index_t & origin, bytes_t & buffer) const -> std::optional<unsigned int>;
+    // lay {buffer} down as the chunk that holds the cell at {origin}, taking it to be already
+    // in stored form and recording {filterMask} as the filters it was spared. nothing is
+    // converted, selected, or filtered on the way in, so the bytes had better have come from
+    // a dataset whose pipeline and chunk shape match mine
+    auto writeChunk(const index_t & origin, unsigned int filterMask, const bytes_t & buffer) const
+        -> void;
     // my access property list, as a fresh owned wrapper
     auto dapl() const -> properties::DAPL;
     // my creation property list, as a fresh owned wrapper
@@ -139,6 +153,11 @@ public:
 private:
     // trim the persisted padding from {value} according to the string padding strategy {pad}
     auto _trim(string_t & value, H5T_str_t pad) const -> void;
+    // the corner of the chunk that holds the cell at {origin}: check that the cell is one i
+    // actually have, and round it down to the anchor of its chunk. the chunk table snaps a
+    // cell to its chunk on its own, but the direct read and write refuse anything that is
+    // not already a corner, so the whole family shares one answer and behaves alike
+    auto _corner(const index_t & origin) const -> std::optional<index_t>;
     // assemble a mosaic over a tiled {layout}: one demand-materialized page per tile
     template <class cellT>
     auto _assemble(const tiling_t & layout) const -> mosaic_t<cellT>;

--- a/lib/h5/Group.cc
+++ b/lib/h5/Group.cc
@@ -95,8 +95,20 @@ pyre::h5::Group::openGroup(const string_t & path) const -> Group
 auto
 pyre::h5::Group::openDataSet(const string_t & path) const -> DataSet
 {
-    // open it; the library hands back a fresh handle the wrapper adopts
-    return DataSet(static_cast<id_type>(H5Dopen2(id(), path.data(), H5P_DEFAULT)));
+    // defer to the full flavor, asking for the library defaults
+    return openDataSet(path, properties::DAPL::theDefault());
+}
+
+
+// open the dataset at the given {path}, with the access property list {dapl}
+auto
+pyre::h5::Group::openDataSet(const string_t & path, const properties::DAPL & dapl) const -> DataSet
+{
+    // open it; the access properties are the caller's chance to say how the dataset should
+    // be reached, and the chunk cache is the one that matters: it is a per dataset budget of
+    // decompressed chunks, and a reader that revisits a chunk gets it back for the price of
+    // a copy instead of an inflation. adopt the fresh handle
+    return DataSet(static_cast<id_type>(H5Dopen2(id(), path.data(), dapl.id())));
 }
 
 
@@ -117,8 +129,8 @@ pyre::h5::Group::createGroup(
 {
     // make it; the group access property list has no properties of its own, so it stays
     // the library default until hdf5 gives it something to say; adopt the fresh handle
-    return Group(static_cast<id_type>(
-        H5Gcreate2(id(), path.data(), lcpl.id(), gcpl.id(), H5P_DEFAULT)));
+    return Group(
+        static_cast<id_type>(H5Gcreate2(id(), path.data(), lcpl.id(), gcpl.id(), H5P_DEFAULT)));
 }
 
 
@@ -141,8 +153,9 @@ pyre::h5::Group::createDataSet(
     const properties::DAPL & dapl) const -> DataSet
 {
     // make it; adopt the fresh handle
-    return DataSet(static_cast<id_type>(H5Dcreate2(
-        id(), path.data(), type.id(), space.id(), lcpl.id(), dcpl.id(), dapl.id())));
+    return DataSet(
+        static_cast<id_type>(
+            H5Dcreate2(id(), path.data(), type.id(), space.id(), lcpl.id(), dcpl.id(), dapl.id())));
 }
 
 

--- a/lib/h5/Group.h
+++ b/lib/h5/Group.h
@@ -52,12 +52,14 @@ public:
     auto openGroup(const string_t & path) const -> Group;
     // open the dataset at the given {path}
     auto openDataSet(const string_t & path) const -> DataSet;
+    // open the dataset at the given {path}, with the access property list {dapl}
+    auto openDataSet(const string_t & path, const properties::DAPL & dapl) const -> DataSet;
     // create a subgroup at the given {path}
     auto createGroup(const string_t & path) const -> Group;
     // create a subgroup at the given {path}, with property lists {lcpl} and {gcpl}
     auto createGroup(
-        const string_t & path, const properties::LCPL & lcpl,
-        const properties::GCPL & gcpl) const -> Group;
+        const string_t & path, const properties::LCPL & lcpl, const properties::GCPL & gcpl) const
+        -> Group;
     // create a dataset {path} of {type} over {space}, with property lists {dcpl} and {dapl}
     auto createDataSet(
         const string_t & path, const types::Datatype & type, const DataSpace & space,

--- a/lib/h5/datasets.h
+++ b/lib/h5/datasets.h
@@ -104,10 +104,35 @@ pyre::h5::read(
     // the shape of the read region
     const shape_t & shape) -> void
 {
-    // get the size of the buffer
-    hsize_t memsize = data.cells();
-    // the in-memory layout is one-dimensional
-    auto memspace = dataspace_t(shape_t { memsize });
+    // work out how many cells the tile holds
+    hsize_t cells = 1;
+    for (auto extent : shape) {
+        cells *= extent;
+    }
+    // the destination has to be able to hold them
+    if (static_cast<hsize_t>(data.cells()) < cells) {
+        // if it cannot, make a channel
+        auto channel = pyre::journal::error_t("pyre.h5");
+        // complain
+        channel
+            // what
+            << "the destination is too small for the tile"
+            << pyre::journal::newline
+            // details
+            << "it holds " << data.cells() << " cells, and the tile has "
+            << cells
+            // where
+            << pyre::journal::endl(__HERE__);
+        // and bail, rather than let the library write past the end of the buffer
+        return;
+    }
+    // describe the destination with the SHAPE of the tile, rather than as a flat run of the
+    // same number of cells. the two hold the same elements and the library accepts either,
+    // so this looks like a matter of taste -- it is not. a destination whose rank does not
+    // match the source's cannot be filled by the path that hands over a whole chunk, so the
+    // library falls back to a general scatter and inflates the chunk again on every read,
+    // however much of it is already sitting in the chunk cache
+    auto memspace = dataspace_t(shape);
     // restrict the dataset's dataspace to the region of interest
     auto filespace = self.dataspace();
     filespace.slab(origin, shape);

--- a/lib/h5/datasets.h
+++ b/lib/h5/datasets.h
@@ -142,6 +142,60 @@ pyre::h5::read(
     return;
 }
 
+// the same, visiting only every {stride}-th cell along each axis
+template <class memT>
+auto
+pyre::h5::read(
+    // the dataset we are reading from
+    const dataset_t & self,
+    // the destination
+    memT & data,
+    // the destination datatype
+    const datatype_t & memtype,
+    // the location to read from
+    const shape_t & origin,
+    // the number of samples to bring back along each axis
+    const shape_t & shape,
+    // and how far apart in the file consecutive samples sit
+    const shape_t & stride) -> void
+{
+    // work out how many cells come back
+    hsize_t cells = 1;
+    for (auto extent : shape) {
+        cells *= extent;
+    }
+    // the destination has to be able to hold them
+    if (static_cast<hsize_t>(data.cells()) < cells) {
+        // if it cannot, make a channel
+        auto channel = pyre::journal::error_t("pyre.h5");
+        // complain
+        channel
+            // what
+            << "the destination is too small for the tile"
+            << pyre::journal::newline
+            // details
+            << "it holds " << data.cells() << " cells, and the tile has "
+            << cells
+            // where
+            << pyre::journal::endl(__HERE__);
+        // and bail, rather than let the library write past the end of the buffer
+        return;
+    }
+    // the samples arrive packed, so the destination is shaped like the sample grid rather
+    // than like the region they were drawn from
+    auto memspace = dataspace_t(shape);
+    // each selected coordinate stands for a single cell, not a run of them
+    shape_t block(shape.size(), 1);
+    // restrict the dataset's dataspace to the strided region: {shape} blocks of one cell,
+    // spaced {stride} apart, starting at {origin}
+    auto filespace = self.dataspace();
+    filespace.slab(H5S_SELECT_SET, origin, block, stride, shape);
+    // populate the buffer; {memtype} is a pyre wrapper, so hand over its raw type and space ids
+    self.read(memtype.id(), data.data(), memspace.id(), filespace.id());
+    // all done
+    return;
+}
+
 template <class memT>
 auto
 pyre::h5::write(
@@ -154,6 +208,28 @@ pyre::h5::write(
     auto filespace = self.dataspace();
     filespace.slab(origin, shape);
     // populate the buffer; {memtype} is a pyre wrapper, so hand over its raw type and space ids
+    self.write(memtype.id(), data.data(), memspace.id(), filespace.id());
+    // all done
+    return;
+}
+
+// the same, laying the cells down every {stride}-th slot along each axis
+template <class memT>
+auto
+pyre::h5::write(
+    const dataset_t & self, memT & data, const datatype_t & memtype, const shape_t & origin,
+    const shape_t & shape, const shape_t & stride) -> void
+{
+    // the cells arrive packed, so the source is shaped like the sample grid rather than like
+    // the region they are about to be scattered over
+    auto memspace = dataspace_t(shape);
+    // each selected coordinate stands for a single cell, not a run of them
+    shape_t block(shape.size(), 1);
+    // restrict the dataset's dataspace to the strided region: {shape} blocks of one cell,
+    // spaced {stride} apart, starting at {origin}
+    auto filespace = self.dataspace();
+    filespace.slab(H5S_SELECT_SET, origin, block, stride, shape);
+    // drain the buffer; {memtype} is a pyre wrapper, so hand over its raw type and space ids
     self.write(memtype.id(), data.data(), memspace.id(), filespace.id());
     // all done
     return;

--- a/lib/h5/external.h
+++ b/lib/h5/external.h
@@ -68,6 +68,9 @@ namespace pyre::h5 {
     // a hyperslab as a (begin, end) corner pair, and a collection of them
     using slab_t = std::pair<shape_t, shape_t>;
     using slabs_t = std::vector<slab_t>;
+    // an opaque run of bytes: a chunk in the form it is stored in, still carrying whatever
+    // the filter pipeline did to it, and therefore not cells of anything until it is decoded
+    using bytes_t = std::vector<char>;
 
     // the grid descriptions handed out by dataspaces and datasets: dataset and chunk shapes
     // are facts discovered at runtime, so they travel as the runtime-rank flavors of the

--- a/lib/h5/forward.h
+++ b/lib/h5/forward.h
@@ -132,6 +132,14 @@ namespace pyre::h5 {
         const dataset_t & self, memT & data, const datatype_t & memtype, const shape_t & origin,
         const shape_t & shape) -> void;
 
+    // the same, but visiting only every {stride}-th cell along each axis, which is how a
+    // decimated view is assembled without moving the cells it skips: {shape} counts the
+    // samples that come back, so the region swept is {shape} times {stride}
+    template <class memT>
+    inline auto read(
+        const dataset_t & self, memT & data, const datatype_t & memtype, const shape_t & origin,
+        const shape_t & shape, const shape_t & stride) -> void;
+
     // support for reading into existing {pyre::grid} instances
     template <class gridT>
     inline auto readGrid(
@@ -143,6 +151,13 @@ namespace pyre::h5 {
     inline auto write(
         const dataset_t & self, memT & data, const datatype_t & memtype, const shape_t & origin,
         const shape_t & shape) -> void;
+
+    // the same, but laying the cells down every {stride}-th slot along each axis, so that a
+    // decimated block can be scattered back into the extent it was drawn from
+    template <class memT>
+    inline auto write(
+        const dataset_t & self, memT & data, const datatype_t & memtype, const shape_t & origin,
+        const shape_t & shape, const shape_t & stride) -> void;
 
     // support for writing from existing {pyre::grid} instances
     template <class gridT>

--- a/lib/h5/forward.h
+++ b/lib/h5/forward.h
@@ -30,6 +30,8 @@ namespace pyre::h5 {
     class File;
     // a dataset
     class DataSet;
+    // one chunk of a chunked dataset, as it exists in the file
+    class Chunk;
 } // namespace pyre::h5
 
 

--- a/lib/h5/public.h
+++ b/lib/h5/public.h
@@ -29,6 +29,8 @@
 #include "Attribute.h"
 #include "Group.h"
 #include "File.h"
+// the pieces a dataset describes itself in terms of
+#include "Chunk.h"
 #include "DataSet.h"
 
 // implementation

--- a/tests/h5.ext/chunk_table.py
+++ b/tests/h5.ext/chunk_table.py
@@ -99,16 +99,34 @@ def test():
     channel.device = journal.trash()
     channel.fatal = False
 
+    # the guarded calls below complain on the {pyre.h5} error channel and decline to answer.
+    # whether such a complaint also stops the application is a policy the application sets,
+    # not part of what the guard promises, and the muzzle above does not reach the c++ side
+    # of every build. so treat a refusal and a raised complaint as the same outcome: what is
+    # being tested is that the guard saw the bad input, not what the application does about it
+    def declined(call):
+        """
+        Report whether the guard turned {call} away
+        """
+        # make the call
+        try:
+            # a guard that declined hands back nothing
+            return call() is None
+        # and one whose complaint was fatal never returns at all
+        except journal.ApplicationError:
+            # which is the same news
+            return True
+
     # an index past the end of the table names nothing; the table is as long as the number of
     # chunks written, not as long as the tiling, so this is a moving target and worth saying
-    assert chunked.chunk(index=2) is None
+    assert declined(lambda: chunked.chunk(index=2))
 
     # the library does not bounds check the by-coordinate lookup: it answers a coordinate that
     # cannot exist exactly the way it answers a chunk nobody wrote, which would make "outside
     # the raster" and "pure fill" indistinguishable. so we check for it ourselves
-    assert chunked.chunkAt(origin=[999, 999]) is None
+    assert declined(lambda: chunked.chunkAt(origin=[999, 999]))
     # and a coordinate of the wrong rank cannot even be checked, let alone used
-    assert chunked.chunkAt(origin=[0]) is None
+    assert declined(lambda: chunked.chunkAt(origin=[0]))
 
     # clean up
     f.close()

--- a/tests/h5.ext/chunk_table.py
+++ b/tests/h5.ext/chunk_table.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Exercise the chunk table of a chunked dataset
+
+    A chunked dataset is diced into tiles, but only the tiles somebody wrote are stored. The
+    chunk table is the library's record of which ones those are, and asking it is far cheaper
+    than reading: a region whose chunks are absent is pure fill, and a reader that knows this
+    can skip the work entirely rather than inflate a chunk of fill values.
+
+    The table lists only the chunks that exist, so an index into it is a cursor and not a
+    durable address, and it is ordered by chunk origin rather than by the order the chunks
+    were written. This writes its two chunks out of logical order so that a change to either
+    of those properties cannot pass unnoticed
+    """
+    # get the bindings
+    from pyre.extensions import libh5
+
+    # for a scratch path and a payload
+    import os
+    import array
+
+    # and for muzzling the complaints the guarded calls below are meant to raise
+    import journal
+
+    # a scratch data product
+    uri = "chunk_table.h5"
+    # make sure a stale one is not lying around
+    if os.path.exists(uri):
+        os.remove(uri)
+
+    # the layout: a raster diced into sixteen chunks, of which we will write two
+    extent = [256, 256]
+    chunk = [64, 64]
+    cells = chunk[0] * chunk[1]
+    # a double is eight bytes, and nothing here is filtered, so a stored chunk is exactly
+    # this big; anything else means the pipeline changed under us
+    footprint = cells * 8
+
+    # make the file
+    f = libh5.File(uri=uri, mode="w")
+    # describe the extent
+    space = libh5.DataSpace(shape=extent)
+    # the creation properties: chunked
+    dcpl = libh5.properties.dcpl()
+    dcpl.chunk = chunk
+    # make the chunked dataset
+    chunked = f.create(path="chunked", type=libh5.types.native.double, space=space, dcpl=dcpl)
+    # and a contiguous one beside it, so the questions that are ill posed for it can be asked
+    flat = f.create(path="flat", type=libh5.types.native.double, space=space)
+
+    # something to write
+    payload = array.array("d", (float(cell) for cell in range(cells)))
+    # write two chunks, and deliberately in the wrong order: the one further along the raster
+    # goes down first, so that write order and logical order disagree
+    chunked.write(payload, libh5.types.native.double, [64, 64], chunk)
+    chunked.write(payload, libh5.types.native.double, [0, 0], chunk)
+
+    # two of the sixteen tiles have been written, and only those are in the table
+    assert chunked.chunks == 2
+
+    # the table is ordered by origin, not by the order the chunks were laid down; if it were
+    # write order, these two would come back the other way round
+    first = chunked.chunk(index=0)
+    second = chunked.chunk(index=1)
+    assert first.origin == [0, 0]
+    assert second.origin == [64, 64]
+    # both are really there
+    assert first.bytes == footprint
+    assert second.bytes == footprint
+    # nothing was filtered, so no stage was skipped
+    assert first.filterMask == 0
+
+    # a chunk can be named by any of its cells, not just its corner, and it reports its own
+    # origin rather than the cell it was asked about
+    interior = chunked.chunkAt(origin=[70, 70])
+    assert interior.origin == [64, 64]
+    assert interior.address == second.address
+
+    # a tile nobody wrote has no entry, and that is the answer rather than a failure: it says
+    # the region is pure fill
+    assert chunked.chunkAt(origin=[128, 128]) is None
+
+    # the questions are ill posed for a dataset that is not stored as chunks, and both of them
+    # say so rather than letting the library raise
+    assert flat.chunks is None
+    assert flat.chunkAt(origin=[0, 0]) is None
+
+    # the lookups that are given something unusable complain and decline to answer; muzzle
+    # the complaint so the rest of this can run, and so the suite stays silent on success
+    channel = journal.error("pyre.h5")
+    channel.device = journal.trash()
+    channel.fatal = False
+
+    # an index past the end of the table names nothing; the table is as long as the number of
+    # chunks written, not as long as the tiling, so this is a moving target and worth saying
+    assert chunked.chunk(index=2) is None
+
+    # the library does not bounds check the by-coordinate lookup: it answers a coordinate that
+    # cannot exist exactly the way it answers a chunk nobody wrote, which would make "outside
+    # the raster" and "pure fill" indistinguishable. so we check for it ourselves
+    assert chunked.chunkAt(origin=[999, 999]) is None
+    # and a coordinate of the wrong rank cannot even be checked, let alone used
+    assert chunked.chunkAt(origin=[0]) is None
+
+    # clean up
+    f.close()
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # do...
+    test()
+
+
+# end of file

--- a/tests/h5.ext/dapl_chunk_cache.py
+++ b/tests/h5.ext/dapl_chunk_cache.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Exercise opening a dataset with an access property list of one's own
+
+    The raw data chunk cache is a property of the dataset access list, so a dataset opened
+    with the library defaults gets whatever budget the file hands out. Handing an access list
+    to the open is how a reader asks for something else: a budget sized for the chunks it
+    means to revisit, rather than one sized for whoever happened to open the file.
+
+    The cache belongs to the dataset rather than to the handle, and it is settled by the FIRST
+    open. A second open of a dataset already in hand shares what the first one asked for,
+    whichever way round they happen. Anyone tuning a cache therefore has to do it when the
+    dataset is first reached, and this exercises the rule in both directions so that a change
+    to it cannot pass unnoticed
+    """
+    # get the bindings
+    from pyre.extensions import libh5
+
+    # for a scratch path and its cleanup
+    import os
+
+    # a scratch data product
+    uri = "dapl_chunk_cache.h5"
+    # make sure a stale one is not lying around
+    if os.path.exists(uri):
+        os.remove(uri)
+
+    # the layout
+    chunk = [64, 64]
+
+    # make the file
+    f = libh5.File(uri=uri, mode="w")
+    # describe the extent
+    space = libh5.DataSpace(shape=[256, 256])
+    # the creation properties: chunked
+    dcpl = libh5.properties.dcpl()
+    dcpl.chunk = chunk
+    # make the dataset
+    f.create(path="product", type=libh5.types.native.double, space=space, dcpl=dcpl)
+    # and let go of every handle, so the opens below start from nothing
+    f.close()
+    del f
+
+    # the budget to ask for: room for sixteen chunks
+    slots = 521
+    budget = 16 * chunk[0] * chunk[1] * 8
+    # an access list carrying it
+    dapl = libh5.properties.dapl()
+    dapl.chunkCache = libh5.properties.ChunkCache(slots, budget, 0.75)
+
+    # take the dataset through it, on a file nobody else holds
+    f = libh5.File(uri=uri, mode="r")
+    tuned = f.dataset(path="product", dapl=dapl)
+    # it reports the budget it was asked for
+    cache = tuned.dapl.chunkCache
+    assert cache.slots == slots
+    assert cache.bytes == budget
+    assert cache.preemption == 0.75
+    # and the default it would otherwise have had is something else, or this proves nothing
+    assert cache.bytes != libh5.properties.fapl().cache.bytes
+
+    # a plain open of a dataset already in hand inherits what the first open asked for
+    inherited = f.dataset(path="product")
+    assert inherited.dapl.chunkCache.bytes == budget
+
+    # let everything go
+    f.close()
+    del f, tuned, inherited, cache
+
+    # and the same the other way round: a plain open first
+    f = libh5.File(uri=uri, mode="r")
+    plain = f.dataset(path="product")
+    # takes the file's default
+    assert plain.dapl.chunkCache.bytes == libh5.properties.fapl().cache.bytes
+    # and a tuned open afterwards does NOT get what it asks for, because the dataset is
+    # already open and its cache is already settled
+    late = f.dataset(path="product", dapl=dapl)
+    assert late.dapl.chunkCache.bytes != budget
+
+    # clean up
+    f.close()
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # do...
+    test()
+
+
+# end of file

--- a/tests/h5.ext/direct_chunk.py
+++ b/tests/h5.ext/direct_chunk.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Exercise direct chunk access: moving a chunk in the form it is stored in
+
+    The ordinary read hands over cells, which means inflating the chunk and converting it. The
+    direct read hands over the chunk exactly as it sits in the file, filter pipeline and all,
+    and the direct write puts such bytes back without filtering them again. Between them they
+    let a chunk be moved, or held somewhere, without ever being decoded.
+
+    The library insists that these two calls be given the chunk's own corner, unlike the chunk
+    table, which accepts any cell of a chunk. Pinning that difference matters, because we hide
+    it: {readChunk} and {writeChunk} snap the cell for the caller so the whole chunk family
+    can be addressed the same way
+    """
+    # get the bindings
+    from pyre.extensions import libh5
+
+    # for a scratch path and a payload
+    import os
+    import array
+
+    # and for muzzling the complaints the guarded calls below are meant to raise
+    import journal
+
+    # a scratch data product
+    uri = "direct_chunk.h5"
+    # make sure a stale one is not lying around
+    if os.path.exists(uri):
+        os.remove(uri)
+
+    # the layout: an extent that is not a whole number of chunks, so the tiling has an edge
+    extent = [200, 200]
+    chunk = [64, 64]
+    cells = chunk[0] * chunk[1]
+    # what a chunk would occupy if nothing were done to it
+    raw = cells * 8
+
+    # make the file
+    f = libh5.File(uri=uri, mode="w")
+    # describe the extent
+    space = libh5.DataSpace(shape=extent)
+    # the creation properties: chunked and compressed, so that stored form and cell form
+    # genuinely differ and a test cannot pass by confusing the two
+    dcpl = libh5.properties.dcpl()
+    dcpl.chunk = chunk
+    dcpl.addShuffle()
+    dcpl.addDeflate(4)
+    # a dataset to write, and an identical one to move a chunk into
+    src = f.create(path="src", type=libh5.types.native.double, space=space, dcpl=dcpl)
+    dst = f.create(path="dst", type=libh5.types.native.double, space=space, dcpl=dcpl)
+    # and a contiguous one, for the question that is ill posed
+    flat = f.create(path="flat", type=libh5.types.native.double, space=space)
+
+    # something that does not compress away to nothing; a regular sequence would be crushed
+    # and the stored size would stop being interesting
+    def noise():
+        """
+        Generate {cells} pseudo random values, deterministically
+        """
+        # a seed
+        state = 0x2545F4914F6CDD1D
+        # go through the cells
+        for _ in range(cells):
+            # advance the sequence
+            state = (state * 6364136223846793005 + 1442695040888963407) % (2**64)
+            # and hand back its high bits
+            yield float(state >> 32)
+
+    payload = array.array("d", noise())
+    # write one interior chunk the ordinary way
+    src.write(payload, libh5.types.native.double, [0, 0], chunk)
+
+    # now take that chunk out in the form it is stored in
+    mask, stored = src.readChunk(origin=[0, 0])
+    # what came back is the compressed form, not the cells: the chunk table agrees with its
+    # length, and it is smaller than the cells would be
+    assert len(stored) == src.chunkAt(origin=[0, 0]).bytes
+    assert len(stored) < raw
+    # nothing in the pipeline was skipped for this chunk
+    assert mask == 0
+
+    # the library would refuse a cell that is not the chunk's corner; we snap it, so any cell
+    # of the chunk names it, exactly as it does for the chunk table
+    interiorMask, interior = src.readChunk(origin=[5, 5])
+    assert interior == stored
+    assert interiorMask == mask
+
+    # put those bytes down in the other dataset without ever decoding them
+    dst.writeChunk(origin=[0, 0], filterMask=mask, data=stored)
+
+    # and read it back the ordinary way: the cells have to survive the trip
+    check = array.array("d", bytes(raw))
+    dst.read(check, libh5.types.native.double, [0, 0], chunk)
+    assert check[0] == payload[0]
+    assert check[cells // 2] == payload[cells // 2]
+    assert check[cells - 1] == payload[cells - 1]
+
+    # a chunk nobody wrote has no stored form to hand over, and that is the answer rather
+    # than a failure
+    assert src.readChunk(origin=[128, 128]) is None
+
+    # the question is ill posed for a dataset that is not stored as chunks
+    assert flat.readChunk(origin=[0, 0]) is None
+
+    # a cell outside the extent is refused rather than mistaken for an empty chunk; muzzle
+    # the complaint so the suite stays silent on success
+    channel = journal.error("pyre.h5")
+    channel.device = journal.trash()
+    channel.fatal = False
+    assert src.readChunk(origin=[999, 999]) is None
+
+    # clean up
+    f.close()
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # do...
+    test()
+
+
+# end of file

--- a/tests/h5.ext/direct_chunk.py
+++ b/tests/h5.ext/direct_chunk.py
@@ -115,7 +115,26 @@ def test():
     channel = journal.error("pyre.h5")
     channel.device = journal.trash()
     channel.fatal = False
-    assert src.readChunk(origin=[999, 999]) is None
+
+    # the guarded calls below complain on the {pyre.h5} error channel and decline to answer.
+    # whether such a complaint also stops the application is a policy the application sets,
+    # not part of what the guard promises, and the muzzle above does not reach the c++ side
+    # of every build. so treat a refusal and a raised complaint as the same outcome: what is
+    # being tested is that the guard saw the bad input, not what the application does about it
+    def declined(call):
+        """
+        Report whether the guard turned {call} away
+        """
+        # make the call
+        try:
+            # a guard that declined hands back nothing
+            return call() is None
+        # and one whose complaint was fatal never returns at all
+        except journal.ApplicationError:
+            # which is the same news
+            return True
+
+    assert declined(lambda: src.readChunk(origin=[999, 999]))
 
     # clean up
     f.close()

--- a/tests/h5.ext/read_chunk_cache.py
+++ b/tests/h5.ext/read_chunk_cache.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Exercise the raw data chunk cache: reading a compressed chunk a second time must be served
+    from the cache rather than inflated again
+
+    The library holds decompressed chunks in a per dataset cache, and consults it only on the
+    path that hands over a whole chunk at once. That path is available when the destination
+    has the same rank as the source. Describing the destination instead as a flat run of the
+    same number of cells is accepted, and returns identical data, so nothing about the answer
+    reveals the difference -- but the library must then scatter the chunk cell by cell, and it
+    inflates the chunk again on every read no matter what is already in the cache. On a
+    compressed product that is the difference between repeating a read in microseconds and
+    repeating it in milliseconds, and it is invisible to any test that only checks the values
+    """
+    # get the bindings
+    from pyre.extensions import libh5
+
+    # for a scratch path, timing, and a buffer
+    import os
+    import time
+    import array
+
+    # a scratch data product
+    uri = "read_chunk_cache.h5"
+    # make sure a stale one is not lying around
+    if os.path.exists(uri):
+        os.remove(uri)
+
+    # the layout: a raster of one chunk, big enough that inflating it is measurable
+    chunk = [512, 512]
+    cells = chunk[0] * chunk[1]
+
+    # make the file
+    f = libh5.File(uri=uri, mode="w")
+    # describe the extent
+    space = libh5.DataSpace(shape=chunk)
+    # the creation properties: one chunk, compressed, so a read has real work to do
+    dcpl = libh5.properties.dcpl()
+    dcpl.chunk = chunk
+    dcpl.addShuffle()
+    dcpl.addDeflate(4)
+    # make the dataset
+    dataset = f.create(
+        path="product", type=libh5.types.native.double, space=space, dcpl=dcpl
+    )
+
+    # fill it with something that does not compress, or the inflation costs nothing and there
+    # is no difference left to detect. a regular sequence is crushed by shuffle and deflate
+    # into a chunk that reinflates in microseconds; these are the low bits of a linear
+    # congruential sequence, which are noise as far as a compressor is concerned, and the
+    # sequence is fixed so the test measures the same work every time
+    def noise():
+        """
+        Generate {cells} pseudo random values, deterministically
+        """
+        # a seed
+        state = 0x2545F4914F6CDD1D
+        # go through the cells
+        for _ in range(cells):
+            # advance the sequence
+            state = (state * 6364136223846793005 + 1442695040888963407) % (2**64)
+            # and hand back its low bits, which carry no pattern to exploit
+            yield float(state & 0xFFFFFFFF)
+
+    payload = array.array("d", noise())
+    dataset.write(payload, libh5.types.native.double, [0, 0], chunk)
+    # close, and let go of every handle into the file. the library reference counts its open
+    # files: reopening one while a handle is still alive hands back the same file, chunk
+    # cache and all, and the chunk this test just wrote would still be sitting in it. the
+    # first read would then be served from the cache like every other, and the measurement
+    # would compare a cache hit against a cache hit
+    f.close()
+    del dataset
+    del f
+
+    # open it again, with a cache with room to spare for the one chunk
+    fapl = libh5.properties.fapl()
+    fapl.cache = libh5.properties.Cache(
+        fapl.cache.metadataElements, 521, 16 * cells * 8, 0.75
+    )
+    f = libh5.File(uri=uri, mode="r", fapl=fapl)
+    dataset = f.dataset(path="product")
+
+    # somewhere to put it
+    buffer = array.array("d", bytes(cells * 8))
+
+    # time a read
+    def read():
+        """
+        Read the whole chunk and report how long it took, in milliseconds
+        """
+        # start the clock
+        start = time.perf_counter()
+        # pull the tile
+        dataset.read(buffer, libh5.types.native.double, [0, 0], chunk)
+        # and report
+        return (time.perf_counter() - start) * 1000
+
+    # the first read inflates the chunk
+    first = read()
+    # the ones after it must not: they are served from the cache
+    repeats = [read() for _ in range(4)]
+
+    # the data has to be right, whichever path delivered it
+    assert buffer[0] == payload[0]
+    assert buffer[cells // 2] == payload[cells // 2]
+    assert buffer[cells - 1] == payload[cells - 1]
+
+    # and a repeat must be far cheaper than an inflation. the margin is deliberately loose --
+    # the measured ratio is around a hundred, and this asks for four -- because the point is
+    # to catch a destination that silently loses the cache, not to police the timing
+    best = min(repeats)
+    assert best * 4 < first, (
+        f"a repeated read cost {best:.3f}ms against {first:.3f}ms for the first, "
+        f"which means the chunk was inflated again rather than taken from the cache"
+    )
+
+    # clean up
+    f.close()
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # do...
+    test()
+
+
+# end of file

--- a/tests/h5.ext/strided_tile.py
+++ b/tests/h5.ext/strided_tile.py
@@ -103,7 +103,12 @@ def test():
     channel.fatal = False
     # a buffer that would be big enough, so nothing but the stride is wrong here
     scratch = array.array("d", bytes(shape[0] * shape[1] * 8))
-    src.read(scratch, libh5.types.native.double, [0, 0], shape, [2])
+    # the complaint may or may not be fatal, depending on how the build wires the journal
+    # across the language boundary; either way the read must not have happened
+    try:
+        src.read(scratch, libh5.types.native.double, [0, 0], shape, [2])
+    except journal.ApplicationError:
+        pass
     # nothing was read, so the buffer is still as it started
     assert scratch[0] == 0.0
 

--- a/tests/h5.ext/strided_tile.py
+++ b/tests/h5.ext/strided_tile.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Exercise reading and writing a tile that visits only every n-th cell
+
+    Decimating a raster by pulling all of it and throwing most of it away moves cells nobody
+    wanted. A strided selection asks the library to skip them instead, so the cost of a zoomed
+    out view falls with the zoom rather than staying flat.
+
+    The stride is per axis, since the two axes are decimated independently, and {shape} counts
+    the samples that come back rather than the extent they were drawn from: the region swept
+    is {shape} times {stride}. This pins that reading, in both directions, and checks that the
+    samples really are the ones a caller would have picked out by hand
+    """
+    # get the bindings
+    from pyre.extensions import libh5
+
+    # for a scratch path and a payload
+    import os
+    import array
+
+    # and for muzzling the complaint the mismatched stride is meant to raise
+    import journal
+
+    # a scratch data product
+    uri = "strided_tile.h5"
+    # make sure a stale one is not lying around
+    if os.path.exists(uri):
+        os.remove(uri)
+
+    # the layout: a small raster whose cells each say where they live, so a sample can be
+    # checked against the coordinate it claims to have come from
+    extent = [32, 32]
+    cells = extent[0] * extent[1]
+
+    # make the file
+    f = libh5.File(uri=uri, mode="w")
+    # describe the extent
+    space = libh5.DataSpace(shape=extent)
+    # a dataset to read back from, and one to scatter into
+    src = f.create(path="src", type=libh5.types.native.double, space=space)
+    dst = f.create(path="dst", type=libh5.types.native.double, space=space)
+
+    # every cell carries its own row and column, encoded so that either one can be recovered
+    payload = array.array(
+        "d", (float(100 * row + col) for row in range(extent[0]) for col in range(extent[1]))
+    )
+    # lay the whole raster down the ordinary way
+    src.write(payload, libh5.types.native.double, [0, 0], extent)
+
+    # now pull a decimated view: every second row and every fourth column, which is the case
+    # that catches an implementation that assumes one stride for the whole request
+    stride = [2, 4]
+    shape = [8, 4]
+    # somewhere to put the samples; they arrive packed, so the destination is the sample grid
+    sampled = array.array("d", bytes(shape[0] * shape[1] * 8))
+    src.read(sampled, libh5.types.native.double, [1, 3], shape, stride)
+
+    # each sample has to be the cell a caller would have reached for by hand
+    for row in range(shape[0]):
+        for col in range(shape[1]):
+            # the cell this sample was drawn from, walking out from the origin by the stride
+            sourceRow = 1 + row * stride[0]
+            sourceCol = 3 + col * stride[1]
+            # and the value that cell was given when the raster was laid down
+            assert sampled[row * shape[1] + col] == float(100 * sourceRow + sourceCol)
+
+    # asking for no stride at all still means every cell of a solid block, which is what
+    # every existing caller expects to keep getting
+    solid = array.array("d", bytes(cells * 8))
+    src.read(solid, libh5.types.native.double, [0, 0], extent)
+    assert solid[0] == payload[0]
+    assert solid[cells - 1] == payload[cells - 1]
+
+    # the write side scatters: put the samples back into the second dataset at the same
+    # spacing they were drawn from
+    dst.write(sampled, libh5.types.native.double, [1, 3], shape, stride)
+
+    # and read them back one at a time, to confirm they landed where they were aimed rather
+    # than in a packed block at the corner
+    one = array.array("d", bytes(8))
+    for row in range(shape[0]):
+        for col in range(shape[1]):
+            # the slot this sample should have landed in
+            targetRow = 1 + row * stride[0]
+            targetCol = 3 + col * stride[1]
+            # read that single cell
+            dst.read(one, libh5.types.native.double, [targetRow, targetCol], [1, 1])
+            # and it has to carry the value that travelled with it
+            assert one[0] == float(100 * targetRow + targetCol)
+
+    # a stride that does not speak for every axis is refused rather than guessed at; muzzle
+    # the complaint so the suite stays silent on success
+    channel = journal.error("pyre.h5")
+    channel.device = journal.trash()
+    channel.fatal = False
+    # a buffer that would be big enough, so nothing but the stride is wrong here
+    scratch = array.array("d", bytes(shape[0] * shape[1] * 8))
+    src.read(scratch, libh5.types.native.double, [0, 0], shape, [2])
+    # nothing was read, so the buffer is still as it started
+    assert scratch[0] == 0.0
+
+    # clean up
+    f.close()
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # do...
+    test()
+
+
+# end of file

--- a/tests/h5.ext/transfer_list.py
+++ b/tests/h5.ext/transfer_list.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Exercise handing a transfer property list to a read and to a write
+
+    The transfer list is the only place a caller can say what should happen to cells while
+    they are in flight: the size of the conversion buffer, whether checksums are verified,
+    and the data transform, which is an arithmetic expression the library applies to every
+    value as it crosses. Until now one could be built and never used, because every read and
+    write named the library default instead.
+
+    The transform is what makes this visible from a test: with it, the same cells come back
+    different, and the difference is exactly the expression. It also pins the direction --
+    a transform on the way out and a transform on the way in are separate events, and
+    applying one on each is how a round trip can end up back where it started
+    """
+    # get the bindings
+    from pyre.extensions import libh5
+
+    # for a scratch path and a payload
+    import os
+    import array
+
+    # a scratch data product
+    uri = "transfer_list.h5"
+    # make sure a stale one is not lying around
+    if os.path.exists(uri):
+        os.remove(uri)
+
+    # the layout: a handful of cells is plenty to see a transform take effect
+    extent = [4, 4]
+    cells = extent[0] * extent[1]
+
+    # make the file
+    f = libh5.File(uri=uri, mode="w")
+    # describe the extent
+    space = libh5.DataSpace(shape=extent)
+    # a dataset to read back from, and one to write through a transform into
+    src = f.create(path="src", type=libh5.types.native.double, space=space)
+    dst = f.create(path="dst", type=libh5.types.native.double, space=space)
+
+    # cells that count up, so a transform on them is easy to check by eye
+    payload = array.array("d", (float(cell) for cell in range(cells)))
+    # lay them down untouched
+    src.write(payload, libh5.types.native.double, [0, 0], extent)
+
+    # read them back with nothing asked for: the default transfer list leaves them alone
+    plain = array.array("d", bytes(cells * 8))
+    src.read(plain, libh5.types.native.double, [0, 0], extent)
+    assert plain[0] == 0.0
+    assert plain[cells - 1] == float(cells - 1)
+
+    # now read the same cells through a transfer list that triples them on the way across
+    tripling = libh5.properties.dxpl(expression="3*x")
+    tripled = array.array("d", bytes(cells * 8))
+    src.read(tripled, libh5.types.native.double, [0, 0], extent, [], tripling)
+    # every value arrives multiplied, and the file is untouched by any of it
+    for cell in range(cells):
+        assert tripled[cell] == 3.0 * payload[cell]
+
+    # the dataset itself did not change: a transform lives in the transfer, not in the file
+    again = array.array("d", bytes(cells * 8))
+    src.read(again, libh5.types.native.double, [0, 0], extent)
+    assert again[cells - 1] == float(cells - 1)
+
+    # the write side takes one too: send the tripled values out through a transform that
+    # divides by three, which should put the original values in the file
+    thirding = libh5.properties.dxpl(expression="x/3")
+    dst.write(tripled, libh5.types.native.double, [0, 0], extent, [], thirding)
+    # read what landed, plainly, and it has to be what we started with
+    landed = array.array("d", bytes(cells * 8))
+    dst.read(landed, libh5.types.native.double, [0, 0], extent)
+    for cell in range(cells):
+        assert landed[cell] == payload[cell]
+
+    # and a transfer list composes with a stride: the two are independent settings, and the
+    # transform has to apply to the samples the stride picked rather than to all of them
+    stride = [2, 2]
+    shape = [2, 2]
+    sampled = array.array("d", bytes(shape[0] * shape[1] * 8))
+    src.read(sampled, libh5.types.native.double, [0, 0], shape, stride, tripling)
+    # walk the samples the stride would have chosen
+    for row in range(shape[0]):
+        for col in range(shape[1]):
+            # the cell each was drawn from
+            sourceCell = (row * stride[0]) * extent[1] + col * stride[1]
+            # tripled on its way here
+            assert sampled[row * shape[1] + col] == 3.0 * payload[sourceCell]
+
+    # clean up
+    f.close()
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # do...
+    test()
+
+
+# end of file

--- a/tests/h5.lib/dataset_strided.cc
+++ b/tests/h5.lib/dataset_strided.cc
@@ -1,0 +1,111 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+#include <cassert>
+// get the h5 support
+#include <pyre/h5.h>
+
+
+// the block the tile lands in
+using heap_t = pyre::memory::heap_t<double>;
+
+
+// verify that a tile can be read and written visiting only every n-th cell along each axis:
+// the decimated view a zoomed out reader wants, assembled without moving the cells it skips
+int
+main(int argc, char * argv[])
+{
+    // initialize the journal
+    pyre::journal::init(argc, argv);
+    // attribute whatever gets logged to this test
+    pyre::journal::application("dataset_strided");
+
+    // the scratch product
+    auto uri = "dataset_strided.h5";
+    // a scope, so the file closes before the cleanup
+    {
+        // make it
+        pyre::h5::File file { uri, H5F_ACC_TRUNC, {}, {} };
+
+        // a small raster, whose cells will each be made to say where they live so that a
+        // sample can be checked against the coordinate it claims to have come from
+        auto extent = pyre::h5::shape_t { 32, 32 };
+        pyre::h5::DataSpace space { extent };
+        // the cell type the whole exhibit trades in
+        auto cell = pyre::h5::datatype<double>();
+        // a dataset to read back from, and one to scatter into
+        auto src = file.createDataSet(
+            "src", cell, space, pyre::h5::properties::DCPL(), pyre::h5::properties::DAPL());
+        auto dst = file.createDataSet(
+            "dst", cell, space, pyre::h5::properties::DCPL(), pyre::h5::properties::DAPL());
+
+        // room for the whole raster; the block counts its cells with a signed type, so
+        // carry the product across the signedness boundary rather than narrow it silently
+        heap_t whole { static_cast<heap_t::cell_count_type>(extent[0] * extent[1]) };
+        // give every cell its own row and column, encoded so either can be recovered
+        for (std::size_t row = 0; row < extent[0]; ++row) {
+            for (std::size_t col = 0; col < extent[1]; ++col) {
+                // stamp the coordinate into the cell
+                whole[row * extent[1] + col] = static_cast<double>(100 * row + col);
+            }
+        }
+        // lay the raster down the ordinary way
+        pyre::h5::write(src, whole, cell, pyre::h5::shape_t { 0, 0 }, extent);
+
+        // now pull a decimated view: every second row and every fourth column, which is the
+        // case that catches an implementation assuming one stride for the whole request
+        auto stride = pyre::h5::shape_t { 2, 4 };
+        auto shape = pyre::h5::shape_t { 8, 4 };
+        auto origin = pyre::h5::shape_t { 1, 3 };
+        // the samples arrive packed, so the destination holds only as many as come back
+        heap_t sampled { static_cast<heap_t::cell_count_type>(shape[0] * shape[1]) };
+        // take them
+        pyre::h5::read(src, sampled, cell, origin, shape, stride);
+
+        // every sample has to be the cell a caller would have reached for by hand
+        for (std::size_t row = 0; row < shape[0]; ++row) {
+            for (std::size_t col = 0; col < shape[1]; ++col) {
+                // the cell it was drawn from, walking out from the origin by the stride
+                auto sourceRow = origin[0] + row * stride[0];
+                auto sourceCol = origin[1] + col * stride[1];
+                // and the value that cell was given when the raster was laid down
+                auto expected = static_cast<double>(100 * sourceRow + sourceCol);
+                // which is what should have arrived
+                assert((sampled[row * shape[1] + col] == expected));
+            }
+        }
+
+        // the write side scatters: put those samples into the other dataset at the same
+        // spacing they were drawn from
+        pyre::h5::write(dst, sampled, cell, origin, shape, stride);
+
+        // read them back one cell at a time, to confirm they landed where they were aimed
+        // rather than packed into a block at the corner
+        heap_t one { 1 };
+        // go through the samples
+        for (std::size_t row = 0; row < shape[0]; ++row) {
+            for (std::size_t col = 0; col < shape[1]; ++col) {
+                // the slot this sample should have landed in
+                auto targetRow = origin[0] + row * stride[0];
+                auto targetCol = origin[1] + col * stride[1];
+                // read that single cell
+                pyre::h5::read(
+                    dst, one, cell, pyre::h5::shape_t { targetRow, targetCol },
+                    pyre::h5::shape_t { 1, 1 });
+                // and it has to carry the value that travelled with it
+                assert((one[0] == static_cast<double>(100 * targetRow + targetCol)));
+            }
+        }
+    }
+
+    // all done
+    return 0;
+}
+
+
+// end of file


### PR DESCRIPTION
This branch closes a set of coverage gaps in `pyre::h5`, the wrappers over the HDF5 C API. The work began as an audit of the HDF5 dataset interface against what the library, the bindings, and the Python layer actually expose, and it addresses the gaps that audit identified. Virtual datasets were deliberately left out of scope.

Two of the changes are corrections rather than additions, and both concern the same defect. The remainder add capabilities that HDF5 offers and `pyre::h5` did not reach.

## The destination of a tile read

`H5Dread` consults the raw data chunk cache only along the code path that hands over a whole chunk at once, and that path is available only when the destination has the same rank as the source. Describing the destination instead as a flat run of the same number of cells is accepted by the library and returns identical data, so nothing about the result reveals the difference. The library must then scatter the chunk cell by cell, and it inflates the chunk again on every read regardless of what is already resident in the cache. Measured against a compressed NISAR product, this is the difference between repeating a read in roughly 0.03 milliseconds and repeating it in roughly 4.8 milliseconds.

The binding layer carried this defect and has been corrected. The runtime-rank generic `pyre::h5::read` in `lib/h5/datasets.h` carried it as well, and has been corrected separately. That second instance has no callers today, since `qed` reaches HDF5 through the static-rank grid template, which was always correct; it remains public API and is reachable through `readGrid`. Both now describe the destination with the shape of the tile, and both refuse a destination too small to hold it rather than allowing the library to write past the end of a caller's buffer.

## Access property lists on dataset open

`Group::openDataSet` hardwired the library defaults, so the raw data chunk cache of a dataset could not be sized by the code that opened it. A second overload now accepts a `properties::DAPL`, and the single-argument form defers to it with the library defaults. The binding follows the convention already used by `Group::create` and takes a defaulted property list on the existing `dataset` method rather than presenting a second overload.

The accompanying test records a property of HDF5 that is easy to get wrong: the chunk cache belongs to the dataset rather than to the handle, and it is settled by the first open. A second open of a dataset already in hand inherits whatever the first one asked for, in either order. Code that intends to size a cache must therefore do so at first contact.

## The chunk table

A chunked dataset is diced into tiles, but only the tiles that have been written are stored. Knowing which ones exist is considerably cheaper than reading, because a region whose chunks are absent consists entirely of fill values and need not be read at all.

`DataSet` gains three queries. `chunks` reports how many chunks are held, `chunk` addresses the chunk table by index, and `chunkAt` finds the chunk holding a given cell. A new record type, `Chunk`, carries the origin, filter mask, file address, and stored size, and follows the convention already established by `properties::Filter` and `properties::ChunkCache`.

Three aspects of the design follow from the behaviour of the underlying calls rather than from preference. First, `chunks` returns an empty optional for a dataset that is not stored as chunks, because `H5Dget_num_chunks` fails outright in that case and reporting either zero or one would be an invention; a chunked dataset with nothing written reports zero, and the two answers remain distinct. Second, `chunkAt` reports an unwritten chunk as an empty optional rather than passing along the hollow record that `H5Dget_chunk_info_by_coord` produces, so that every `Chunk` handed to a caller describes something that can actually be read. Third, and most consequentially, that same call performs no bounds checking: a coordinate that cannot exist returns success, with the file address set to `HADDR_UNDEF`, which is indistinguishable from a legitimately empty chunk. `pyre::h5` checks the rank and the extent itself, records the complaint on the `pyre.h5` channel, and declines to answer.

The test writes two of sixteen chunks in deliberately reversed order and confirms that the table still reports them ordered by origin, since an index into the table is a cursor over the chunks that exist rather than a durable address.

## Direct chunk access

`H5Dread_chunk` and `H5Dwrite_chunk` move a chunk in the form it is stored in, bypassing the filter pipeline, the datatype conversion, and hyperslab selection. `DataSet::readChunk` and `DataSet::writeChunk` expose them.

`readChunk` sizes the destination itself, from the stored size the chunk table reports, so that a caller cannot supply a buffer too small for the chunk. The buffer is a `std::vector<char>`, newly aliased as `bytes_t`, which allows it to be reused across calls once it is large enough. A new alias was preferred over reusing an existing one because these bytes are not cells of anything until they have been decoded.

These two calls differ from the chunk table in a way worth stating plainly: they refuse any coordinate that is not the chunk's own corner, whereas `H5Dget_chunk_info_by_coord` accepts any cell of a chunk. Rather than expose that inconsistency, both new methods round the coordinate down to the chunk corner. The rank check, the bounds check, and the rounding are now performed by a single private helper that `chunkAt` also uses, so the three cannot diverge in what they accept.

`H5Dread_chunk` is a version-selected macro. HDF5 2.0 introduced a six-argument form that accepts the capacity of the buffer and reports the number of bytes written, while earlier releases provide only a five-argument form that takes the caller's word for it. Since `lib/h5/external.h` declares a floor of 1.14.4, the implementation selects between them on `H5_VERSION_GE(2, 0, 0)` rather than raising the floor. The pre-2.0 branch is safe by construction, because the buffer is sized from the chunk's own storage size immediately beforehand. It could not be compiled on the machine where this work was done, which carries HDF5 2.1.0; forcing the version macro confirmed that the call shape is correct, but the branch has not been exercised against an HDF5 that genuinely selects it. The Ubuntu runners carry HDF5 1.14, so CI will be the first environment to build it.

## Strides

Assembling a decimated view by reading a region at full resolution and discarding most of it moves cells that nobody wanted. A strided selection asks the library to skip them, so that the cost of a zoomed-out view falls with the zoom rather than remaining flat.

The audit anticipated a gap in `DataSpace::slab` that does not exist: the fully specified strided form was already present in the library and already bound. The gap was in the reading and writing of tiles. `pyre::h5::read` and `pyre::h5::write` gain flavours that take a per-axis stride, and the Python `read` and `write` gain an optional `stride` argument that defaults to empty, so that no existing caller is affected. The `shape` argument counts the samples that are returned; the region swept is the shape multiplied by the stride. A stride whose rank does not match the tile is refused rather than guessed at.

Both tests use asymmetric strides, taking every second row and every fourth column, which distinguishes a correct implementation from one that assumes a single stride for the whole request. The write side is verified by reading the scattered cells back individually, rather than by comparing against a packed block.

## Transfer property lists

`properties::DXPL` could be constructed, including with a data transform expression, and was fully bound, but nothing could be done with one: `DataSet::read` and `DataSet::write` both named `H5P_DEFAULT`. Both now accept a transfer property list, defaulting to the library's own settings, and the binding passes the caller's list through.

The transfer property list was deliberately not added to the convenience generics in `lib/h5/datasets.h`. A defaulted trailing argument there would make the existing five-argument call ambiguous against the new one, so it would require four additional overloads in each direction. Since `DataSet::read` and `DataSet::write` are the seam at which the property list reaches the library, C++ callers have the full capability; what they lack relative to Python is the convenience of a single-line call, which is a matter of ergonomics rather than of reach.

The test uses the data transform, since it is the one setting whose effect is observable from outside. Reading through `3*x` returns tripled values, and reading the same dataset plainly afterwards returns the originals, which establishes that the transform belongs to the transfer and not to the file. Writing those tripled values out through `x/3` restores the original contents, which establishes that the two directions are separate events.

## Build maintenance

The cmake build enumerates extension sources by hand, so `extensions/h5/Chunk.cc` has been added to the `h5module` target. The new library headers require no change, since `pyre_h5Lib` collects them with a recursive glob.

Separately, cmake registered no h5 test suites at all. The seven C++ drivers and the fourteen Python drivers, most of which predate this branch, were reachable only through `mm`. Two new modules, `pyre_tests_h5_lib.cmake` and `pyre_tests_h5_ext.cmake`, register them, guarded on `HDF5_FOUND` in the manner already used for GSL, MPI, and PostgreSQL. Each driver that leaves a scratch product behind has a matching sweep, which mirrors the `clean` declarations in `.mm`.

No workflow changes were required. Every workflow that runs tests already installs HDF5, whether through `libhdf5-dev` on the apt-based runners, `hdf5-devel` on Fedora, or `hdf5` in the conda-forge environment specification. The workflows that publish to PyPI build wheels through `cibuildwheel` and do not run the test suites; installing HDF5 there would change what is shipped and was therefore left alone. Because `pr-cmake` invokes `ctest` with only the PostgreSQL suites excluded, the newly registered h5 suites are picked up without any edit to the workflow.

## Verification

Both `mm` suites, `pyre-h5.lib.tests` and `pyre-h5.ext.tests`, pass. The cmake build configures, compiles, installs, and runs sixty-four h5 test cases through `ctest`, all of which pass, with the scratch products swept afterwards. Because the C++ drivers rely on `assert` and are compiled in an optimised build, an assertion was deliberately broken to confirm that the suite is not vacuous; it aborts as expected.

Two things remain unverified locally and are left to CI. The pre-2.0 branch of the direct chunk read has not been compiled against an HDF5 that selects it, and the twenty-one h5 test cases have never previously run in continuous integration, on any platform or against any HDF5 other than 2.1.0.
