### PR TITLE
pyre::memory: cells in an explicit byte order

### DIFF
--- a/.mm/pyre.ext.tests
+++ b/.mm/pyre.ext.tests
@@ -14,6 +14,8 @@ pyre.ext.tests.prerequisites := pyre.ext
 # sweeps them
 tests.pyre.ext.grid.map.clean := grid_map_test.dat
 tests.pyre.ext.grid.readonly.clean := grid_readonly_test.dat
+tests.pyre.ext.grid.ordered.clean := grid_ordered_test.dat
+tests.pyre.ext.memory.ordered.clean := memory_ordered_test.dat
 
 
 # end of file

--- a/.mm/pyre.lib.tests
+++ b/.mm/pyre.lib.tests
@@ -15,7 +15,7 @@ pyre.lib.tests.c++.flags += -Wall $(pyre.lib.c++.flags)
 
 
 # cleanup
-tests.pyre.lib.grid.clean += grid_map_access.data
+tests.pyre.lib.grid.clean += grid_map_access.data grid_map_foreign.data
 tests.pyre.lib.memory.clean += filemap.dat map.dat map_slice.dat constmap_slice.dat
 tests.pyre.lib.viz.iterators.clean += \
     pyre_viz_iterators_amplitude.bmp pyre_viz_iterators_bmp.bmp pyre_viz_iterators_complex.bmp \

--- a/.mm/pyre.pkg.tests
+++ b/.mm/pyre.pkg.tests
@@ -21,6 +21,7 @@ tests.pyre.pkg.h5.api.writer.clean := writer.h5
 tests.pyre.pkg.h5.api.file_create_empty.clean := file_create_empty.h5
 tests.pyre.pkg.h5.api.raster_roundtrip.clean := raster_roundtrip.h5
 tests.pyre.pkg.h5.api.raster_value.clean := raster_value.h5
+tests.pyre.pkg.memory.ordered.clean := memory_ordered_test.dat
 
 
 # the {filesystem.local-make} test modifies the current directory, which creates race

--- a/extensions/pyre/grid/__init__.cc
+++ b/extensions/pyre/grid/__init__.cc
@@ -29,11 +29,12 @@ namespace pyre::py::grid {
     // its shape carries one signed extent per axis
     using shape_t = packing_t::shape_type;
 
-    // choose a cell type from its pyre memory cell name and hand it to a callable that is
-    // templated on that type; this keeps the twelve-way dispatch in one place, and the return
-    // type is deduced so both grid and mosaic factories can ride it
+    // choose a native cell type from its pyre memory cell name and hand it to a callable that
+    // is templated on that type; this keeps the twelve-way dispatch in one place, and the
+    // return type is deduced so both grid and mosaic factories can ride it; {requested} is the
+    // name the caller actually used, for the complaint
     template <class F>
-    auto dispatchCell(const string_t & cell, F && f)
+    auto dispatchBase(const string_t & cell, const string_t & requested, F && f)
     {
         // signed integers
         if (cell == "int8")
@@ -67,10 +68,41 @@ namespace pyre::py::grid {
         // anything else is a caller mistake
         auto channel = pyre::journal::error_t("pyre.grid.bindings");
         // complain
-        channel << pyre::journal::at() << "unsupported grid cell type '" << cell << "'"
+        channel << pyre::journal::at() << "unsupported grid cell type '" << requested << "'"
                 << pyre::journal::endl;
         // and refuse
-        throw py::value_error("unsupported grid cell type '" + cell + "'");
+        throw py::value_error("unsupported grid cell type '" + requested + "'");
+    }
+
+    // choose a cell type from its name, honoring a trailing byte order marker: {float64be} is a
+    // big endian double, {uint16le} a little endian unsigned short; a marker that names the
+    // host's own order collapses to the native cell, so only foreign order data pays for the
+    // wrapper
+    template <class F>
+    auto dispatchCell(const string_t & cell, F && f)
+    {
+        // the marker is the last two characters, if there is room for a base name before them
+        if (cell.size() > 2) {
+            // split the name
+            auto base = cell.substr(0, cell.size() - 2);
+            auto marker = cell.substr(cell.size() - 2);
+            // big endian
+            if (marker == "be") {
+                // wrap the base cell in the big endian spelling
+                return dispatchBase(base, cell, [&]<class T>() {
+                    return f.template operator()<pyre::memory::big_t<T>>();
+                });
+            }
+            // little endian
+            if (marker == "le") {
+                // wrap the base cell in the little endian spelling
+                return dispatchBase(base, cell, [&]<class T>() {
+                    return f.template operator()<pyre::memory::little_t<T>>();
+                });
+            }
+        }
+        // no marker: the name is a native cell
+        return dispatchBase(cell, cell, std::forward<F>(f));
     }
 
 

--- a/extensions/pyre/grid/__init__.cc
+++ b/extensions/pyre/grid/__init__.cc
@@ -65,12 +65,9 @@ namespace pyre::py::grid {
         if (cell == "complex128")
             return f.template operator()<pyre::memory::complex128_t>();
 
-        // anything else is a caller mistake
-        auto channel = pyre::journal::error_t("pyre.grid.bindings");
-        // complain
-        channel << pyre::journal::at() << "unsupported grid cell type '" << requested << "'"
-                << pyre::journal::endl;
-        // and refuse
+        // anything else is a caller mistake; refuse it the way the other factories refuse bad
+        // arguments, with a python exception and no journal entry, since a fatal error channel
+        // would preempt the exception
         throw py::value_error("unsupported grid cell type '" + requested + "'");
     }
 

--- a/extensions/pyre/memory/accessors.icc
+++ b/extensions/pyre/memory/accessors.icc
@@ -21,6 +21,9 @@ pyre::py::memory::accessors(pymem_t<T> & cls) -> void
     using mem_t = T;
     // and views derived from it
     using view_t = pyre::memory::View<typename mem_t::value_type, mem_t::readonly()>;
+    // the native scalar behind the cell, which is what python sees; a byte ordered cell swaps on
+    // the way through, so python never meets the wrapper
+    using native_t = pyre::memory::native_t<typename mem_t::value_type>;
 
     // metamethods
     cls.def(
@@ -36,8 +39,10 @@ pyre::py::memory::accessors(pymem_t<T> & cls) -> void
         "__iter__",
         // the implementation
         [](const mem_t & self) {
-            // make an iterator and return it
-            return py::make_iterator(self.begin(), self.end());
+            // make an iterator that lifts each cell to its native value, and return it
+            return py::make_iterator<
+                py::return_value_policy::reference_internal, decltype(self.begin()),
+                decltype(self.end()), native_t>(self.begin(), self.end());
         },
         // keep the storage around while its iterator is in use
         py::keep_alive<0, 1>());
@@ -48,9 +53,9 @@ pyre::py::memory::accessors(pymem_t<T> & cls) -> void
         "__getitem__",
         // the implementation
         // &mem_t::at,
-        [](const mem_t & self, int idx) -> typename mem_t::value_type {
-            // get the value
-            auto value = self.at(idx);
+        [](const mem_t & self, int idx) -> native_t {
+            // get the value, as a native scalar
+            native_t value = self.at(idx);
             // and return it
             return value;
         },

--- a/extensions/pyre/memory/buffer_protocol.icc
+++ b/extensions/pyre/memory/buffer_protocol.icc
@@ -30,8 +30,8 @@ pyre::py::memory::bufferProtocol(pymem_t<T> & cls)
                 const_cast<typename mem_t::value_type *>(mem.data()),
                 // the size of the cell
                 sizeof(typename mem_t::value_type),
-                // the format descriptor
-                py::format_descriptor<typename mem_t::value_type>::format(),
+                // the format descriptor, byte order marker and all
+                format<typename mem_t::value_type>(),
                 // the number of dimensions: memory buffers are flat
                 1,
                 // the shape

--- a/extensions/pyre/memory/buffers.cc
+++ b/extensions/pyre/memory/buffers.cc
@@ -26,6 +26,8 @@ pyre::py::memory::buffers::__init__(py::module & memory)
     using buffers_t = pyre::memory::buffers_t;
     // build the classes
     expand(buffers, buffers_t {});
+    // and the ones over the foreign order scalars
+    expand(buffers, pyre::memory::foreignbuffers_t {});
 
     // all done
     return;

--- a/extensions/pyre/memory/cells.cc
+++ b/extensions/pyre/memory/cells.cc
@@ -33,8 +33,16 @@ pyre::py::memory::cells::__init__(py::module & memory) -> void
 
     // get the pile of cell types
     using cells_t = pyre::memory::cells_t;
+    // the foreign order cell types
+    using foreigncells_t = pyre::memory::foreigncells_t;
+    // and the scalars wide enough to have a byte order
+    using widetypes_t = pyre::memory::widetypes_t;
     // build the classes
     expand(cells, cells_t {});
+    // the foreign order cells are distinct classes
+    expand(cells, foreigncells_t {});
+    // while the native order spellings are just other names for the native classes
+    aliases(cells, widetypes_t {});
 
     // all done
     return;

--- a/extensions/pyre/memory/cells.h
+++ b/extensions/pyre/memory/cells.h
@@ -25,6 +25,13 @@ namespace pyre::py::memory::cells {
     template <class cellT>
     inline auto cell(py::module & m) -> void;
 
+    // the native order alias registrar
+    template <class... T>
+    inline auto aliases(py::module &, pyre::typelists::types_t<T...> &&) -> void;
+    // the native order alias builder
+    template <class T>
+    inline auto alias(py::module & m) -> void;
+
     // the class docstring
     template <class cellT>
     inline auto docstring() -> string_t;

--- a/extensions/pyre/memory/cells.icc
+++ b/extensions/pyre/memory/cells.icc
@@ -54,6 +54,39 @@ pyre::py::memory::cells::cell(py::module & memory) -> void
 }
 
 
+// the native order alias registrar
+template <typename... T>
+auto
+pyre::py::memory::cells::aliases(py::module & memory, pyre::typelists::types_t<T...> &&) -> void
+{
+    // register the aliases
+    (alias<T>(memory), ...);
+    // all done
+    return;
+}
+
+
+// the native order alias builder
+template <class T>
+auto
+pyre::py::memory::cells::alias(py::module & memory) -> void
+{
+    // the byte order marker for the host's own order
+    auto marker = std::endian::native == std::endian::big ? "BE" : "LE";
+    // the mutable and const spellings of the scalar's name
+    for (auto suffix : { "", "Const" }) {
+        // the native cell's name
+        auto native = pyre::memory::cellname_t<T>::name() + suffix;
+        // and the ordered spelling of it
+        auto ordered = pyre::memory::cellname_t<T>::name() + marker + suffix;
+        // the host's own order needs no wrapper, so the ordered name is the native class
+        memory.attr(ordered.data()) = memory.attr(native.data());
+    }
+    // all done
+    return;
+}
+
+
 // the docstring builder
 template <class cellT>
 auto

--- a/extensions/pyre/memory/external.h
+++ b/extensions/pyre/memory/external.h
@@ -12,6 +12,8 @@
 #include "../external.h"
 // get the pyre parts
 #include <pyre/memory.h>
+// the buffer protocol description of a cell type, byte order marker and all
+#include <pyre/py/memory/format.h>
 
 
 // end of file

--- a/extensions/pyre/memory/heaps.cc
+++ b/extensions/pyre/memory/heaps.cc
@@ -26,6 +26,8 @@ pyre::py::memory::heaps::__init__(py::module & memory)
     using heaps_t = pyre::memory::heaps_t;
     // build the classes
     expand(heaps, heaps_t {});
+    // and the ones over the foreign order scalars
+    expand(heaps, pyre::memory::foreignheaps_t {});
 
     // all done
     return;

--- a/extensions/pyre/memory/interface.icc
+++ b/extensions/pyre/memory/interface.icc
@@ -19,13 +19,18 @@ pyre::py::memory::interface(pymem_t<T> & cls) -> void
 {
     // alias the storage strategy
     using mem_t = T;
+    // the native scalar behind the cell, which is what python hands over
+    using native_t = pyre::memory::native_t<typename mem_t::value_type>;
 
     // fill the buffer with a value
     cls.def(
         // the name
         "fill",
         // the implementation
-        &mem_t::fill,
+        [](const mem_t & self, native_t value) -> const mem_t & {
+            // fill, converting to the cell on the way in, and return the buffer
+            return self.fill(value);
+        },
         // signature
         "value"_a,
         // the docstring

--- a/extensions/pyre/memory/maps.cc
+++ b/extensions/pyre/memory/maps.cc
@@ -26,6 +26,8 @@ pyre::py::memory::maps::__init__(py::module & memory)
     using maps_t = pyre::memory::maps_t;
     // build the classes
     expand(maps, maps_t {});
+    // and the ones over the foreign order scalars
+    expand(maps, pyre::memory::foreignmaps_t {});
 
     // all done
     return;

--- a/extensions/pyre/memory/mutators.icc
+++ b/extensions/pyre/memory/mutators.icc
@@ -19,12 +19,15 @@ pyre::py::memory::mutators(pymem_t<T> & cls) -> void
 {
     // alias the storage strategy
     using mem_t = T;
+    // the native scalar behind the cell, which is what python hands over; a byte ordered cell
+    // swaps on the way in
+    using native_t = pyre::memory::native_t<typename mem_t::value_type>;
 
     cls.def(
         // the name
         "__setitem__",
         // the implementation
-        [](mem_t & self, typename mem_t::size_type index, typename mem_t::value_type value) {
+        [](mem_t & self, typename mem_t::size_type index, native_t value) {
             // set the {value} at {index}
             self.at(index) = value;
             // all done

--- a/extensions/pyre/memory/views.cc
+++ b/extensions/pyre/memory/views.cc
@@ -27,6 +27,8 @@ pyre::py::memory::views::__init__(py::module & memory)
     using views_t = pyre::memory::views_t;
     // build the classes
     expand(views, views_t {});
+    // and the ones over the foreign order scalars
+    expand(views, pyre::memory::foreignviews_t {});
 
     // all done
     return;

--- a/lib/pyre/memory/Cell.icc
+++ b/lib/pyre/memory/Cell.icc
@@ -190,5 +190,23 @@ struct pyre::memory::CellName<pyre::memory::complex128_t> {
     inline static auto decl() -> string_t { return "std::complex<std::double_t>"; }
 };
 
+// byte ordered cells carry the name of the scalar they wrap, tagged with their order
+template <typename T, std::endian order>
+struct pyre::memory::CellName<pyre::memory::Ordered<T, order>> {
+    // the name
+    inline static auto name() -> string_t
+    {
+        // the scalar's name with the byte order marker
+        return CellName<T>::name() + (order == std::endian::big ? "BE" : "LE");
+    }
+    // c++ decl string
+    inline static auto decl() -> string_t
+    {
+        // spelled through the api alias
+        return string_t("pyre::memory::") + (order == std::endian::big ? "big_t<" : "little_t<")
+             + CellName<T>::decl() + ">";
+    }
+};
+
 
 // end of file

--- a/lib/pyre/memory/Ordered.h
+++ b/lib/pyre/memory/Ordered.h
@@ -1,0 +1,120 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// externals
+#include "externals.h"
+// forward declarations
+#include "forward.h"
+
+
+// a scalar whose bytes sit in memory in a fixed byte order, whatever the host's
+//
+// a cell of this type reads as the native scalar and accepts one on assignment, swapping bytes
+// on the way through, so a grid over foreign-order data works cell for cell like a native one;
+// it is trivially copyable and exactly as wide as the scalar it stands in for, so it can lay
+// over memory mapped files and travel through {std::memset} and friends unharmed
+//
+// you rarely spell this class out: {ordered_t} in api.h collapses to the plain scalar when the
+// requested order is the host's, so only cells that actually need swapping pay for the wrapper
+template <typename T, std::endian order>
+class pyre::memory::Ordered {
+    // the host must be one or the other; mixed-endian machines have no place to stand
+    static_assert(
+        std::endian::native == std::endian::big || std::endian::native == std::endian::little,
+        "byte ordered cells require a big or little endian host");
+    // and the scalar must be copyable byte by byte, or the swap makes no sense
+    static_assert(std::is_trivially_copyable_v<T>, "byte ordered cells wrap trivial scalars");
+
+    // types
+public:
+    // me
+    using self_type = Ordered<T, order>;
+    // the native scalar i stand in for
+    using value_type = T;
+    // my bytes, exactly as they sit in memory
+    using bytes_type = std::array<std::byte, sizeof(T)>;
+    // sizes of things
+    using size_type = size_t;
+
+    // metamethods
+public:
+    // an indeterminate value, exactly like the scalar i stand in for
+    constexpr Ordered() = default;
+    // adopt a native value, storing its bytes in my order
+    constexpr Ordered(value_type value);
+
+    // special members
+    constexpr Ordered(const Ordered &) = default;
+    constexpr Ordered(Ordered &&) = default;
+    constexpr Ordered & operator=(const Ordered &) = default;
+    constexpr Ordered & operator=(Ordered &&) = default;
+    ~Ordered() = default;
+
+    // operators
+public:
+    // read as the native value
+    constexpr operator value_type() const;
+    // accept a native value
+    constexpr auto operator=(value_type value) -> self_type &;
+    // compound assignment, through the native value
+    constexpr auto operator+=(value_type value) -> self_type &;
+    constexpr auto operator-=(value_type value) -> self_type &;
+    constexpr auto operator*=(value_type value) -> self_type &;
+    constexpr auto operator/=(value_type value) -> self_type &;
+
+    // interface
+public:
+    // the byte order of my storage
+    static constexpr auto endianness() -> std::endian;
+    // whether my bytes happen to be in the host's order
+    static constexpr auto native() -> bool;
+    // the number of independently ordered scalars i hold: two for complex, one otherwise
+    static constexpr auto components() -> size_type;
+    // my value in the host's order
+    constexpr auto value() const -> value_type;
+    // my bytes as they sit in memory
+    constexpr auto bytes() const -> bytes_type;
+
+    // implementation details
+private:
+    // convert a native value to my byte order
+    static constexpr auto encode(value_type value) -> bytes_type;
+    // convert bytes in my order to a native value
+    static constexpr auto decode(bytes_type bytes) -> value_type;
+    // reverse the bytes of each component, which is what takes a value between the two orders
+    static constexpr auto swap(bytes_type bytes) -> bytes_type;
+
+    // data
+private:
+    // the value, in my byte order
+    bytes_type _bytes;
+};
+
+
+// the native scalar behind a cell value type
+// the general case: a type is its own native scalar
+template <typename T>
+struct pyre::memory::Native {
+    // easy
+    using type = T;
+};
+
+// and the ordered wrapper stands in for the scalar it wraps
+template <typename T, std::endian order>
+struct pyre::memory::Native<pyre::memory::Ordered<T, order>> {
+    // unwrap
+    using type = T;
+};
+
+
+// get the inline definitions
+#include "Ordered.icc"
+
+
+// end of file

--- a/lib/pyre/memory/Ordered.icc
+++ b/lib/pyre/memory/Ordered.icc
@@ -1,0 +1,210 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// the declarations
+#include "Ordered.h"
+
+
+// metamethods
+// adopt a native value, storing its bytes in my order
+template <typename T, std::endian order>
+constexpr pyre::memory::Ordered<T, order>::Ordered(value_type value) : _bytes { encode(value) }
+{}
+
+
+// operators
+// read as the native value
+template <typename T, std::endian order>
+constexpr pyre::memory::Ordered<T, order>::
+operator value_type() const
+{
+    // decode my bytes
+    return value();
+}
+
+
+// accept a native value
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::operator=(value_type value) -> self_type &
+{
+    // store its bytes in my order
+    _bytes = encode(value);
+    // all done
+    return *this;
+}
+
+
+// compound assignment: read as native, combine, and store back in my order
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::operator+=(value_type value) -> self_type &
+{
+    // fold in the contribution
+    return *this = this->value() + value;
+}
+
+
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::operator-=(value_type value) -> self_type &
+{
+    // take out the contribution
+    return *this = this->value() - value;
+}
+
+
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::operator*=(value_type value) -> self_type &
+{
+    // scale
+    return *this = this->value() * value;
+}
+
+
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::operator/=(value_type value) -> self_type &
+{
+    // scale down
+    return *this = this->value() / value;
+}
+
+
+// interface
+// the byte order of my storage
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::endianness() -> std::endian
+{
+    // easy
+    return order;
+}
+
+
+// whether my bytes happen to be in the host's order
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::native() -> bool
+{
+    // compare against the host
+    return order == std::endian::native;
+}
+
+
+// the number of independently ordered scalars i hold
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::components() -> size_type
+{
+    // a complex value is a pair of scalars, each in its own byte order
+    if constexpr (complex_c<value_type>) {
+        // so there are two
+        return 2;
+    }
+    // everything else is a single scalar
+    return 1;
+}
+
+
+// my value in the host's order
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::value() const -> value_type
+{
+    // decode my bytes
+    return decode(_bytes);
+}
+
+
+// my bytes as they sit in memory
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::bytes() const -> bytes_type
+{
+    // easy
+    return _bytes;
+}
+
+
+// implementation details
+// convert a native value to my byte order
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::encode(value_type value) -> bytes_type
+{
+    // take the value apart into its native bytes
+    auto bytes = std::bit_cast<bytes_type>(value);
+    // if my order is the host's
+    if constexpr (order == std::endian::native) {
+        // the bytes are already right
+        return bytes;
+    }
+    // otherwise, reverse them
+    return swap(bytes);
+}
+
+
+// convert bytes in my order to a native value
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::decode(bytes_type bytes) -> value_type
+{
+    // if my order is the host's
+    if constexpr (order == std::endian::native) {
+        // the bytes assemble directly into the value
+        return std::bit_cast<value_type>(bytes);
+    }
+    // otherwise, reverse them first
+    return std::bit_cast<value_type>(swap(bytes));
+}
+
+
+// reverse the bytes of each component
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::Ordered<T, order>::swap(bytes_type bytes) -> bytes_type
+{
+    // the width of one component
+    constexpr size_type width = sizeof(value_type) / components();
+    // go through the components
+    for (size_type component = 0; component < components(); ++component) {
+        // the span of this component
+        auto first = bytes.begin() + component * width;
+        auto last = first + width;
+        // reverse it in place; a complex value swaps its two scalars separately, never as a whole
+        std::reverse(first, last);
+    }
+    // hand back the swapped bytes
+    return bytes;
+}
+
+
+// comparisons; needed because the operators for complex scalars are templates, which template
+// argument deduction never reaches through the implicit conversion to the native value
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::operator==(const Ordered<T, order> & lhs, const Ordered<T, order> & rhs) -> bool
+{
+    // compare the native values
+    return lhs.value() == rhs.value();
+}
+
+
+template <typename T, std::endian order>
+constexpr auto
+pyre::memory::operator==(const Ordered<T, order> & lhs, const T & rhs) -> bool
+{
+    // compare the native values
+    return lhs.value() == rhs;
+}
+
+
+// end of file

--- a/lib/pyre/memory/api.h
+++ b/lib/pyre/memory/api.h
@@ -24,6 +24,26 @@ namespace pyre::memory {
     template <typename T>
     using cellname_t = CellName<T>;
 
+    // a scalar stored in a fixed byte order; it collapses to the plain scalar when that order is
+    // the host's, or when the scalar is a single byte, so only cells that actually need swapping
+    // pay for the wrapper
+    template <typename T, std::endian order>
+    using ordered_t =
+        std::conditional_t<order == std::endian::native || sizeof(T) == 1, T, Ordered<T, order>>;
+    // big endian, the network and IEEE order
+    template <typename T>
+    using big_t = ordered_t<T, std::endian::big>;
+    // little endian, the intel order
+    template <typename T>
+    using little_t = ordered_t<T, std::endian::little>;
+    // whichever order the host does not use; the one that always needs swapping
+    template <typename T>
+    using foreign_t = ordered_t<
+        T, std::endian::native == std::endian::big ? std::endian::little : std::endian::big>;
+    // the native scalar behind a cell value type
+    template <typename T>
+    using native_t = typename Native<T>::type;
+
     // block on the stack
     template <int D, typename T>
     using stack_t = Stack<D, T, false>;

--- a/lib/pyre/memory/expansions.h
+++ b/lib/pyre/memory/expansions.h
@@ -70,6 +70,53 @@ namespace pyre::memory {
 
     // the pile of cell types
     using cells_t = typename celltypes_t<basetypes_t>::type;
+    // the cell types wide enough to have a byte order
+    using widetypes_t = pyre::typelists::types_t<
+        // signed integers
+        int16_t, int32_t, int64_t,
+        // unsigned integers
+        uint16_t, uint32_t, uint64_t,
+        // floating point
+        float32_t, float64_t,
+        // complex
+        complex64_t, complex128_t>;
+    // the same scalars in the byte order the host does not use; the native order needs no wrapper
+    // so these are the only ordered cells that exist as distinct types
+    using foreigntypes_t = pyre::typelists::types_t<
+        // signed integers
+        foreign_t<int16_t>, foreign_t<int32_t>, foreign_t<int64_t>,
+        // unsigned integers
+        foreign_t<uint16_t>, foreign_t<uint32_t>, foreign_t<uint64_t>,
+        // floating point
+        foreign_t<float32_t>, foreign_t<float64_t>,
+        // complex
+        foreign_t<complex64_t>, foreign_t<complex128_t>>;
+    // the pile of foreign order cell types
+    using foreigncells_t = typename celltypes_t<foreigntypes_t>::type;
+    // base buffers over the foreign order scalars
+    using foreignbuffers_t = typename pyre::typelists::apply_t<
+        // the buffers
+        pyre::typelists::templates_t<buffer_t, constbuffer_t>,
+        // the cells
+        typename storageCells_t<foreigntypes_t>::type>::type;
+    // heaps over the foreign order scalars
+    using foreignheaps_t = typename pyre::typelists::apply_t<
+        // the heaps
+        pyre::typelists::templates_t<heap_t, constheap_t>,
+        // the cells
+        typename storageCells_t<foreigntypes_t>::type>::type;
+    // maps over the foreign order scalars
+    using foreignmaps_t = typename pyre::typelists::apply_t<
+        // the maps
+        pyre::typelists::templates_t<map_t, constmap_t>,
+        // the cells
+        typename storageCells_t<foreigntypes_t>::type>::type;
+    // views over the foreign order scalars
+    using foreignviews_t = typename pyre::typelists::apply_t<
+        // the views
+        pyre::typelists::templates_t<view_t, constview_t>,
+        // the cells
+        typename storageCells_t<foreigntypes_t>::type>::type;
 
     // base buffers
     using buffers_t = typename pyre::typelists::apply_t<

--- a/lib/pyre/memory/externals.h
+++ b/lib/pyre/memory/externals.h
@@ -12,6 +12,10 @@
 #include <stdexcept>
 #include <algorithm>
 #include <array>
+#include <bit>
+#include <concepts>
+#include <cstddef>
+#include <type_traits>
 #include <complex>
 #include <fstream>
 #include <memory>

--- a/lib/pyre/memory/forward.h
+++ b/lib/pyre/memory/forward.h
@@ -18,6 +18,10 @@ namespace pyre::memory {
     template <typename T, bool isConst>
     class Cell;
 
+    // a scalar stored in a fixed byte order, whatever the host's
+    template <typename T, std::endian order>
+    class Ordered;
+
     // block on the stack
     template <int D, typename T, bool isConst>
     class Stack;
@@ -54,6 +58,13 @@ namespace pyre::memory {
     // inequality
     template <class memT>
     constexpr auto operator!=(const Slice<memT> &, const Slice<memT> &) -> bool;
+
+    // byte ordered cells compare through their native values
+    template <typename T, std::endian order>
+    constexpr auto operator==(const Ordered<T, order> &, const Ordered<T, order> &) -> bool;
+    // also against a native value
+    template <typename T, std::endian order>
+    constexpr auto operator==(const Ordered<T, order> &, const T &) -> bool;
 } // namespace pyre::memory
 
 
@@ -70,6 +81,16 @@ namespace pyre::memory {
     // generator of a human readable name for each supported datatype
     template <typename T>
     struct CellName;
+
+    // the native scalar behind a cell value type: the type itself, unless it is a byte ordered
+    // wrapper, in which case the scalar it wraps
+    template <typename T>
+    struct Native;
+
+    // recognize complex scalars, whose two components swap bytes independently
+    template <typename T>
+    concept complex_c = requires { typename T::value_type; }
+                     && std::same_as<T, std::complex<typename T::value_type>>;
 } // namespace pyre::memory
 
 

--- a/lib/pyre/memory/public.h
+++ b/lib/pyre/memory/public.h
@@ -19,6 +19,8 @@
 
 // implementation
 #include "Cell.h"
+// scalars in a fixed byte order
+#include "Ordered.h"
 // bas class for memory buffers
 #include "Buffer.h"
 // memory block on the stack

--- a/lib/pyre/py/grid/AnyGrid.icc
+++ b/lib/pyre/py/grid/AnyGrid.icc
@@ -22,6 +22,9 @@ pyre::py::grid::describe(
     using value_t = typename gridT::value_type;
     // the writable spelling of it, so a read-only source still yields a compilable writer
     using cell_t = std::remove_const_t<value_t>;
+    // and the native scalar behind it, which is what python sees; a byte ordered cell swaps on
+    // the way through, so python never meets the wrapper
+    using native_t = pyre::memory::native_t<cell_t>;
     // and the layout
     const auto & packing = grid.packing();
 
@@ -43,13 +46,13 @@ pyre::py::grid::describe(
 
     // lift one cell from memory into python, knowing its type here where it is still concrete
     AnyGrid::reader_type read = [](const void * p) -> py::object {
-        // interpret the address as a cell and cast it across
-        return py::cast(*static_cast<const cell_t *>(p));
+        // interpret the address as a cell, read it as a native value, and cast it across
+        return py::cast(static_cast<native_t>(*static_cast<const cell_t *>(p)));
     };
     // deposit one cell from python into memory, its companion
     AnyGrid::writer_type write = [](void * p, const py::object & v) -> void {
-        // interpret the address as a cell and assign the converted value
-        *static_cast<cell_t *>(p) = v.cast<cell_t>();
+        // interpret the address as a cell and assign the converted native value
+        *static_cast<cell_t *>(p) = v.cast<native_t>();
         // all done
         return;
     };
@@ -60,8 +63,8 @@ pyre::py::grid::describe(
         data,
         // one cell is this wide
         sizeof(value_t),
-        // described by this struct code
-        py::format_descriptor<value_t>::format(),
+        // described by this struct code, byte order marker and all
+        pyre::py::memory::format<value_t>(),
         // over this shape
         std::move(shape),
         // with these strides

--- a/lib/pyre/py/grid/AnyMosaic.icc
+++ b/lib/pyre/py/grid/AnyMosaic.icc
@@ -91,11 +91,13 @@ pyre::py::grid::anyMosaic(const gridT & mosaic, string_t cell) -> AnyMosaic
 
     // name the cell type while it is still concrete, in its writable spelling
     using cell_t = std::remove_const_t<typename gridT::value_type>;
+    // and the native scalar behind it, which is what python sees
+    using native_t = pyre::memory::native_t<cell_t>;
 
     // lift the cell at an index into python; the caller has verified that its page is resident
     AnyMosaic::reader_type read = [owner](const AnyMosaic::index_type & index) -> py::object {
-        // pull the cell through the mosaic's own map and cast it across
-        return py::cast((*owner)[index]);
+        // pull the cell through the mosaic's own map, read it as a native value, and cast it across
+        return py::cast(static_cast<native_t>((*owner)[index]));
     };
     // deposit a python value into the cell at an index, its companion
     AnyMosaic::writer_type write =
@@ -104,8 +106,8 @@ pyre::py::grid::anyMosaic(const gridT & mosaic, string_t cell) -> AnyMosaic
         auto ordinal = owner->packing().tileOrdinal(owner->packing().tileOf(index));
         // materialize it, in case this is its first touch
         owner->storage().reside(ordinal);
-        // deposit the converted value through the mosaic's own map
-        (*owner)[index] = value.cast<cell_t>();
+        // deposit the converted native value through the mosaic's own map
+        (*owner)[index] = value.cast<native_t>();
         // the write is a divergence this closure can see, so record it
         owner->storage().taint(ordinal);
         // all done

--- a/lib/pyre/py/grid/externals.h
+++ b/lib/pyre/py/grid/externals.h
@@ -24,6 +24,8 @@
 // the grid vocabulary and the storage strategies the erased classes travel over
 #include <pyre/grid.h>
 #include <pyre/memory.h>
+// the buffer protocol description of a cell type
+#include <pyre/py/memory/format.h>
 
 
 // type aliases

--- a/lib/pyre/py/memory/externals.h
+++ b/lib/pyre/py/memory/externals.h
@@ -1,0 +1,33 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// externals
+#include <bit>
+#include <string>
+
+// the format codes describe cells to the python buffer protocol, so this layer depends on
+// pybind11 by construction; it is the python-support tier of the library, never included by
+// the pure c++ surface
+#include <pybind11/pybind11.h>
+#include <pybind11/complex.h>
+
+// the cell types being described
+#include <pyre/memory.h>
+
+
+// type aliases
+namespace pyre::py {
+    // import {pybind11}
+    namespace py = pybind11;
+    // strings
+    using string_t = std::string;
+} // namespace pyre::py
+
+
+// end of file

--- a/lib/pyre/py/memory/format.h
+++ b/lib/pyre/py/memory/format.h
@@ -1,0 +1,20 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// externals
+#include "externals.h"
+// forward declarations
+#include "forward.h"
+
+
+// get the inline definitions
+#include "format.icc"
+
+
+// end of file

--- a/lib/pyre/py/memory/format.icc
+++ b/lib/pyre/py/memory/format.icc
@@ -1,0 +1,35 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// the declarations
+#include "format.h"
+
+
+// the struct module code for a cell type
+template <typename cellT>
+auto
+pyre::py::memory::format() -> string_t
+{
+    // the value type, in its writable spelling
+    using value_t = std::remove_const_t<cellT>;
+    // and the native scalar behind it
+    using native_t = pyre::memory::native_t<value_t>;
+    // the code for the scalar itself
+    auto code = py::format_descriptor<native_t>::format();
+    // if the cell is a byte ordered wrapper
+    if constexpr (!std::is_same_v<value_t, native_t>) {
+        // lead with the marker for its order, so consumers that understand the protocol swap
+        return (value_t::endianness() == std::endian::big ? ">" : "<") + code;
+    }
+    // otherwise, a native cell needs no marker
+    return code;
+}
+
+
+// end of file

--- a/lib/pyre/py/memory/forward.h
+++ b/lib/pyre/py/memory/forward.h
@@ -1,0 +1,23 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// externals
+#include "externals.h"
+
+
+// set up the namespace
+namespace pyre::py::memory {
+    // the struct module code that describes a cell type to the python buffer protocol, with the
+    // byte order marker a foreign order cell needs
+    template <typename cellT>
+    inline auto format() -> string_t;
+} // namespace pyre::py::memory
+
+
+// end of file

--- a/packages/pyre/grid/__init__.py
+++ b/packages/pyre/grid/__init__.py
@@ -25,6 +25,12 @@ reads or writes one cell, while a partial or sliced index returns a sub-grid ove
 memory. A grid also presents the buffer protocol, so a consumer that speaks it reaches the cells
 directly, with no copy. The grid keeps its cells alive for as long as any view or sub-grid holds
 on, so {g} may go out of scope while one of them is still in use.
+
+A cell name may carry a byte order marker, as in {float64be} or {uint16le}. A grid over such
+cells swaps bytes on every access, so a data product written on a machine of the other
+endianness reads correctly in place, and the buffer protocol description carries the marker so
+consumers that understand it, such as numpy, see the right values too. A marker that names the
+host's own order costs nothing. Without a marker, cells are in the host's order.
 """
 
 # pull in pyre so we can reach the bindings

--- a/packages/pyre/memory/cells.py
+++ b/packages/pyre/memory/cells.py
@@ -58,5 +58,69 @@ if cells:
     complexFloatConst = cells.ComplexFloatConst
     complexDoubleConst = cells.ComplexDoubleConst
 
+    # cells in an explicit byte order; the spelling that matches the host's order is the native
+    # cell itself, the other one swaps bytes on every access
+    # big endian
+    # signed integral types
+    int16BE = cells.Int16BE
+    int32BE = cells.Int32BE
+    int64BE = cells.Int64BE
+    # unsigned integral types
+    uint16BE = cells.UInt16BE
+    uint32BE = cells.UInt32BE
+    uint64BE = cells.UInt64BE
+    # floats
+    floatBE = cells.FloatBE
+    doubleBE = cells.DoubleBE
+    # complex
+    complexFloatBE = cells.ComplexFloatBE
+    complexDoubleBE = cells.ComplexDoubleBE
+    # const versions
+    # signed integral types
+    int16BEConst = cells.Int16BEConst
+    int32BEConst = cells.Int32BEConst
+    int64BEConst = cells.Int64BEConst
+    # unsigned integral types
+    uint16BEConst = cells.UInt16BEConst
+    uint32BEConst = cells.UInt32BEConst
+    uint64BEConst = cells.UInt64BEConst
+    # floats
+    floatBEConst = cells.FloatBEConst
+    doubleBEConst = cells.DoubleBEConst
+    # complex
+    complexFloatBEConst = cells.ComplexFloatBEConst
+    complexDoubleBEConst = cells.ComplexDoubleBEConst
+
+    # little endian
+    # signed integral types
+    int16LE = cells.Int16LE
+    int32LE = cells.Int32LE
+    int64LE = cells.Int64LE
+    # unsigned integral types
+    uint16LE = cells.UInt16LE
+    uint32LE = cells.UInt32LE
+    uint64LE = cells.UInt64LE
+    # floats
+    floatLE = cells.FloatLE
+    doubleLE = cells.DoubleLE
+    # complex
+    complexFloatLE = cells.ComplexFloatLE
+    complexDoubleLE = cells.ComplexDoubleLE
+    # const versions
+    # signed integral types
+    int16LEConst = cells.Int16LEConst
+    int32LEConst = cells.Int32LEConst
+    int64LEConst = cells.Int64LEConst
+    # unsigned integral types
+    uint16LEConst = cells.UInt16LEConst
+    uint32LEConst = cells.UInt32LEConst
+    uint64LEConst = cells.UInt64LEConst
+    # floats
+    floatLEConst = cells.FloatLEConst
+    doubleLEConst = cells.DoubleLEConst
+    # complex
+    complexFloatLEConst = cells.ComplexFloatLEConst
+    complexDoubleLEConst = cells.ComplexDoubleLEConst
+
 
 # end of file

--- a/tests/pyre.ext/grid/ordered.py
+++ b/tests/pyre.ext/grid/ordered.py
@@ -143,11 +143,6 @@ def bad():
     # the grid bindings
     from pyre.extensions.pyre import grid
 
-    # the journal, to silence the complaint
-    import journal
-
-    # quiet the error channel
-    journal.error("pyre.grid.bindings").active = False
     # carefully
     try:
         # ask for a cell that does not exist

--- a/tests/pyre.ext/grid/ordered.py
+++ b/tests/pyre.ext/grid/ordered.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def heap():
+    """
+    Build heap grids over byte ordered cells and confirm their bytes sit in the declared order
+    while their cells read as native values
+    """
+    # the grid bindings
+    from pyre.extensions.pyre import grid
+
+    # a value whose two bytes differ
+    value = 0x0102
+    # in each explicit order
+    for marker, expected, code in [("be", b"\x01\x02", ">H"), ("le", b"\x02\x01", "<H")]:
+        # make a grid
+        g = grid.heap(shape=[1], cell=f"uint16{marker}")
+        # write through the erased class
+        g[0] = value
+        # read back; the value must come through the swap
+        assert g[0] == value
+        # the raw bytes must be in the declared order, whatever the host
+        assert bytes(g) == expected
+        # and the buffer protocol description carries the order marker, except when the
+        # marker names the host's own order, in which case the cell is the native one
+        assert memoryview(g).format in (code, code[1:])
+    # all done
+    return
+
+
+def map():
+    """
+    Map a data product written in each byte order and confirm that declaring the right order
+    yields the values, while declaring the wrong one yields their byte swapped shadows
+    """
+    # the grid bindings
+    from pyre.extensions.pyre import grid
+
+    # for packing the product
+    import struct
+
+    # for a scratch path and its cleanup
+    import os
+
+    # a scratch data product
+    uri = "grid_ordered_test.dat"
+    # make sure a stale one is not lying around
+    if os.path.exists(uri):
+        os.remove(uri)
+
+    # the shape
+    shape = [2, 3]
+    # the values, each with two distinct bytes
+    values = [0x0100 * (i + 1) + (i + 1) for i in range(6)]
+    # their byte swapped shadows
+    shadows = [((v & 0xFF) << 8) | (v >> 8) for v in values]
+
+    # for each byte order
+    for marker, other, code in [("be", "le", ">"), ("le", "be", "<")]:
+        # write the product in this order
+        with open(uri, "wb") as product:
+            # pack
+            product.write(struct.pack(f"{code}{len(values)}H", *values))
+        # map it read-only, declaring the matching order
+        g = grid.map(uri=uri, shape=shape, cell=f"uint16{marker}", create=False, writable=False)
+        # every cell reads as its value
+        assert [g[i, j] for i in range(2) for j in range(3)] == values
+        # map it again, declaring the other order
+        h = grid.map(uri=uri, shape=shape, cell=f"uint16{other}", create=False, writable=False)
+        # every cell reads as the shadow of its value
+        assert [h[i, j] for i in range(2) for j in range(3)] == shadows
+        # let go
+        del g, h
+
+        # map it for writing, declaring the matching order
+        w = grid.map(uri=uri, shape=shape, cell=f"uint16{marker}", create=False)
+        # change a cell
+        w[1, 2] = 0xABCD
+        # it reads right back
+        assert w[1, 2] == 0xABCD
+        # flush
+        del w
+        # the file must hold the new value in the declared order
+        with open(uri, "rb") as product:
+            # unpack
+            stored = struct.unpack(f"{code}{len(values)}H", product.read())
+        # check
+        assert stored[5] == 0xABCD
+        # and the rest are untouched
+        assert list(stored[:5]) == values[:5]
+
+    # all done
+    return
+
+
+def numpy():
+    """
+    Confirm that numpy, when available, honors the byte order marker in the buffer description
+    """
+    # the grid bindings
+    from pyre.extensions.pyre import grid
+
+    # numpy is optional
+    try:
+        # get it
+        import numpy
+    # if it's not there
+    except ImportError:
+        # there is nothing to check
+        return
+
+    # a value with distinct bytes
+    value = 0x0102
+    # in each explicit order
+    for marker in ["be", "le"]:
+        # make a grid
+        g = grid.heap(shape=[2, 2], cell=f"uint16{marker}")
+        # fill it
+        for i in range(2):
+            for j in range(2):
+                g[i, j] = value + 2 * i + j
+        # view it through numpy, without copying
+        a = numpy.asarray(g)
+        # numpy must see the same native values
+        assert a[1, 1] == value + 3
+        # write through numpy
+        a[0, 0] = 0x0304
+        # and the grid must see the write, through its own swap
+        assert g[0, 0] == 0x0304
+    # all done
+    return
+
+
+def bad():
+    """
+    Confirm that a marker on an unknown base cell is refused with the name the caller used
+    """
+    # the grid bindings
+    from pyre.extensions.pyre import grid
+
+    # the journal, to silence the complaint
+    import journal
+
+    # quiet the error channel
+    journal.error("pyre.grid.bindings").active = False
+    # carefully
+    try:
+        # ask for a cell that does not exist
+        grid.heap(shape=[1], cell="float6be")
+    # the refusal
+    except ValueError as error:
+        # must name what was asked for
+        assert "float6be" in str(error)
+    # anything else
+    else:
+        # is a failure
+        assert False, "unsupported cell name was accepted"
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the tests
+    heap()
+    map()
+    numpy()
+    bad()
+
+
+# end of file

--- a/tests/pyre.ext/memory/cells.py
+++ b/tests/pyre.ext/memory/cells.py
@@ -105,12 +105,68 @@ def complexCells() -> None:
     return
 
 
+def orderedCells() -> None:
+    """
+    Sanity test: make sure the bindings for byte ordered cells are present, that the spelling
+    that matches the host is the native cell, and that the other one is a distinct class
+    """
+    # access the memory bindings
+    from pyre.extensions.pyre.memory import cells
+
+    # the host's byte order
+    import sys
+
+    # the marker that names the host's order, and the one that names the other
+    native, foreign = ("LE", "BE") if sys.byteorder == "little" else ("BE", "LE")
+    # access rights
+    const = ["", "Const"]
+    # the scalars wide enough to have a byte order
+    scalars = [
+        ("Int16", 16),
+        ("Int32", 32),
+        ("Int64", 64),
+        ("UInt16", 16),
+        ("UInt32", 32),
+        ("UInt64", 64),
+        ("Float", 32),
+        ("Double", 64),
+        ("ComplexFloat", 64),
+        ("ComplexDouble", 128),
+    ]
+
+    # go through them
+    for perm, (scalar, size) in itertools.product(const, scalars):
+        # the native cell
+        plain = getattr(cells, f"{scalar}{perm}")
+        # the spelling that matches the host is another name for it
+        assert getattr(cells, f"{scalar}{native}{perm}") is plain
+        # the other spelling is its own class
+        name = f"{scalar}{foreign}{perm}"
+        cell = getattr(cells, name)
+        # that is not the native cell
+        assert cell is not plain
+        # with the right name
+        assert name == cell.__name__
+        # the same size
+        assert size == cell.bits
+        assert size == 8 * cell.bytes
+        # the same access rights
+        assert perm == ("" if cell.mutable else "Const")
+        # and a declaration that spells out the order
+        marker = "big_t" if foreign == "BE" else "little_t"
+        assert marker in cell.declValue
+
+    # all done
+    return
+
+
 # main
 if __name__ == "__main__":
     # run the tests
     intCells()
     floatCells()
     complexCells()
+    orderedCells()
 
 
 # end of file

--- a/tests/pyre.ext/memory/ordered.py
+++ b/tests/pyre.ext/memory/ordered.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import itertools
+import struct
+import sys
+
+# the scalars wide enough to have a byte order
+scalars = [
+    # ints
+    "Int16",
+    "Int32",
+    "Int64",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    # floats
+    "Float",
+    "Double",
+    # complex
+    "ComplexFloat",
+    "ComplexDouble",
+]
+# the marker that names the order the host lacks
+foreign = "BE" if sys.byteorder == "little" else "LE"
+# and the struct code for it
+code = ">" if foreign == "BE" else "<"
+
+
+def presence():
+    """
+    Verify that the buffer, heap, map, and view expansions over the foreign order cells are all
+    present, in both access modes
+    """
+    # get the memory bindings
+    from pyre.extensions.pyre import memory
+
+    # the storage strategies
+    strategies = ["Buffer", "Heap", "Map", "View"]
+    # given access rights
+    permissions = ["", "Const"]
+    # go through all combinations
+    for strategy, scalar, permission in itertools.product(strategies, scalars, permissions):
+        # the module that holds the class
+        module = getattr(memory, f"{strategy.lower()}s")
+        # the class name
+        name = f"{strategy}{scalar}{foreign}{permission}"
+        # verify it is present
+        cls = getattr(module, name)
+        # and that it reports its name
+        assert cls.__name__ == name
+
+    # all done
+    return
+
+
+def heaps():
+    """
+    Verify that a heap over foreign order cells reads and writes native values while its bytes sit
+    in the declared order
+    """
+    # get the heap bindings
+    from pyre.extensions.pyre.memory import heaps
+
+    # a value whose two bytes differ
+    value = 0x0102
+    # the number of cells
+    cells = 4
+    # make a heap over foreign order cells
+    heap = getattr(heaps, f"HeapUInt16{foreign}")(cells=cells)
+    # it reports its size
+    assert len(heap) == cells
+    # fill it
+    heap.fill(value)
+    # every cell reads as the value
+    assert list(heap) == [value] * cells
+    # write a different value
+    heap[3] = 0x0304
+    # and read it back
+    assert heap[3] == 0x0304
+    # the buffer description carries the order marker
+    assert memoryview(heap).format == f"{code}H"
+    # and the raw bytes are in the declared order
+    assert bytes(heap) == struct.pack(f"{code}4H", value, value, value, 0x0304)
+    # a slice is a view over the same cells, in the same order
+    view = heap[1:3]
+    assert type(view).__name__ == f"ViewUInt16{foreign}"
+    assert list(view) == [value, value]
+    assert memoryview(view).format == f"{code}H"
+    # and writes through the view land in the heap
+    view[0] = 7
+    assert heap[1] == 7
+
+    # all done
+    return
+
+
+def complexHeaps():
+    """
+    Verify that a heap over foreign order complex cells swaps each component on its own
+    """
+    # get the heap bindings
+    from pyre.extensions.pyre.memory import heaps
+
+    # make a heap over foreign order complex cells
+    heap = getattr(heaps, f"HeapComplexFloat{foreign}")(cells=2)
+    # write
+    heap[0] = 1.5 - 2j
+    heap[1] = 3 + 4j
+    # read back
+    assert list(heap) == [1.5 - 2j, 3 + 4j]
+    # the buffer description carries the order marker
+    assert memoryview(heap).format == f"{code}Zf"
+    # and the raw bytes are the components, each in the declared order
+    assert bytes(heap) == struct.pack(f"{code}4f", 1.5, -2, 3, 4)
+
+    # all done
+    return
+
+
+def maps():
+    """
+    Verify that a map over foreign order cells reads a product written in that order and writes
+    back in the same order
+    """
+    # get the map bindings
+    from pyre.extensions.pyre.memory import maps
+
+    # the scratch product
+    uri = "memory_ordered_test.dat"
+    # the values
+    values = [1, 2, 3, 0x1234]
+    # write the product in the foreign order
+    with open(uri, "wb") as product:
+        product.write(struct.pack(f"{code}4H", *values))
+
+    # map it read-only
+    const = getattr(maps, f"MapUInt16{foreign}Const")(uri)
+    # every cell reads as its value
+    assert list(const) == values
+    # and the description says so
+    assert memoryview(const).format == f"{code}H"
+    assert memoryview(const).readonly
+    # let go
+    del const
+
+    # map it for writing
+    writable = getattr(maps, f"MapUInt16{foreign}")(uri, True)
+    # change a cell
+    writable[0] = 0xABCD
+    # and read it back
+    assert writable[0] == 0xABCD
+    # flush
+    del writable
+    # the file must hold the new value in the foreign order
+    with open(uri, "rb") as product:
+        stored = struct.unpack(f"{code}4H", product.read())
+    assert list(stored) == [0xABCD] + values[1:]
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the tests
+    presence()
+    heaps()
+    complexHeaps()
+    maps()
+
+
+# end of file

--- a/tests/pyre.lib/grid/grid_map_foreign.cc
+++ b/tests/pyre.lib/grid/grid_map_foreign.cc
@@ -1,0 +1,128 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+// get the grid
+#include <pyre/grid.h>
+// and the storage strategies
+#include <pyre/memory.h>
+
+
+// the parts of the grid under test: a canonical layout over a file whose cells were written in
+// the byte order the host lacks
+using value_t = pyre::memory::uint16_t;
+using cell_t = pyre::memory::foreign_t<value_t>;
+using canonical_t = pyre::grid::canonical_t<2>;
+using map_t = pyre::memory::map_t<cell_t>;
+using constmap_t = pyre::memory::constmap_t<cell_t>;
+using grid_t = pyre::grid::grid_t<canonical_t, map_t>;
+using constgrid_t = pyre::grid::grid_t<canonical_t, constmap_t>;
+// and the pieces used to address it
+using shape_t = canonical_t::shape_type;
+using index_t = canonical_t::index_type;
+// the bytes of one cell
+using bytes_t = std::array<std::byte, sizeof(value_t)>;
+
+
+// the bytes of a value as a machine of the other endianness would write them
+static auto
+swapped(value_t value) -> bytes_t
+{
+    // take the value apart
+    auto bytes = std::bit_cast<bytes_t>(value);
+    // and reverse it
+    std::reverse(bytes.begin(), bytes.end());
+    // all done
+    return bytes;
+}
+
+
+// verify that a grid over byte ordered cells reads a foreign order data product in place, and
+// writes back in the same order
+int
+main(int argc, char * argv[])
+{
+    // initialize the journal
+    pyre::journal::init(argc, argv);
+    // attribute whatever gets logged to this test
+    pyre::journal::application("grid_map_foreign");
+
+    // the file that backs this grid
+    const char * uri = "grid_map_foreign.data";
+    // pick a shape
+    constexpr shape_t shape { 3, 4 };
+    // lay it out canonically
+    const canonical_t packing { shape };
+
+    // write the product the way a machine of the other endianness would: each cell holds its
+    // own offset, with its bytes reversed relative to this host
+    {
+        // open the file
+        std::ofstream product(uri, std::ios::binary);
+        // go through the cells
+        for (auto offset = 0; offset < packing.cells(); ++offset) {
+            // the foreign bytes of this cell
+            auto bytes = swapped(static_cast<value_t>(offset));
+            // write them
+            product.write(reinterpret_cast<const char *>(bytes.data()), bytes.size());
+        }
+    }
+
+    // map the product read-only, over byte ordered cells
+    {
+        // open
+        const constmap_t store = constmap_t::open(uri);
+        // the file holds exactly the cells of the grid
+        assert((store.cells() == packing.cells()));
+        // make a grid over it
+        const constgrid_t grid { packing, store };
+        // every cell must read as its own offset, in native form
+        for (auto it = grid.packing().begin(); it != grid.packing().end(); ++it) {
+            // the value has to come through the swap
+            assert((grid[*it] == static_cast<value_t>(packing.offset(*it))));
+        }
+        // spot check a cell whose two bytes differ
+        assert((grid[index_t { 2, 3 }] == 11));
+    }
+
+    // map it for writing and change a cell
+    {
+        // open
+        const map_t store = map_t::open(uri, true);
+        // make a grid over it
+        const grid_t grid { packing, store };
+        // write a value with distinguishable bytes
+        grid[index_t { 1, 1 }] = 0x1234;
+        // and read it right back
+        assert((grid[index_t { 1, 1 }] == 0x1234));
+    }
+
+    // the file must now hold the new value in the foreign order
+    {
+        // open the file
+        std::ifstream product(uri, std::ios::binary);
+        // seek to the cell
+        product.seekg(packing.offset(index_t { 1, 1 }) * sizeof(value_t));
+        // read its bytes
+        bytes_t bytes;
+        product.read(reinterpret_cast<char *>(bytes.data()), bytes.size());
+        // they must be the swapped form of the value
+        assert((bytes == swapped(0x1234)));
+    }
+
+    // done with the backing file
+    std::remove(uri);
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.lib/memory/ordered_complex.cc
+++ b/tests/pyre.lib/memory/ordered_complex.cc
@@ -1,0 +1,70 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// get the memory
+#include <pyre/memory.h>
+// support
+#include <cassert>
+
+
+// the pieces under test: a complex scalar in the order the host lacks
+using complex_t = pyre::memory::complex64_t;
+using foreign_t = pyre::memory::foreign_t<complex_t>;
+// the bytes of one component
+using component_t = std::array<std::byte, sizeof(float)>;
+// and of the whole value
+using bytes_t = std::array<std::byte, sizeof(complex_t)>;
+
+
+// verify that a byte ordered complex scalar swaps each component on its own, never the pair as
+// a whole
+int
+main(int argc, char * argv[])
+{
+    // initialize the journal
+    pyre::journal::init(argc, argv);
+    pyre::journal::application("ordered_complex");
+
+    // a value with distinguishable parts
+    const complex_t value { 1.5f, -2.0f };
+    // in the foreign order
+    const foreign_t foreign = value;
+
+    // it knows it holds two scalars
+    assert((foreign.components() == 2));
+    // it reads back as the value
+    assert((foreign == value));
+    assert((foreign.value() == value));
+    // and casting it makes the native arithmetic available
+    assert((static_cast<complex_t>(foreign) * 2.0f == complex_t(3.0f, -4.0f)));
+
+    // the expected byte layout: each component's native bytes, reversed, in the original order
+    auto real = std::bit_cast<component_t>(value.real());
+    auto imag = std::bit_cast<component_t>(value.imag());
+    std::reverse(real.begin(), real.end());
+    std::reverse(imag.begin(), imag.end());
+    // assemble
+    bytes_t expected;
+    std::copy(real.begin(), real.end(), expected.begin());
+    std::copy(imag.begin(), imag.end(), expected.begin() + real.size());
+    // compare
+    assert((foreign.bytes() == expected));
+
+    // writes go through the same path
+    foreign_t other;
+    other = complex_t { 0.25f, 4.0f };
+    assert((other == complex_t(0.25f, 4.0f)));
+    // as does compound assignment
+    other += complex_t { 1.0f, 1.0f };
+    assert((other == complex_t(1.25f, 5.0f)));
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.lib/memory/ordered_heap.cc
+++ b/tests/pyre.lib/memory/ordered_heap.cc
@@ -1,0 +1,74 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// get the memory
+#include <pyre/memory.h>
+// support
+#include <cassert>
+
+
+// the pieces under test: a heap block of scalars in the order the host lacks
+using value_t = pyre::memory::int32_t;
+using cell_t = pyre::memory::foreign_t<value_t>;
+using heap_t = pyre::memory::heap_t<cell_t>;
+// and the bytes of one cell
+using bytes_t = std::array<std::byte, sizeof(value_t)>;
+
+
+// verify that a memory block over byte ordered cells reads and writes native values while
+// keeping its bytes in the declared order
+int
+main(int argc, char * argv[])
+{
+    // initialize the journal
+    pyre::journal::init(argc, argv);
+    pyre::journal::application("ordered_heap");
+
+    // the number of cells
+    const std::size_t cells = 256ul;
+    // make a block on the heap
+    heap_t block(cells);
+    // the block is as wide as the same number of native scalars
+    assert((block.bytes() == cells * sizeof(value_t)));
+
+    // stamp every cell with its own offset, as a native value
+    value_t offset = 0;
+    for (auto & cell : block) {
+        // through the wrapper
+        cell = offset++;
+    }
+
+    // read them all back
+    offset = 0;
+    for (auto cell : block) {
+        // each cell must hold the native value it was given
+        assert((cell == offset++));
+    }
+
+    // look at the raw bytes of a cell: they are the native bytes, reversed
+    const value_t sample = 0x0a0b0c0d;
+    block[cells / 2] = sample;
+    auto expected = std::bit_cast<bytes_t>(sample);
+    std::reverse(expected.begin(), expected.end());
+    assert((std::bit_cast<bytes_t>(block.data()[cells / 2]) == expected));
+    // while the cell itself reads as the native value
+    assert((block[cells / 2] == sample));
+
+    // fill the whole block with one value
+    block.fill(-17);
+    // and check
+    for (auto cell : block) {
+        // every cell agrees
+        assert((cell == -17));
+    }
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.lib/memory/ordered_sanity.cc
+++ b/tests/pyre.lib/memory/ordered_sanity.cc
@@ -1,0 +1,103 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// get the memory
+#include <pyre/memory.h>
+// support
+#include <cassert>
+
+
+// the pieces under test: a scalar in each explicit byte order, and in the order the host lacks
+using big_t = pyre::memory::big_t<pyre::memory::uint32_t>;
+using little_t = pyre::memory::little_t<pyre::memory::uint32_t>;
+using foreign_t = pyre::memory::foreign_t<pyre::memory::uint32_t>;
+// the bytes of one such scalar
+using bytes_t = std::array<std::byte, sizeof(pyre::memory::uint32_t)>;
+
+
+// the spelling that matches the host is the plain scalar, so only the other one is a wrapper
+static_assert(std::is_same_v<
+              pyre::memory::ordered_t<pyre::memory::uint32_t, std::endian::native>,
+              pyre::memory::uint32_t>);
+static_assert(!std::is_same_v<foreign_t, pyre::memory::uint32_t>);
+// single byte scalars have no order, so they never get wrapped
+static_assert(std::is_same_v<pyre::memory::big_t<pyre::memory::uint8_t>, pyre::memory::uint8_t>);
+static_assert(std::is_same_v<pyre::memory::little_t<pyre::memory::int8_t>, pyre::memory::int8_t>);
+// the wrapper is exactly as wide as the scalar and travels byte by byte
+static_assert(sizeof(foreign_t) == sizeof(pyre::memory::uint32_t));
+static_assert(std::is_trivially_copyable_v<foreign_t>);
+// and the native scalar behind each spelling is the same
+static_assert(std::is_same_v<pyre::memory::native_t<foreign_t>, pyre::memory::uint32_t>);
+static_assert(
+    std::is_same_v<pyre::memory::native_t<pyre::memory::uint32_t>, pyre::memory::uint32_t>);
+
+
+// verify that a byte ordered scalar stores its bytes in the declared order and reads back as
+// the native value
+int
+main(int argc, char * argv[])
+{
+    // initialize the journal
+    pyre::journal::init(argc, argv);
+    pyre::journal::application("ordered_sanity");
+
+    // a value whose bytes are all distinct
+    const pyre::memory::uint32_t value = 0x01020304;
+
+    // the same value in each explicit order
+    const big_t big = value;
+    const little_t little = value;
+    // both read back as the value
+    assert((big == value));
+    assert((little == value));
+    // and their bytes sit in memory in the declared order, whatever the host
+    assert(
+        (std::bit_cast<bytes_t>(big)
+         == bytes_t { std::byte { 1 }, std::byte { 2 }, std::byte { 3 }, std::byte { 4 } }));
+    assert(
+        (std::bit_cast<bytes_t>(little)
+         == bytes_t { std::byte { 4 }, std::byte { 3 }, std::byte { 2 }, std::byte { 1 } }));
+
+    // the foreign spelling is a wrapper; exercise its interface
+    foreign_t foreign = value;
+    // it knows it is not in the host's order
+    assert((!foreign.native()));
+    // it holds one scalar
+    assert((foreign.components() == 1));
+    // it reads back as the value, both implicitly and explicitly
+    assert((foreign == value));
+    assert((foreign.value() == value));
+    // and its bytes are the host's bytes, reversed
+    auto native = std::bit_cast<bytes_t>(value);
+    std::reverse(native.begin(), native.end());
+    assert((foreign.bytes() == native));
+
+    // assignment from a native value
+    foreign = 7;
+    assert((foreign == 7u));
+    // compound assignment goes through the native value
+    foreign += 3;
+    assert((foreign == 10u));
+    foreign -= 4;
+    assert((foreign == 6u));
+    foreign *= 5;
+    assert((foreign == 30u));
+    foreign /= 3;
+    assert((foreign == 10u));
+    // and arithmetic in an expression sees the native value
+    assert((foreign * 2 == 20u));
+
+    // copies compare equal to each other
+    const foreign_t copy = foreign;
+    assert((copy == foreign));
+
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/tests/pyre.pkg/memory/cells.py
+++ b/tests/pyre.pkg/memory/cells.py
@@ -114,12 +114,64 @@ def complexCells() -> None:
     return
 
 
+def orderedCells() -> None:
+    """
+    Sanity test: make sure the byte ordered cells are published under their python names
+    """
+    # access the cell types
+    from pyre.memory import cells
+
+    # the host's byte order
+    import sys
+
+    # the marker that names the host's order
+    native = "LE" if sys.byteorder == "little" else "BE"
+    # access rights
+    const = ["", "Const"]
+    # byte order markers
+    markers = ["BE", "LE"]
+    # the scalars wide enough to have a byte order, with the names they report
+    scalars = [
+        ("int16", "Int16", 16),
+        ("int32", "Int32", 32),
+        ("int64", "Int64", 64),
+        ("uint16", "UInt16", 16),
+        ("uint32", "UInt32", 32),
+        ("uint64", "UInt64", 64),
+        ("float", "Float", 32),
+        ("double", "Double", 64),
+        ("complexFloat", "ComplexFloat", 64),
+        ("complexDouble", "ComplexDouble", 128),
+    ]
+
+    # go through them
+    for perm, marker, (scalar, tag, size) in itertools.product(const, markers, scalars):
+        # assemble the name in the module
+        name = f"{scalar}{marker}{perm}"
+        # the name the cell reports: the host's own order is the native cell
+        cellName = f"{tag}{perm}" if marker == native else f"{tag}{marker}{perm}"
+        # verify that the cell exists
+        cell = getattr(cells, name)
+        # check the name
+        assert cellName == cell.__name__
+        # check the size, in bits
+        assert size == cell.bits
+        # check the size, in bytes
+        assert size == 8 * cell.bytes
+        # check the access rights
+        assert perm == ("" if cell.mutable else "Const")
+
+    # all done
+    return
+
+
 # main
 if __name__ == "__main__":
     # run the tests
     intCells()
     floatCells()
     complexCells()
+    orderedCells()
 
 
 # end of file

--- a/tests/pyre.pkg/memory/ordered.py
+++ b/tests/pyre.pkg/memory/ordered.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import struct
+import sys
+
+# the marker that names the order the host lacks
+foreign = "BE" if sys.byteorder == "little" else "LE"
+# and the struct code for it
+code = ">" if foreign == "BE" else "<"
+
+
+def heap():
+    """
+    Verify that the heap factory allocates over byte ordered cells, in both spellings
+    """
+    # get the package
+    import pyre
+    from pyre.memory import cells
+
+    # a cell in the order the host lacks
+    cell = getattr(cells, f"uint16{foreign}")()
+    # allocate
+    heap = pyre.memory.heap(type=cell, cells=4)
+    # the class is the foreign order one
+    assert type(heap).__name__ == f"HeapUInt16{foreign}"
+    # fill and read back as native values
+    heap.fill(0x0102)
+    assert list(heap) == [0x0102] * 4
+    # while the bytes sit in the declared order
+    assert bytes(heap) == struct.pack(f"{code}4H", *([0x0102] * 4))
+
+    # a cell in the host's own order is the native cell
+    native = "LE" if foreign == "BE" else "BE"
+    cell = getattr(cells, f"uint16{native}")()
+    # so the factory hands back the native heap
+    heap = pyre.memory.heap(type=cell, cells=4)
+    assert type(heap).__name__ == "HeapUInt16"
+
+    # all done
+    return
+
+
+def map():
+    """
+    Verify that the map factory opens a product in the order the host lacks, read-only and
+    writable
+    """
+    # get the package
+    import pyre
+    from pyre.memory import cells
+
+    # the scratch product
+    uri = pyre.primitives.path("memory_ordered_test.dat")
+    # the values
+    values = [1, 2, 3, 0x1234]
+    # write the product in the foreign order
+    with open(uri, "wb") as product:
+        product.write(struct.pack(f"{code}4H", *values))
+
+    # open it read-only
+    const = pyre.memory.map(uri=uri, type=getattr(cells, f"uint16{foreign}Const")())
+    # the cells read as their native values
+    assert list(const) == values
+    # let go
+    del const
+
+    # a writable map over an existing product goes through the bindings directly
+    from pyre.extensions.pyre.memory import maps
+
+    writable = getattr(maps, f"MapUInt16{foreign}")(str(uri), True)
+    # change a cell
+    writable[3] = 0xABCD
+    # flush
+    del writable
+    # and the file must hold it in the foreign order
+    with open(uri, "rb") as product:
+        stored = struct.unpack(f"{code}4H", product.read())
+    assert list(stored) == values[:3] + [0xABCD]
+
+    # all done
+    return
+
+
+def numpy():
+    """
+    Verify that numpy, when available, honors the order marker on a heap over byte ordered cells
+    """
+    # numpy is optional
+    try:
+        # get it
+        import numpy
+    # if it's not there
+    except ImportError:
+        # there is nothing to check
+        return
+
+    # get the package
+    import pyre
+    from pyre.memory import cells
+
+    # allocate over foreign order complex cells
+    heap = pyre.memory.heap(type=getattr(cells, f"complexFloat{foreign}")(), cells=2)
+    # fill
+    heap[0] = 1.5 - 2j
+    heap[1] = 3 + 4j
+    # view through numpy, without copying
+    a = numpy.asarray(heap)
+    # numpy sees the marker
+    assert a.dtype == numpy.dtype(f"{code}c8")
+    # and the values
+    assert a.tolist() == [1.5 - 2j, 3 + 4j]
+    # a write through numpy
+    a[1] = 5 + 6j
+    # is seen by the heap
+    assert heap[1] == 5 + 6j
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the tests
+    heap()
+    map()
+    numpy()
+
+
+# end of file


### PR DESCRIPTION
Cells in an explicit byte order. A grid, a buffer, or a mosaic over such cells reads and writes native values while its bytes sit in memory in the declared order, so a data product written on a machine of the other endianness is read in place, with no conversion pass and no copy.

## The wrapper

`pyre::memory::Ordered<T, std::endian>` is a trivially copyable value type exactly as wide as the scalar it stands in for. It converts to the native scalar on read and accepts one on assignment, swapping bytes on the way through, and it carries the compound assignment operators so it behaves as the scalar in expressions. Complex scalars swap each component on its own. The wrapper can lay over memory mapped files and travels through `std::memset` and friends unharmed.

`ordered_t<T, order>` is the spelling to use. It collapses to the plain scalar when the requested order is the host's, or when the scalar is a single byte, so only cells that actually need swapping pay for the wrapper. `big_t<T>` and `little_t<T>` name the two orders; `foreign_t<T>` names whichever one the host lacks; `native_t<cell>` recovers the scalar behind any cell type.

Cell names follow the scalar's with an order marker: `UInt16BE`, `ComplexFloatLE`, and their `Const` forms. `expansions.h` gains the list of scalars wide enough to have an order and the lists of foreign order cells, buffers, heaps, maps, and views.

## The python support tier

`lib/pyre/py/memory/format.h` produces the buffer protocol format code for a cell type, leading with `>` or `<` for a byte ordered cell. The type erased grid and mosaic lift cells into python through `native_t`, so python never meets the wrapper, and describe themselves with the marked format. Consumers of the buffer protocol that understand the marker, such as numpy, see the right values with no copy.

## The bindings

The memory module registers the foreign order cells as classes and aliases the native order names to the native classes, so `cells.Int16LE is cells.Int16` holds on a little endian host. Heaps, maps, and views over the foreign order cells are registered alongside the native ones; item access, iteration, `__setitem__`, and `fill` go through the native scalar, and the buffer protocol description carries the marker.

The grid factories accept a byte order suffix on the cell name: `cell="float64be"` or `cell="uint16le"`. A suffix that names the host's own order yields the native cell.

`pyre.memory.cells` publishes the new cells under `int16BE`, `uint16LE`, `complexFloatBEConst`, and so on, and the `pyre.memory` allocators accept them.

## Tests

C++ drivers cover the wrapper's value and byte semantics, complex components, a heap over foreign order cells, and a grid mapping a product written in the foreign order and writing back to it. Bindings and package drivers cover the presence of every new class, heaps, slices, maps, and grids over foreign order cells in both orders, the collapse to the native cell, the refusal of a marker on an unknown base cell, and numpy interoperability where numpy is present. The drivers construct the foreign order relative to the host, so they exercise the wrapper on either kind of machine.

## Cost

A touched rebuild of the memory extension takes the same time within run to run noise. The extension module grows from 9.7 MB to 13.9 MB for the 80 additional buffer, heap, map, and view classes and the 20 additional cell classes.
