### PR TITLE
pyre.components: anonymous instances accept trait values as constructor arguments

### DIFF
--- a/packages/pyre/components/Actor.py
+++ b/packages/pyre/components/Actor.py
@@ -118,6 +118,12 @@ class Actor(Requirement):
         # and ask the component class for any opinions on the name of this instance
         name = self.pyre_normalizeInstanceName(name)
 
+        # separate the constructor arguments that name my traits from the rest; the table maps
+        # every alias to its descriptor, so the caller may use any spelling of a trait
+        traits = {alias: trait for trait in self.pyre_configurables() for alias in trait.aliases}
+        # the trait values, keyed by descriptor, pulled out of the constructor arguments
+        values = {traits[key]: kwds.pop(key) for key in list(kwds) if key in traits}
+
         # if I know the name after all
         if name:
             # look for this name among my instances
@@ -132,40 +138,28 @@ class Actor(Requirement):
                 # do it
                 self.pyre_pullGlobalSettingsIntoScope(scope=name)
 
-            # if the constructor has any extra arguments
-            if kwds:
-                # make a discard pile
-                discard = set()
-                # build a table that maps my trait aliases to the canonical trait name
-                traits = {
-                    alias: trait.name
-                    for trait in self.pyre_configurables()
-                    for alias in trait.aliases
-                }
-                # go through the extra arguments and their values
-                for key, value in kwds.items():
-                    # if the argument does not correspond to one of my traits
-                    if key not in traits:
-                        # skip it
-                        continue
-                    # otherwise, form its full name
-                    full = nameserver.join(name, traits[key])
-                    # assign a priority
-                    priority = executive.priority.construction()
-                    # make a configuration entry
-                    nameserver.insert(name=full, value=value, locator=locator, priority=priority)
-                    # and add it to the discard pile
-                    discard.add(key)
-
-                # to clean up, go through the discard pile
-                for key in discard:
-                    # and remove each key from the pile of constructor arguments
-                    del kwds[key]
+            # a named instance is configured through the nameserver, so its trait values go
+            # there, at construction priority, where user configuration under its name can
+            # override them; go through them
+            for trait, value in values.items():
+                # form the full name of the setting
+                full = nameserver.join(name, trait.name)
+                # assign a priority
+                priority = executive.priority.construction()
+                # and make a configuration entry
+                nameserver.insert(name=full, value=value, locator=locator, priority=priority)
+            # the instance finds these in the store when its inventory binds, so there is
+            # nothing left to hand over directly
+            values = {}
 
         # invoke the pre-instantiation hooks
         self.pyre_staged(name=name, locator=locator, implicit=implicit)
-        # build the instance
-        instance = super().__call__(name=name, locator=locator, implicit=implicit, **kwds)
+        # build the instance; an anonymous one has no namespace in the store, so it receives
+        # its trait values directly and deposits them in its private inventory before its
+        # configuration hooks run
+        instance = super().__call__(
+            name=name, locator=locator, implicit=implicit, pyre_values=values, **kwds
+        )
 
         # invoke the instantiation hook and harvest any errors
         initializationErrors = list(instance.pyre_initialized())

--- a/packages/pyre/components/Component.py
+++ b/packages/pyre/components/Component.py
@@ -293,7 +293,7 @@ class Component(Configurable, metaclass=Actor, internal=True):
         return cls.pyre_inventory.getTraitLocator(trait)
 
     # meta methods
-    def __new__(cls, name, locator, implicit, **kwds):
+    def __new__(cls, name, locator, implicit, pyre_values=None, **kwds):
         # build the instance; in order to accommodate components with non-trivial constructors,
         # we have to swallow any extra arguments passed to {__new__}; unfortunately, this
         # places some restrictions on how components participate in class hierarchies: no
@@ -312,13 +312,24 @@ class Component(Configurable, metaclass=Actor, internal=True):
         inventory = cls.PrivateInventory if name is None else cls.PublicInventory
         # ask the inventory to initialize the instance
         inventory.initializeInstance(instance=instance, name=name, implicit=implicit)
+        # deposit the trait values the constructor was handed; only an anonymous instance gets
+        # any, since a named one finds its values in the nameserver, and they must be in place
+        # before the configuration hooks run, the way they are for a named instance
+        for trait, value in (pyre_values or {}).items():
+            # through the inventory, at construction priority, from where the caller stood
+            instance.pyre_setTrait(
+                alias=trait.name,
+                value=value,
+                priority=cls.pyre_executive.priority.construction(),
+                locator=locator,
+            )
         # and collect configuration errors
         instance.pyre_configurationErrors = list(inventory.configureInstance(instance))
 
         # all done
         return instance
 
-    def __init__(self, name, locator, implicit, **kwds):
+    def __init__(self, name, locator, implicit, pyre_values=None, **kwds):
         # chain up, but first swallow the extra arguments that are used by my metaclass
         super().__init__(**kwds)
         # make me an id

--- a/tests/pyre.pkg/components/component_instance_configuration_anonymous.py
+++ b/tests/pyre.pkg/components/component_instance_configuration_anonymous.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify that an anonymous component instance accepts trait values as constructor arguments, under
+any of their spellings, and that they are in place before the configuration hooks run
+"""
+
+
+def declare():
+    # get the framework
+    import pyre
+
+    # make a component
+    class component(pyre.component, family="sample.nameless"):
+        """a test component"""
+
+        # properties
+        p1 = pyre.properties.str(default="p1")
+        p1.aliases = {"first"}
+        p2 = pyre.properties.int(default=0)
+
+        # the configuration hook
+        def pyre_configured(self, **kwds):
+            # record what the traits held when the hook ran
+            self.seen = (self.p1, self.p2)
+            # chain up
+            yield from super().pyre_configured(**kwds)
+            # all done
+            return
+
+        # meta method
+        def __init__(self, extra=None, **kwds):
+            # chain up
+            super().__init__(**kwds)
+            # the trait values are in place by now
+            self.initialized = (self.p1, self.p2)
+            # and so is the argument that is not a trait
+            self.extra = extra
+            # all done
+            return
+
+    # and publish it
+    return component
+
+
+def test():
+    # get the declaration
+    component = declare()
+
+    # an anonymous instance built with trait values and an ordinary argument
+    c = component(p1="one", p2="2", extra="x")
+    # it is anonymous
+    assert c.pyre_name is None
+    # the values landed, converted to their types
+    assert c.p1 == "one"
+    assert c.p2 == 2
+    # the configuration hook saw them
+    assert c.seen == ("one", 2)
+    # and so did the constructor
+    assert c.initialized == ("one", 2)
+    # while the ordinary argument reached the constructor untouched
+    assert c.extra == "x"
+
+    # the alias spelling works as well
+    d = component(**{"first": "alias"})
+    assert d.p1 == "alias"
+    assert d.p2 == 0
+
+    # an instance built without arguments gets the defaults
+    e = component()
+    assert e.p1 == "p1"
+    assert e.p2 == 0
+    assert e.seen == ("p1", 0)
+
+    # instances are independent of each other
+    assert c.p1 == "one"
+    assert d.p1 == "alias"
+
+    # and a named instance behaves as it always did
+    n = component(name="nameless-named", p1="named", p2=7)
+    assert n.pyre_name == "nameless-named"
+    assert n.p1 == "named"
+    assert n.p2 == 7
+    assert n.seen == ("named", 7)
+
+    # all done
+    return c
+
+
+# main
+if __name__ == "__main__":
+    test()
+
+
+# end of file


### PR DESCRIPTION
Anonymous component instances accept trait values as constructor arguments.

## Background

`Actor.__call__` has always accepted trait values as keywords on named instances: it inserts them in the nameserver under `<name>.<trait>` at construction priority, matched by alias, and only the remaining arguments reach the class constructor. An anonymous instance has no namespace in the nameserver, so the same keywords fell through to the constructor and `object.__init__` rejected them. The requirement was a consequence of the deposit mechanism rather than a property of the design.

## The change

`Actor.__call__` separates the trait-named keywords from the rest for every instance, using the same alias table. A named instance is handled as before. An anonymous instance receives its values through a `pyre_values` argument, and `Component.__new__` deposits them in its private inventory through `pyre_setTrait` at construction priority, after the inventory is built and before `configureInstance` runs, so `pyre_configured` and `pyre_initialized` see the values exactly as they do for a named instance. `Component.__init__` swallows the argument.

Priority does not enter for anonymous instances: nothing but explicit assignment can write to a private inventory, so construction priority and explicit priority are indistinguishable there.

## Compatibility

A constructor that expects to receive a keyword matching one of its own trait names or aliases would previously have received it on anonymous instances and not on named ones; it now receives it on neither. A scan of the component classes in pyre, qed, and qef found no constructor parameter that collides with a trait or alias declared in the same class. Anonymous keyword construction raised `TypeError` before this change, so no existing code depends on the previous behavior.

## Tests

`component_instance_configuration_anonymous.py` builds an anonymous instance from keywords and checks that the values land converted to their types, that the alias spelling works, that the configuration hook and the constructor both see the values, that a keyword that is not a trait still reaches the constructor, that instances are independent, that an instance built without arguments gets the defaults, and that a named instance behaves as before. The full test suite passes.
