### PR TITLE
An event handler that raises does not silence its channel, and a crew member outlives a failing subscriber

### DIFF
--- a/packages/pyre/ipc/Selector.py
+++ b/packages/pyre/ipc/Selector.py
@@ -214,14 +214,31 @@ class Selector(Scheduler, family="pyre.ipc.dispatchers.selector", implements=dis
             # they run accumulates separately instead of being invoked prematurely on
             # this pass
             pile = index.pop(active, [])
-            # invoke the event handlers and save the events whose handlers return {True}
-            events = list(
-                event for event in pile if event.handler(channel=event.channel, **event.context)
-            )
-            # if any handlers requested to be rescheduled
-            if events:
-                # put them back, ahead of whatever interest arrived while they ran
-                index[active][:0] = events
+            # the events whose handlers ask to be rescheduled
+            survivors = []
+            # how many handlers have had their turn
+            done = 0
+            # carefully, since a handler that raises must not take the rest of the pile with
+            # it: the ones that never got their turn are still interested, and losing them
+            # leaves a channel nobody listens to, which is a silent failure
+            try:
+                # go through the handlers
+                for event in pile:
+                    # count this one before it runs, so that if it raises it is the one
+                    # that is dropped
+                    done += 1
+                    # invoke it; a handler that returns {True} asks to be rescheduled
+                    if event.handler(channel=event.channel, **event.context):
+                        # so keep it
+                        survivors.append(event)
+            # whatever happened
+            finally:
+                # the handlers that did not get their turn keep their place
+                survivors += pile[done:]
+                # if anything is going back
+                if survivors:
+                    # put it back, ahead of whatever interest arrived while the handlers ran
+                    index[active][:0] = survivors
         # all done
         return
 

--- a/packages/pyre/ipc/SelectorPSL.py
+++ b/packages/pyre/ipc/SelectorPSL.py
@@ -10,9 +10,12 @@ in the python standard library
 """
 
 # external
+import errno
+import selectors
+
+# support
 import pyre
 import journal
-import selectors
 
 # interface
 from .Dispatcher import Dispatcher
@@ -201,36 +204,57 @@ class SelectorPSL(Scheduler, family="pyre.ipc.dispatchers.psl", implements=Dispa
         pile = index.pop(key, [])
         # make a pile of event handlers to reschedule
         reschedule = []
-        # go through the snapshot
-        for event in pile:
-            # very very carefully
-            try:
-                # invoke the handler
-                keep = event.handler(channel=event.channel, **event.context)
-            # if a transient error occurs
-            except (BlockingIOError, InterruptedError):
-                # let's try this again
-                keep = True
-            # if something more serious happens
-            except OSError as error:
-                # the connection is broken; discarding the handler is the only sane move,
-                # but say so, since silent drops make failures undiagnosable
-                channel = journal.debug("pyre.ipc.psl")
-                # describe what happened
-                channel.line(f"discarding a handler of {event.channel}")
-                channel.line(f"after it raised {error}")
-                # flush
-                channel.log()
-                # and drop it
-                keep = False
-            # keepers
-            if keep:
-                # get rescheduled
-                reschedule.append(event)
-        # if any handlers survived
-        if reschedule:
-            # put them back, ahead of whatever interest arrived while they ran
-            index.setdefault(key, [])[:0] = reschedule
+        # how many handlers have had their turn
+        done = 0
+        # carefully, since a handler that raises something other than an {OSError} must not
+        # take the rest of the pile with it: the ones that never got their turn are still
+        # interested, and losing them leaves a channel nobody listens to
+        try:
+            # go through the snapshot
+            for event in pile:
+                # count this one before it runs, so that if it raises it is the one that is
+                # dropped
+                done += 1
+                # very very carefully
+                try:
+                    # invoke the handler
+                    keep = event.handler(channel=event.channel, **event.context)
+                # if a transient error occurs
+                except (BlockingIOError, InterruptedError):
+                    # let's try this again
+                    keep = True
+                # if something more serious happens
+                except OSError as error:
+                    # discarding the handler is the only sane move, but say so, since a
+                    # silent drop is undiagnosable: a broken connection is routine and goes
+                    # on the debug channel, while a process that has run out of resources,
+                    # e.g. file descriptors, is news that must reach somebody
+                    exhausted = error.errno in (errno.EMFILE, errno.ENFILE, errno.ENOMEM)
+                    # pick the channel accordingly
+                    channel = (
+                        journal.warning("pyre.ipc.psl")
+                        if exhausted
+                        else journal.debug("pyre.ipc.psl")
+                    )
+                    # describe what happened
+                    channel.line(f"discarding a handler of {event.channel}")
+                    channel.line(f"after it raised {error}")
+                    # flush
+                    channel.log()
+                    # and drop it
+                    keep = False
+                # keepers
+                if keep:
+                    # get rescheduled
+                    reschedule.append(event)
+        # whatever happened
+        finally:
+            # the handlers that did not get their turn keep their place
+            reschedule += pile[done:]
+            # if any handlers survived
+            if reschedule:
+                # put them back, ahead of whatever interest arrived while they ran
+                index.setdefault(key, [])[:0] = reschedule
         # all done
         return
 

--- a/packages/pyre/nexus/Crew.py
+++ b/packages/pyre/nexus/Crew.py
@@ -179,31 +179,37 @@ class Crew(Peer, family="pyre.nexus.peers.crew"):
         # show me on the debug channel
         self.debug.log(f"{self.pid}: {memberstatus}, {taskstatus}, {result}")
 
-        # first, let's figure out what to do with the task; if it ran to completion
-        if taskstatus is self.taskcodes.completed:
-            # deliver the result; the team decides what results are for
-            team.collect(task=task, result=result)
-        # if it failed due to some temporary condition
-        elif taskstatus is self.taskcodes.failed:
-            # tell me
-            self.reportRecoverableError(team=team, task=task, error=result)
-            # the team decides whether it gets another chance
-            team.requeue(task=task, error=result)
-        # otherwise, the task aborted
-        else:
-            # deliver the bad news; the team decides how to break it
-            team.abandon(task=task, error=result)
-
-        # now, let's figure out what to do with me; if i'm healthy
-        if memberstatus is self.crewcodes.healthy:
-            # put me back in the work queue
-            team.schedule(crew=self)
-        # otherwise
-        else:
-            # tell me
-            self.reportUnrecoverableError(team=team, task=task, error=result)
-            # dismiss me
-            team.dismiss(crew=self)
+        # first, let's figure out what to do with the task. the delivery runs code that
+        # belongs to whoever asked for the task, and it may fail; my own fate must be
+        # settled regardless, or a failed subscriber leaves me counted as busy with nobody
+        # listening to me, and the team never hands out work again
+        try:
+            # if it ran to completion
+            if taskstatus is self.taskcodes.completed:
+                # deliver the result; the team decides what results are for
+                team.collect(task=task, result=result)
+            # if it failed due to some temporary condition
+            elif taskstatus is self.taskcodes.failed:
+                # tell me
+                self.reportRecoverableError(team=team, task=task, error=result)
+                # the team decides whether it gets another chance
+                team.requeue(task=task, error=result)
+            # otherwise, the task aborted
+            else:
+                # deliver the bad news; the team decides how to break it
+                team.abandon(task=task, error=result)
+        # whatever the delivery did
+        finally:
+            # now, let's figure out what to do with me; if i'm healthy
+            if memberstatus is self.crewcodes.healthy:
+                # put me back in the work queue
+                team.schedule(crew=self)
+            # otherwise
+            else:
+                # tell me
+                self.reportUnrecoverableError(team=team, task=task, error=result)
+                # dismiss me
+                team.dismiss(crew=self)
 
         # all done
         return False

--- a/tests/pyre.pkg/ipc/selector_raise.py
+++ b/tests/pyre.pkg/ipc/selector_raise.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a handler that raises does not take the rest of its channel's handlers with it
+
+The selector takes possession of a channel's handlers before invoking them, so that interest
+registered while they run is not invoked prematurely. A handler that raises unwinds through
+that pass; the handlers that never got their turn are still interested, and losing them
+leaves a channel nobody listens to, which is a silent failure. So the ones that did not run
+keep their place, the one that raised is dropped, and the exception still reaches the caller
+"""
+
+# support
+import pyre
+
+
+# the marker of a handler that fails
+class Failure(Exception):
+    """
+    What the failing handler raises
+    """
+
+
+def test():
+    # a pair of connected channels
+    reader, writer = pyre.ipc.newSocket().open()
+    # a selector
+    selector = pyre.ipc.newPSL()
+    # the record of who ran
+    ran = []
+
+    # a handler that raises
+    def failing(channel, **kwds):
+        """
+        Fail, after noting that i ran
+        """
+        # note
+        ran.append("failing")
+        # and fail
+        raise Failure("the failing handler")
+
+    # a handler that never gets its turn on the first pass
+    def patient(channel, **kwds):
+        """
+        Note that i ran, and ask to stay
+        """
+        # note
+        ran.append("patient")
+        # and stay registered
+        return True
+
+    # register both, the failing one first
+    selector.whenReadReady(channel=reader, call=failing)
+    selector.whenReadReady(channel=reader, call=patient)
+    # make the channel readable
+    writer.write(bytes=b"x")
+    # run the loop, which should raise on the first pass
+    try:
+        # watch
+        selector.watch()
+    # the failure reaches the caller
+    except Failure:
+        # as it should
+        pass
+    # anything else is wrong
+    else:
+        # so complain
+        assert False, "the failing handler did not raise through the loop"
+    # only the failing handler got its turn
+    assert ran == ["failing"]
+    # the patient one kept its place
+    registered = [event.handler for event in selector._read[reader.inbound]]
+    assert patient in registered
+    # and the failing one was dropped
+    assert failing not in registered
+
+    # the alarm that winds down the loop once the patient handler has had its turn
+    def expire(timestamp):
+        """
+        Stop the loop
+        """
+        # stop
+        selector.stop()
+        # and don't reschedule
+        return None
+
+    # let the loop run again; the byte is still there, so the patient handler runs, on every
+    # turn of the loop until the alarm stops it, since nobody consumes the byte
+    selector.alarm(interval=0.1 * pyre.units.SI.second, call=expire)
+    selector.watch()
+    # it ran
+    assert "patient" in ran
+    # the failing one did not run again
+    assert ran.count("failing") == 1
+    # and, having asked to stay, the patient one is still registered
+    assert patient in [event.handler for event in selector._read[reader.inbound]]
+
+    # clean up
+    reader.close()
+    writer.close()
+    # all done
+    return selector
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/nexus/staff_subscriber.py
+++ b/tests/pyre.pkg/nexus/staff_subscriber.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that a subscriber that fails while taking delivery does not cost the team a member
+
+The delivery of a task's outcome runs code that belongs to whoever asked for the task, inside
+the harvest of the member that did the work. If that code raises, the exception reaches the
+event loop's caller, as it should; but the member's own fate must be settled regardless, or it
+stays counted as busy with nobody listening to it, and the team never hands it work again
+"""
+
+# support
+import pyre
+
+# the unit of time
+from pyre.units.SI import second
+
+
+# a task that finishes at once
+class Quick(pyre.nexus.task):
+    """
+    A task with nothing to do
+    """
+
+    # interface
+    def execute(self, **kwds):
+        """
+        The body of the functor
+        """
+        # done already
+        return "done"
+
+
+def test():
+    # build a staff of one
+    staff = pyre.nexus.staff()(name="test.staff.subscriber")
+    staff.size = 1
+    # the outcome drop box
+    outcomes = []
+
+    # a subscriber that fails while taking delivery, the way one that runs out of file
+    # descriptors does
+    def failing(result, error):
+        """
+        Fail on delivery
+        """
+        # note the delivery
+        outcomes.append(("failing", result, error))
+        # and fail
+        raise OSError(24, "Too many open files")
+
+    # a subscriber that takes delivery
+    def record(result, error):
+        """
+        Record the outcome
+        """
+        # file the report
+        outcomes.append(("record", result, error))
+        # all done
+        return
+
+    # the alarm that winds down the event loop
+    def expire(timestamp):
+        """
+        Stop the event loop
+        """
+        # ask the dispatcher to stop
+        staff.dispatcher.stop()
+        # and don't reschedule
+        return None
+
+    # hand over a task whose subscriber fails
+    staff.assign(task=Quick(), callback=failing)
+    # run the loop long enough for the member to be recruited, take the task, and report;
+    # the failure does not reach us: the dispatcher discards a handler that raises an
+    # {OSError}, which is exactly what makes this failure silent in the field
+    staff.dispatcher.alarm(interval=1 * second, call=expire)
+    staff.dispatcher.watch()
+    # the subscriber was served
+    assert outcomes == [("failing", "done", None)]
+
+    # the member that did the work is accounted for: it is on the bench, or on its way there
+    # with a wake-up pending, and in either case not counted as busy with nobody listening
+    (member,) = list(staff.crews())
+    assert member not in staff.active or staff.dispatcher._write.get(member.channel.outbound)
+
+    # a second task, with a subscriber that behaves, completes normally
+    staff.assign(task=Quick(), callback=record)
+    # let the loop run long enough
+    staff.dispatcher.alarm(interval=1 * second, call=expire)
+    staff.dispatcher.watch()
+    # the second outcome arrived
+    assert outcomes[-1] == ("record", "done", None)
+    # send everybody home
+    staff.disband()
+
+    # all done
+    return staff
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file


### PR DESCRIPTION
## Summary

An event handler that raises must not silence the channel it was registered on, and a crew member must be accounted for whatever the code that takes delivery of its result does. Both selectors keep the handlers that never got their turn when one raises, the selector in use reports a handler dropped for want of resources on a warning channel rather than a debug one, and a crew member returns to the schedule in a `finally`. Two tests pin the behaviour.

## The failure this addresses

A qed server whose descriptor table was full stopped serving tiles while its event loop kept turning, its GraphQL endpoint kept answering, and every worker sat idle. The chain was the following. Mapping a tile's payload for the response needs a descriptor; with none left, `mmap` raised `OSError` inside the requester's callback, inside `Staff.collect`, inside the member's `Crew.assess`. `SelectorPSL.dispatch` caught the `OSError`, logged it on `pyre.ipc.psl`, a debug channel that is off by default, and discarded the handler. `assess` had not reached `team.schedule`, so the member stayed in the active roster with no handler on its channel and no wake-up pending. Four reports later every member of the team was in that state, and the team never handed out work again. Nothing was logged at any severity that reaches a terminal.

## `pyre.ipc`

`dispatch` takes possession of a channel's pile of handlers before invoking them, so that interest registered while they run is not invoked prematurely on the same pass. On normal completion it puts back the handlers that asked to stay. When a handler raises something other than an `OSError`, the exception now unwinds through a `finally` that puts back the handlers that never got their turn; the one that raised is dropped, and the exception still reaches the caller of `watch`. This holds for both `Selector` and `SelectorPSL`.

`SelectorPSL.dispatch` still discards a handler that raises an `OSError`, since a broken connection is routine and dropping its handler is the right response. It distinguishes the cause: `EMFILE`, `ENFILE` and `ENOMEM` mean the process has run out of a resource, and those drops go to `journal.warning("pyre.ipc.psl")`; anything else stays on the debug channel.

## `pyre.nexus`

`Crew.assess` delivers the report, then decides the member's fate: a healthy member is put back on the schedule, an unhealthy one is dismissed. The delivery runs code that belongs to whoever asked for the task. The fate is now decided in a `finally`, so a delivery that raises leaves the member on the schedule, with a wake-up pending, rather than counted as busy with nobody listening.

## Tests

`tests/pyre.pkg/ipc/selector_raise.py` registers two read handlers on one channel, the first of which raises. The exception reaches the caller, the second handler is still registered and runs on the next pass, and the first does not run again.

`tests/pyre.pkg/nexus/staff_subscriber.py` assigns a task whose subscriber raises `OSError` on delivery. The dispatcher discards that handler without raising, the member is on the bench or has a wake-up pending, and a second task with a well-behaved subscriber completes.

The `nexus` and `ipc` suites pass.

## Not changed

The bookkeeping of the death watch on a parked member, which can also leave a channel without a read handler when a stale watch fires while the harvester is not registered, is unchanged. It was examined during this diagnosis and found not to be the cause; the counters qed added to its team census, `deaf` and `waking`, are what would show it.
