### PR TITLE
ci, merlin: the conda debug legs compile their checks in, and the mm mirror is brought level

### DIFF
--- a/.github/workflows/pr-conda.yaml
+++ b/.github/workflows/pr-conda.yaml
@@ -34,8 +34,14 @@ jobs:
         exclude:
           - compiler: clang
             cuda: cuda
-        # the conda-forge toolchain packages for each compiler
+        # the debug leg compiles in the developer-time checks, so the test drivers assert what
+        # they claim; the opt leg is a deployment build, and its drivers must still run clean
+        # with the checks compiled out
         include:
+          - target: debug
+            assertions: yes
+          - target: opt
+            assertions: no
           - compiler: gcc
             suite: gcc
             toolchain: gcc gxx
@@ -48,8 +54,9 @@ jobs:
             cxx: clang++
 
     env:
-      # mm discovers its settings from the {mm.yaml} we install into ~/.pyre below
-      mm: python3 ${{github.workspace}}/mm/mm
+      # mm discovers its settings from the {mm.yaml} we install into ~/.pyre below; the assertion
+      # disposition rides on the command line, since the packaging workflow shares that file
+      mm: python3 ${{github.workspace}}/mm/mm --assertions=${{matrix.assertions}}
       target: ${{matrix.target}}
       suite: ${{matrix.suite}}
 

--- a/packages/merlin/shells/MM.py
+++ b/packages/merlin/shells/MM.py
@@ -38,6 +38,10 @@ class MM(pyre.application, family="pyre.applications.mm", namespace="mm"):
     mode.validators = pyre.constraints.isMember("dev", "release", "conda", "macports", "ubuntu", "fedora")
     mode.doc = "the strategy for generating locations for the build products"
 
+    assertions = pyre.properties.bool()
+    assertions.default = None
+    assertions.doc = "compile in the developer-time checks whatever the mode says (False leaves them out; None defers to the mode)"
+
     branch = pyre.properties.bool()
     branch.default = None
     branch.doc = (
@@ -1061,6 +1065,9 @@ class MM(pyre.application, family="pyre.applications.mm", namespace="mm"):
         yield f"project.home={self._root}"
         # the build mode, so the make subsystem can gate behavior on {mode != dev}
         yield f"project.mode={self.mode}"
+        # the assertion disposition; a pinned choice overrides the mode, an unset one defers to it
+        pinned = "" if self.assertions is None else ("yes" if self.assertions else "no")
+        yield f"project.assertions={pinned}"
         # the path to the mm configuration files
         yield f"project.config={self._projectCfg}"
         # the location to place the intermediate build products

--- a/packages/merlin/shells/MM.py
+++ b/packages/merlin/shells/MM.py
@@ -1702,7 +1702,11 @@ class MM(pyre.application, family="pyre.applications.mm", namespace="mm"):
                 "module": "pybind11",
             },
             "pyre": {"candidates": ["pyre"]},
-            "python": {"candidates": ["python"], "handler": "_emitCondaPython", "trim": True},
+            "python": {
+                "candidates": ["python"],
+                "handler": "_emitCondaPython",
+                "trim": True,
+            },
             "slepc": {"candidates": ["slepc"]},
             "sundials": {"candidates": ["sundials"]},
             "vtk": {"candidates": ["vtk"]},

--- a/share/mm/make/modes/init.mm
+++ b/share/mm/make/modes/init.mm
@@ -9,6 +9,14 @@ include make/modes/default.mm
 # the selected mode's overrides; a mode with no file here is a fatal error
 include make/modes/$(project.mode).mm
 
+# the driver may pin the assertion disposition, e.g. to keep the developer-time checks in a
+# deployment layout while testing it: {yes} compiles them in, {no} leaves them out, and an empty
+# value defers to the mode
+project.assertions ?=
+ifneq ($(project.assertions),)
+mode.compiler.assertions := ${filter yes,$(project.assertions)}
+endif
+
 # {mode.compiler} joins the compiler option sources as a flat, language-independent contributor,
 # just like {mm}; declare its full category set so no slot is ever an undefined variable
 mode.compiler.flags :=

--- a/share/mm/make/modes/rules.mm
+++ b/share/mm/make/modes/rules.mm
@@ -13,6 +13,7 @@ mode.info:
 	@${call log.var,locked,$(mode.npm.locked)}
 	@${call log.sec,"  compiler",}
 	@${call log.var,assertions,${if $(mode.compiler.assertions),yes,no}}
+	@${call log.var,pinned,${if $(project.assertions),$(project.assertions),no}}
 	@${call log.var,defines,$(mode.compiler.defines)}
 
 # what the build mode controls and the values it can take
@@ -22,6 +23,10 @@ mode.help: | mm.banner
 	@$(log) "select one on the command line, e.g."
 	@$(log)
 	@$(log) "    mm --mode=release"
+	@$(log)
+	@$(log) "pin the developer-time checks on or off whatever the mode says, e.g."
+	@$(log)
+	@$(log) "    mm --mode=conda --assertions=yes"
 	@$(log)
 	@${call log.help,"mode.info","show the current mode and its resolved settings"}
 	@$(log)

--- a/share/mm/make/tests/rules.mm
+++ b/share/mm/make/tests/rules.mm
@@ -192,10 +192,11 @@ ${if $($(1).post),\
     ${eval $($(1).post) :: $(1).run} \
 }
 
-# clean up the staging area (objects and the binary live here too)
+# clean up the staging area (objects and the binary live here too), plus any leftovers the
+# suite declares in its source tree, e.g. reports dropped by a hand-run of the tool
 $(1).clean::
 	@${call log.action,clean,$(1)}
-	@$(rm.force-recurse) $(_stageroot)
+	@$(rm.force-recurse) $(_stageroot) ${addprefix $($(1).prefix),$($(1).clean)}
 
 # show info
 $(1).info.runner:


### PR DESCRIPTION
The conda workflow's debug legs compile their developer-time checks in, so the test drivers assert what they claim, and the `merlin` mirror of the mm driver and make engine is brought level with mm.

## The conda workflow

The workflow builds with `mode: conda`, so its products land in the conda environment. That mode's baseline leaves the developer-time checks out, which meant both of its legs compiled every `assert` and every `journal` `debug` and `firewall` channel away, and the drivers only ever proved that they ran to completion. mm main now accepts `--assertions=yes|no`, which pins the disposition whatever the mode says (aivazis/mm#53). The matrix gives the debug target `assertions: yes` and the opt target `assertions: no`, and the flag rides on mm's command line rather than in `mm-conda.yaml`, which the packaging workflow shares and which stays a deployment build. The debug legs now check their assertions; the opt legs keep proving that the same drivers run clean with the checks compiled out.

## The merlin mirror

`packages/merlin/shells/MM.py` gains the `assertions` trait and hands `project.assertions` to the engine, as the mm driver does. `share/mm/make/modes/init.mm` and `rules.mm` are copies of mm's, applying the pin right after the mode's file is read and reporting it in `mode.info`. `share/mm/make/tests/rules.mm` picks up mm's per-suite cleanup areas, and one dictionary in the driver takes mm's formatting, so the driver and its twin differ only where they are meant to: the banner, the version source, the launcher-supplied defaults, the bootstrap block, and the makefile trait's name.
