### PR TITLE
journal: the channel indices live in the library

### DIFF
--- a/.cmake/pyre_journal.cmake
+++ b/.cmake/pyre_journal.cmake
@@ -69,13 +69,19 @@ function(pyre_journalLib)
     lib/journal/Chronicler.cc
     lib/journal/Console.cc
     lib/journal/Courier.cc
+    lib/journal/Debug.cc
     lib/journal/Device.cc
+    lib/journal/Error.cc
     lib/journal/ErrorConsole.cc
     lib/journal/File.cc
+    lib/journal/Firewall.cc
+    lib/journal/Help.cc
+    lib/journal/Informational.cc
     lib/journal/Memo.cc
     lib/journal/Renderer.cc
     lib/journal/Stream.cc
     lib/journal/Trash.cc
+    lib/journal/Warning.cc
     lib/journal/debuginfo.cc
     lib/journal/firewalls.cc
     )

--- a/lib/journal/Debug.cc
+++ b/lib/journal/Debug.cc
@@ -1,0 +1,23 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// my declarations
+#include "Debug.h"
+
+
+// the one definition of the channel index; the declaration in the header explains why it lives
+// in the library rather than in every translation unit that touches the channel; it is built
+// the way the generic definition builds it, by asking the channel to initialize it
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Debug<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index =
+    pyre::journal::Channel<
+        pyre::journal::Debug<pyre::journal::InventoryProxy>,
+        pyre::journal::InventoryProxy>::_initializeIndex();
+
+
+// end of file

--- a/lib/journal/Debug.h
+++ b/lib/journal/Debug.h
@@ -12,6 +12,8 @@
 #include "forward.h"
 // my superclass
 #include "Channel.h"
+// the proxy that binds a channel to its shared state
+#include "InventoryProxy.h"
 // my parts
 #include "exceptions.h"
 #include "Chronicler.h"
@@ -65,6 +67,17 @@ private:
 
 // get the inline definitions
 #include "Debug.icc"
+
+
+// the channel index is a static data member of a class template, so every translation unit
+// that touches the channel would otherwise carry its own definition; a linker that does not
+// unify such definitions across shared objects then splits the channel state between the
+// library and every extension module that uses it, and a channel deactivated in one is still
+// active in the other; so the index is declared here as an explicit specialization, which
+// makes it an ordinary variable with one definition, in the library
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Debug<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index;
 
 
 // end of file

--- a/lib/journal/Error.cc
+++ b/lib/journal/Error.cc
@@ -1,0 +1,23 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// my declarations
+#include "Error.h"
+
+
+// the one definition of the channel index; the declaration in the header explains why it lives
+// in the library rather than in every translation unit that touches the channel; it is built
+// the way the generic definition builds it, by asking the channel to initialize it
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Error<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index =
+    pyre::journal::Channel<
+        pyre::journal::Error<pyre::journal::InventoryProxy>,
+        pyre::journal::InventoryProxy>::_initializeIndex();
+
+
+// end of file

--- a/lib/journal/Error.h
+++ b/lib/journal/Error.h
@@ -12,6 +12,8 @@
 #include "forward.h"
 // my superclass
 #include "Channel.h"
+// the proxy that binds a channel to its shared state
+#include "InventoryProxy.h"
 // my parts
 #include "exceptions.h"
 #include "Chronicler.h"
@@ -66,6 +68,17 @@ private:
 
 // get the inline definitions
 #include "Error.icc"
+
+
+// the channel index is a static data member of a class template, so every translation unit
+// that touches the channel would otherwise carry its own definition; a linker that does not
+// unify such definitions across shared objects then splits the channel state between the
+// library and every extension module that uses it, and a channel deactivated in one is still
+// active in the other; so the index is declared here as an explicit specialization, which
+// makes it an ordinary variable with one definition, in the library
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Error<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index;
 
 
 // end of file

--- a/lib/journal/Firewall.cc
+++ b/lib/journal/Firewall.cc
@@ -1,0 +1,23 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// my declarations
+#include "Firewall.h"
+
+
+// the one definition of the channel index; the declaration in the header explains why it lives
+// in the library rather than in every translation unit that touches the channel; it is built
+// the way the generic definition builds it, by asking the channel to initialize it
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Firewall<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index =
+    pyre::journal::Channel<
+        pyre::journal::Firewall<pyre::journal::InventoryProxy>,
+        pyre::journal::InventoryProxy>::_initializeIndex();
+
+
+// end of file

--- a/lib/journal/Firewall.h
+++ b/lib/journal/Firewall.h
@@ -12,6 +12,8 @@
 #include "forward.h"
 // my superclass
 #include "Channel.h"
+// the proxy that binds a channel to its shared state
+#include "InventoryProxy.h"
 // my parts
 #include "exceptions.h"
 #include "Chronicler.h"
@@ -65,6 +67,17 @@ private:
 
 // get the inline definitions
 #include "Firewall.icc"
+
+
+// the channel index is a static data member of a class template, so every translation unit
+// that touches the channel would otherwise carry its own definition; a linker that does not
+// unify such definitions across shared objects then splits the channel state between the
+// library and every extension module that uses it, and a channel deactivated in one is still
+// active in the other; so the index is declared here as an explicit specialization, which
+// makes it an ordinary variable with one definition, in the library
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Firewall<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index;
 
 
 // end of file

--- a/lib/journal/Help.cc
+++ b/lib/journal/Help.cc
@@ -1,0 +1,23 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// my declarations
+#include "Help.h"
+
+
+// the one definition of the channel index; the declaration in the header explains why it lives
+// in the library rather than in every translation unit that touches the channel; it is built
+// the way the generic definition builds it, by asking the channel to initialize it
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Help<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index =
+    pyre::journal::Channel<
+        pyre::journal::Help<pyre::journal::InventoryProxy>,
+        pyre::journal::InventoryProxy>::_initializeIndex();
+
+
+// end of file

--- a/lib/journal/Help.h
+++ b/lib/journal/Help.h
@@ -12,6 +12,8 @@
 #include "forward.h"
 // my superclass
 #include "Channel.h"
+// the proxy that binds a channel to its shared state
+#include "InventoryProxy.h"
 // my parts
 #include "exceptions.h"
 
@@ -64,6 +66,17 @@ private:
 
 // get the inline definitions
 #include "Help.icc"
+
+
+// the channel index is a static data member of a class template, so every translation unit
+// that touches the channel would otherwise carry its own definition; a linker that does not
+// unify such definitions across shared objects then splits the channel state between the
+// library and every extension module that uses it, and a channel deactivated in one is still
+// active in the other; so the index is declared here as an explicit specialization, which
+// makes it an ordinary variable with one definition, in the library
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Help<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index;
 
 
 // end of file

--- a/lib/journal/Informational.cc
+++ b/lib/journal/Informational.cc
@@ -1,0 +1,24 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// my declarations
+#include "Informational.h"
+
+
+// the one definition of the channel index; the declaration in the header explains why it lives
+// in the library rather than in every translation unit that touches the channel; it is built
+// the way the generic definition builds it, by asking the channel to initialize it
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Informational<pyre::journal::InventoryProxy>,
+    pyre::journal::InventoryProxy>::_index =
+    pyre::journal::Channel<
+        pyre::journal::Informational<pyre::journal::InventoryProxy>,
+        pyre::journal::InventoryProxy>::_initializeIndex();
+
+
+// end of file

--- a/lib/journal/Informational.h
+++ b/lib/journal/Informational.h
@@ -12,6 +12,8 @@
 #include "forward.h"
 // my superclass
 #include "Channel.h"
+// the proxy that binds a channel to its shared state
+#include "InventoryProxy.h"
 // my parts
 #include "exceptions.h"
 
@@ -64,6 +66,18 @@ private:
 
 // get the inline definitions
 #include "Informational.icc"
+
+
+// the channel index is a static data member of a class template, so every translation unit
+// that touches the channel would otherwise carry its own definition; a linker that does not
+// unify such definitions across shared objects then splits the channel state between the
+// library and every extension module that uses it, and a channel deactivated in one is still
+// active in the other; so the index is declared here as an explicit specialization, which
+// makes it an ordinary variable with one definition, in the library
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Informational<pyre::journal::InventoryProxy>,
+    pyre::journal::InventoryProxy>::_index;
 
 
 // end of file

--- a/lib/journal/Warning.cc
+++ b/lib/journal/Warning.cc
@@ -1,0 +1,23 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// my declarations
+#include "Warning.h"
+
+
+// the one definition of the channel index; the declaration in the header explains why it lives
+// in the library rather than in every translation unit that touches the channel; it is built
+// the way the generic definition builds it, by asking the channel to initialize it
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Warning<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index =
+    pyre::journal::Channel<
+        pyre::journal::Warning<pyre::journal::InventoryProxy>,
+        pyre::journal::InventoryProxy>::_initializeIndex();
+
+
+// end of file

--- a/lib/journal/Warning.h
+++ b/lib/journal/Warning.h
@@ -12,6 +12,8 @@
 #include "forward.h"
 // my superclass
 #include "Channel.h"
+// the proxy that binds a channel to its shared state
+#include "InventoryProxy.h"
 // my parts
 #include "exceptions.h"
 
@@ -66,6 +68,17 @@ private:
 
 // get the inline definitions
 #include "Warning.icc"
+
+
+// the channel index is a static data member of a class template, so every translation unit
+// that touches the channel would otherwise carry its own definition; a linker that does not
+// unify such definitions across shared objects then splits the channel state between the
+// library and every extension module that uses it, and a channel deactivated in one is still
+// active in the other; so the index is declared here as an explicit specialization, which
+// makes it an ordinary variable with one definition, in the library
+template <>
+pyre::journal::Index pyre::journal::Channel<
+    pyre::journal::Warning<pyre::journal::InventoryProxy>, pyre::journal::InventoryProxy>::_index;
 
 
 // end of file

--- a/tests/h5.ext/channel_state.py
+++ b/tests/h5.ext/channel_state.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Verify that channel state set from python is seen inside another extension module: a channel
+    deactivated here must stay quiet when the h5 bindings log to it
+
+    The journal keeps the state of a channel in a static owned by the library; a build that lets
+    every extension module carry its own copy of that static splits the state, and a channel
+    quieted here would still fire inside the module
+    """
+    # the h5 bindings
+    from pyre.extensions import libh5
+
+    # the journal
+    import journal
+
+    # the bindings complain on this channel when asked for a mode they do not support; the
+    # channel is fatal by default, so the request would raise; quiet it from python
+    channel = journal.error("pyre.h5.file")
+    channel.active = False
+    # ask for a file in a mode the bindings do not support; no file is touched
+    f = libh5.File(uri="channel_state.h5", mode="bogus")
+    # if the deactivation reached the channel inside the module, the bindings returned a stub
+    # rather than raising
+    assert isinstance(f, libh5.File)
+    # restore the channel
+    channel.active = True
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file


### PR DESCRIPTION
The state of every journal channel now lives in exactly one place, the journal library, whichever shared object opens the channel.

## The problem

`Channel<severity, proxy>::_index` is a static data member of a class template, defined in a header. Under clang on Linux it is emitted as a weak definition in every shared object that touches a channel: the journal library, the journal extension module, the pyre extension module, and so on. Python loads extension modules with local symbol scope, so each module binds to its own copy, and the channel state splits. A channel deactivated from python through the journal extension stayed active inside the pyre extension, and its fatal error channel fired where the caller expected a python exception. gcc marks such statics unique across the process, which is why only the clang legs of CI saw this.

## The change

Each of the six channel indices, for `Informational`, `Warning`, `Error`, `Help`, `Debug`, and `Firewall` over `InventoryProxy`, is declared in its severity header as an explicit specialization of the static member and defined in a matching `lib/journal/<Severity>.cc`, built the way the generic definition builds it. A specialization is an ordinary variable: one strong definition in the library, a plain initializer in the defining translation unit, and undefined references everywhere else. The severity headers now include `InventoryProxy.h`, which the specialization needs complete.

An explicit instantiation declaration with a matching definition was tried first and rejected: under clang the library received the storage but no dynamic initializer, and the first channel construction walked a zeroed map.

## Verification

On a Linux host with clang 22, a debug build of the pre-fix grid driver that deactivates a channel from python before calling into the pyre extension fails as it did in CI, and passes with this change. The symbol tables show the index defined once, in `libjournal.so`, and referenced from the extension modules and from `libpyre.so`. The journal, pyre, and h5 python-driven suites pass under that build.

## Tests

`tests/h5.ext/channel_state.py` deactivates the `pyre.h5.file` channel from python and asks the h5 bindings for a file in a mode they refuse. The bindings log the refusal to that channel, which is fatal by default, so the request raises when the state is split and returns a stub when it is shared.
