### PR TITLE
pyre.envi: ENVI header support

### DIFF
--- a/.mm/pyre.pkg.tests
+++ b/.mm/pyre.pkg.tests
@@ -23,6 +23,7 @@ tests.pyre.pkg.h5.api.raster_roundtrip.clean := raster_roundtrip.h5
 tests.pyre.pkg.h5.api.raster_value.clean := raster_value.h5
 tests.pyre.pkg.memory.ordered.clean := memory_ordered_test.dat
 tests.pyre.pkg.envi.write.clean := envi_write_test.hdr
+tests.pyre.pkg.envi.cell.clean := envi_cell_test_0.dat envi_cell_test_0.hdr envi_cell_test_1.dat envi_cell_test_1.hdr
 
 
 # the {filesystem.local-make} test modifies the current directory, which creates race

--- a/.mm/pyre.pkg.tests
+++ b/.mm/pyre.pkg.tests
@@ -22,6 +22,7 @@ tests.pyre.pkg.h5.api.file_create_empty.clean := file_create_empty.h5
 tests.pyre.pkg.h5.api.raster_roundtrip.clean := raster_roundtrip.h5
 tests.pyre.pkg.h5.api.raster_value.clean := raster_value.h5
 tests.pyre.pkg.memory.ordered.clean := memory_ordered_test.dat
+tests.pyre.pkg.envi.write.clean := envi_write_test.hdr
 
 
 # the {filesystem.local-make} test modifies the current directory, which creates race

--- a/packages/pyre/__init__.py
+++ b/packages/pyre/__init__.py
@@ -300,6 +300,9 @@ if _executive:
     # hdf5
     from . import h5
 
+    # ENVI headers
+    from . import envi
+
     # workflows
     from . import flow
 

--- a/packages/pyre/envi/Header.py
+++ b/packages/pyre/envi/Header.py
@@ -1,0 +1,395 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import pyre
+
+# the georeferencing record
+from .MapInfo import MapInfo
+
+# the local exceptions
+from . import exceptions
+
+
+# the contents of an ENVI header
+class Header(pyre.component, family="pyre.envi.header"):
+    """
+    The contents of an ENVI header
+
+    The standard keywords are traits, each aliased to its ENVI spelling, so a value read from a
+    file is converted to its documented type; keywords the standard does not define land in
+    {extras} as text. The keyword list follows the published ENVI header specification.
+
+    Like every component, a named header accepts trait values as constructor keywords, under
+    the attribute names or the ENVI spellings, and user configuration under its name overrides
+    them; an anonymous header takes values only by assignment.
+    """
+
+    # the layout of the product
+    description = pyre.properties.str()
+    description.default = None
+    description.doc = "a string describing the image or the processing performed"
+
+    samples = pyre.properties.int()
+    samples.default = None
+    samples.doc = "the number of samples per image line for each band"
+
+    lines = pyre.properties.int()
+    lines.default = None
+    lines.doc = "the number of lines per image for each band"
+
+    bands = pyre.properties.int()
+    bands.default = None
+    bands.doc = "the number of bands per image file"
+
+    headerOffset = pyre.properties.int()
+    headerOffset.default = 0
+    headerOffset.aliases = {"header offset"}
+    headerOffset.doc = "the number of bytes of embedded header information in the file"
+
+    fileType = pyre.properties.str()
+    fileType.default = None
+    fileType.aliases = {"file type"}
+    fileType.doc = "the ENVI file type"
+
+    dataType = pyre.properties.int()
+    dataType.default = None
+    dataType.aliases = {"data type"}
+    dataType.validators = pyre.constraints.isMember(1, 2, 3, 4, 5, 6, 9, 12, 13, 14, 15)
+    dataType.doc = "the ENVI code for the type of data representation"
+
+    interleave = pyre.properties.str()
+    interleave.default = None
+    interleave.validators = pyre.constraints.isMember("bsq", "bil", "bip")
+    interleave.doc = "the data interleave; one of bsq, bil, bip"
+
+    byteOrder = pyre.properties.int()
+    byteOrder.default = None
+    byteOrder.aliases = {"byte order"}
+    byteOrder.validators = pyre.constraints.isMember(0, 1)
+    byteOrder.doc = "the order of bytes in numeric data; 0 is little endian, 1 is big endian"
+
+    # georeferencing
+    mapInfo = pyre.properties.str()
+    mapInfo.default = None
+    mapInfo.aliases = {"map info"}
+    mapInfo.doc = "geographic information; see {map} for the parsed form"
+
+    projectionInfo = pyre.properties.str()
+    projectionInfo.default = None
+    projectionInfo.aliases = {"projection info"}
+    projectionInfo.doc = "custom projection information"
+
+    coordinateSystem = pyre.properties.str()
+    coordinateSystem.default = None
+    coordinateSystem.aliases = {"coordinate system string"}
+    coordinateSystem.doc = "the ENVI coordinate system identifier"
+
+    geoPoints = pyre.properties.list(schema=pyre.properties.float())
+    geoPoints.default = None
+    geoPoints.aliases = {"geo points"}
+    geoPoints.doc = "geographic corners for non-georeferenced files"
+
+    pixelSize = pyre.properties.list(schema=pyre.properties.float())
+    pixelSize.default = None
+    pixelSize.aliases = {"pixel size"}
+    pixelSize.doc = "the x and y pixel size in meters"
+
+    rpcInfo = pyre.properties.strings()
+    rpcInfo.default = None
+    rpcInfo.aliases = {"rpc info"}
+    rpcInfo.doc = "rational polynomial coefficient geolocation information"
+
+    xStart = pyre.properties.float()
+    xStart.default = None
+    xStart.aliases = {"x start"}
+    xStart.doc = "the image x coordinate of the upper left pixel"
+
+    yStart = pyre.properties.float()
+    yStart.default = None
+    yStart.aliases = {"y start"}
+    yStart.doc = "the image y coordinate of the upper left pixel"
+
+    dem = pyre.properties.path()
+    dem.default = None
+    dem.aliases = {"dem file"}
+    dem.doc = "the path to a DEM associated with the image"
+
+    demBand = pyre.properties.int()
+    demBand.default = None
+    demBand.aliases = {"dem band"}
+    demBand.doc = "the 1-based index of the DEM band associated with the image"
+
+    # the bands
+    bandNames = pyre.properties.strings()
+    bandNames.default = None
+    bandNames.aliases = {"band names"}
+    bandNames.doc = "the names of the image bands"
+
+    wavelength = pyre.properties.list(schema=pyre.properties.float())
+    wavelength.default = None
+    wavelength.doc = "the center wavelength of each band"
+
+    wavelengthUnits = pyre.properties.str()
+    wavelengthUnits.default = None
+    wavelengthUnits.aliases = {"wavelength units"}
+    wavelengthUnits.doc = "the wavelength units"
+
+    fwhm = pyre.properties.list(schema=pyre.properties.float())
+    fwhm.default = None
+    fwhm.doc = "the full width at half maximum of each band, in the wavelength units"
+
+    bbl = pyre.properties.list(schema=pyre.properties.int())
+    bbl.default = None
+    bbl.doc = "the bad band multiplier of each band; 0 is bad, 1 is good"
+
+    defaultBands = pyre.properties.list(schema=pyre.properties.int())
+    defaultBands.default = None
+    defaultBands.aliases = {"default bands"}
+    defaultBands.doc = "the 1-based band numbers to load automatically"
+
+    dataGain = pyre.properties.list(schema=pyre.properties.float())
+    dataGain.default = None
+    dataGain.aliases = {"data gain values"}
+    dataGain.doc = "the gain value of each band"
+
+    dataOffset = pyre.properties.list(schema=pyre.properties.float())
+    dataOffset.default = None
+    dataOffset.aliases = {"data offset values"}
+    dataOffset.doc = "the offset value of each band"
+
+    dataReflectanceGain = pyre.properties.list(schema=pyre.properties.float())
+    dataReflectanceGain.default = None
+    dataReflectanceGain.aliases = {"data reflectance gain values"}
+    dataReflectanceGain.doc = "the reflectance gain value of each band"
+
+    dataReflectanceOffset = pyre.properties.list(schema=pyre.properties.float())
+    dataReflectanceOffset.default = None
+    dataReflectanceOffset.aliases = {"data reflectance offset values"}
+    dataReflectanceOffset.doc = "the reflectance offset value of each band"
+
+    dataIgnore = pyre.properties.float()
+    dataIgnore.default = None
+    dataIgnore.aliases = {"data ignore value"}
+    dataIgnore.doc = "the pixel value that should be ignored in image processing"
+
+    reflectanceScaleFactor = pyre.properties.float()
+    reflectanceScaleFactor.default = None
+    reflectanceScaleFactor.aliases = {"reflectance scale factor"}
+    reflectanceScaleFactor.doc = "the factor that scales reflectance to the [0,1] range"
+
+    solarIrradiance = pyre.properties.list(schema=pyre.properties.float())
+    solarIrradiance.default = None
+    solarIrradiance.aliases = {"solar irradiance"}
+    solarIrradiance.doc = "the top of the atmosphere solar irradiance of each band, in W/(m^2 μm)"
+
+    spectraNames = pyre.properties.strings()
+    spectraNames.default = None
+    spectraNames.aliases = {"spectra names"}
+    spectraNames.doc = "the names of the spectra in a spectral library"
+
+    timestamp = pyre.properties.strings()
+    timestamp.default = None
+    timestamp.doc = "the timestamps of the bands of a temporal cube"
+
+    # classification
+    classes = pyre.properties.int()
+    classes.default = None
+    classes.doc = "the number of pixel classes of a classification file"
+
+    classNames = pyre.properties.strings()
+    classNames.default = None
+    classNames.aliases = {"class names"}
+    classNames.doc = "the class names of a classification file"
+
+    classLookup = pyre.properties.list(schema=pyre.properties.int())
+    classLookup.default = None
+    classLookup.aliases = {"class lookup"}
+    classLookup.doc = "the rgb class colors of a classification file"
+
+    # display
+    defaultStretch = pyre.properties.str()
+    defaultStretch.default = None
+    defaultStretch.aliases = {"default stretch"}
+    defaultStretch.doc = "the type of stretch to apply on display"
+
+    colorTable = pyre.properties.list(schema=pyre.properties.int())
+    colorTable.default = None
+    colorTable.aliases = {"color table"}
+    colorTable.doc = "the default color table; a 3 x 256 array of bytes"
+
+    complexFunction = pyre.properties.str()
+    complexFunction.default = None
+    complexFunction.aliases = {"complex function"}
+    complexFunction.validators = pyre.constraints.isMember(
+        "Real", "Imaginary", "Power", "Magnitude", "Phase"
+    )
+    complexFunction.doc = "the values to extract from a complex image"
+
+    zPlotAverage = pyre.properties.int()
+    zPlotAverage.default = None
+    zPlotAverage.aliases = {"z plot average"}
+    zPlotAverage.doc = "the number of pixels in x and y to average for Z plots"
+
+    zPlotRange = pyre.properties.list(schema=pyre.properties.float())
+    zPlotRange.default = None
+    zPlotRange.aliases = {"z plot range"}
+    zPlotRange.doc = "the default minimum and maximum values for Z plots"
+
+    zPlotTitles = pyre.properties.strings()
+    zPlotTitles.default = None
+    zPlotTitles.aliases = {"z plot titles"}
+    zPlotTitles.doc = "the x and y axis titles for Z plots"
+
+    # acquisition
+    acquisitionTime = pyre.properties.str()
+    acquisitionTime.default = None
+    acquisitionTime.aliases = {"acquisition time"}
+    acquisitionTime.doc = "the data acquisition time, in ISO 8601 form"
+
+    sensorType = pyre.properties.str()
+    sensorType.default = None
+    sensorType.aliases = {"sensor type"}
+    sensorType.doc = "the instrument type"
+
+    sunAzimuth = pyre.properties.float()
+    sunAzimuth.default = None
+    sunAzimuth.aliases = {"sun azimuth"}
+    sunAzimuth.doc = "the angle of the sun, in degrees clockwise from due north"
+
+    sunElevation = pyre.properties.float()
+    sunElevation.default = None
+    sunElevation.aliases = {"sun elevation"}
+    sunElevation.doc = "the angle of the sun above the horizon, in degrees"
+
+    cloudCover = pyre.properties.float()
+    cloudCover.default = None
+    cloudCover.aliases = {"cloud cover"}
+    cloudCover.doc = "the percentage of cloud cover within the raster"
+
+    securityTag = pyre.properties.str()
+    securityTag.default = None
+    securityTag.aliases = {"security tag"}
+    securityTag.doc = "classification information inherited from other formats"
+
+    readProcedures = pyre.properties.strings()
+    readProcedures.default = None
+    readProcedures.aliases = {"read procedures"}
+    readProcedures.doc = "the names of the spatial and spectral read routines"
+
+    # normalizers
+    @pyre.descriptors.normalizer(traits=[interleave])
+    def lower(value: str, **kwds) -> str:
+        """
+        Fold the interleave to lower case, the spelling the validator knows
+        """
+        # easy enough
+        return value.lower()
+
+    # interface
+    @property
+    def datatype(self) -> str | None:
+        """
+        The name of the pyre cell type that matches my {dataType} code, in the host's byte order
+        """
+        # get the code
+        code = self.dataType
+        # if it hasn't been set
+        if code is None:
+            # there is nothing to say
+            return None
+        # look it up
+        try:
+            # and return the name
+            return self.datatypes[code]
+        # if the code is not one ENVI defines
+        except KeyError:
+            # complain
+            raise exceptions.UnknownDataTypeError(code=code)
+
+    @property
+    def shape(self) -> tuple[int, ...] | None:
+        """
+        The shape of the product as laid out in the file: (lines, samples) for a single band,
+        and the three axes in interleave order otherwise
+        """
+        # get the extents
+        lines = self.lines
+        samples = self.samples
+        bands = self.bands
+        # if the image extents are missing
+        if lines is None or samples is None:
+            # there is no shape
+            return None
+        # a single band, declared or implied, is a plane
+        if bands is None or bands == 1:
+            # of lines and samples
+            return lines, samples
+        # otherwise the interleave decides where the band axis goes; the ENVI default is bsq
+        interleave = self.interleave or "bsq"
+        # band sequential: whole planes, one after the other
+        if interleave == "bsq":
+            # bands are the slowest axis
+            return bands, lines, samples
+        # band interleaved by line: each line carries all bands
+        if interleave == "bil":
+            # bands sit between lines and samples
+            return lines, bands, samples
+        # band interleaved by pixel: each pixel carries all bands
+        return lines, samples, bands
+
+    @property
+    def offset(self) -> int:
+        """
+        The number of bytes to skip before the first cell of the product
+        """
+        # the header offset, with the ENVI default when it is missing
+        return self.headerOffset or 0
+
+    def map(self) -> MapInfo | None:
+        """
+        Parse my {mapInfo} into a georeferencing record
+        """
+        # get the text
+        text = self.mapInfo
+        # if there isn't any
+        if text is None:
+            # there is no georeferencing
+            return None
+        # otherwise, parse it
+        return MapInfo.parse(text=text)
+
+    # metamethods
+    def __init__(self, extras: dict | None = None, **kwds):
+        # chain up; a named instance may be built with trait values as keywords, under either
+        # the attribute names or the ENVI spellings, and the framework deposits them in the
+        # configuration store at construction priority before we get here
+        super().__init__(**kwds)
+        # the keywords the standard does not define, as text: a string for a bare value and a
+        # list of strings for a braced one
+        self.extras = dict(extras) if extras else {}
+        # all done
+        return
+
+    # implementation details
+    # the ENVI data type codes and the names of the matching pyre cells
+    datatypes = {
+        1: "uint8",
+        2: "int16",
+        3: "int32",
+        4: "float32",
+        5: "float64",
+        6: "complex64",
+        9: "complex128",
+        12: "uint16",
+        13: "uint32",
+        14: "int64",
+        15: "uint64",
+    }
+
+
+# end of file

--- a/packages/pyre/envi/Header.py
+++ b/packages/pyre/envi/Header.py
@@ -312,6 +312,27 @@ class Header(pyre.component, family="pyre.envi.header"):
             raise exceptions.UnknownDataTypeError(code=code)
 
     @property
+    def cell(self) -> str | None:
+        """
+        The name of the pyre cell type that reads my product in place: my {datatype} with the
+        byte order marker my {byteOrder} calls for, so a product written on a machine of the
+        other endianness comes through the swap
+        """
+        # get the native name
+        name = self.datatype
+        # if there is no data type, or the byte order is not known
+        if name is None or self.byteOrder is None:
+            # there is nothing to add
+            return name
+        # a single byte scalar has no order
+        if name in ("uint8", "int8"):
+            # so it needs no marker
+            return name
+        # ENVI byte order 0 is little endian, 1 is big endian; the grid factories accept either
+        # marker and collapse the one that names the host's own order to the native cell
+        return name + ("be" if self.byteOrder == 1 else "le")
+
+    @property
     def shape(self) -> tuple[int, ...] | None:
         """
         The shape of the product as laid out in the file: (lines, samples) for a single band,

--- a/packages/pyre/envi/MapInfo.py
+++ b/packages/pyre/envi/MapInfo.py
@@ -1,0 +1,129 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the georeferencing record
+class MapInfo:
+    """
+    The contents of the ENVI {map info} field
+
+    The field ties a reference pixel to map coordinates and gives the pixel size; the first
+    seven items are fixed, and what follows depends on the projection: a zone and hemisphere for
+    UTM, then the datum, then {key=value} settings such as the units and the rotation.
+    """
+
+    # metamethods
+    def __init__(
+        self,
+        projection: str,
+        pixel: tuple[float, float],
+        coordinates: tuple[float, float],
+        size: tuple[float, float],
+        extras: list[str] | None = None,
+        **kwds,
+    ):
+        # chain up
+        super().__init__(**kwds)
+        # the projection name
+        self.projection = projection
+        # the reference pixel, as 1-based (x, y) image coordinates
+        self.pixel = pixel
+        # the map coordinates of the reference pixel, as (x, y): easting and northing, or
+        # longitude and latitude
+        self.coordinates = coordinates
+        # the pixel size, as (x, y)
+        self.size = size
+        # the projection dependent items, as text
+        self.extras = list(extras) if extras else []
+        # all done
+        return
+
+    # interface
+    def settings(self) -> dict[str, str]:
+        """
+        The {key=value} items among my extras
+        """
+        # split the items that look like settings
+        return dict(item.split("=", 1) for item in self.extras if "=" in item)
+
+    def toPixel(self, x: float, y: float) -> tuple[float, float]:
+        """
+        Convert map coordinates to 0-based (line, sample) image coordinates
+        """
+        # unpack
+        px, py = self.pixel
+        x0, y0 = self.coordinates
+        dx, dy = self.size
+        # the sample grows with x, the line grows against y
+        sample = (px - 1) + (x - x0) / dx
+        line = (py - 1) + (y0 - y) / dy
+        # all done
+        return line, sample
+
+    def toMap(self, line: float, sample: float) -> tuple[float, float]:
+        """
+        Convert 0-based (line, sample) image coordinates to map coordinates
+        """
+        # unpack
+        px, py = self.pixel
+        x0, y0 = self.coordinates
+        dx, dy = self.size
+        # invert {toPixel}
+        x = x0 + (sample - (px - 1)) * dx
+        y = y0 - (line - (py - 1)) * dy
+        # all done
+        return x, y
+
+    def render(self) -> str:
+        """
+        Render me in the form the {map info} field takes
+        """
+        # the numeric items, rendered the way ENVI writes them
+        numbers = [self.number(value) for value in (*self.pixel, *self.coordinates, *self.size)]
+        # the projection name first, then the numbers, then the projection dependent items
+        items = [self.projection, *numbers, *self.extras]
+        # joined with commas
+        return ", ".join(items)
+
+    @staticmethod
+    def number(value: float) -> str:
+        """
+        Render {value} with the shortest text that reads back exactly, and without a trailing
+        zero when it is integral, which is how ENVI writes reference pixels and integral sizes
+        """
+        # the shortest round trip form
+        text = str(value)
+        # drop a trailing zero after the point
+        return text[:-2] if text.endswith(".0") else text
+
+    @classmethod
+    def parse(cls, text: str) -> "MapInfo":
+        """
+        Build a record out of the {text} of a {map info} field
+        """
+        # split the items
+        items = [item.strip() for item in text.split(",")]
+        # the projection name
+        projection = items[0]
+        # the reference pixel
+        pixel = float(items[1]), float(items[2])
+        # its map coordinates
+        coordinates = float(items[3]), float(items[4])
+        # the pixel size
+        size = float(items[5]), float(items[6])
+        # whatever follows is projection dependent
+        extras = [item for item in items[7:] if item]
+        # assemble the record and return it
+        return cls(
+            projection=projection, pixel=pixel, coordinates=coordinates, size=size, extras=extras
+        )
+
+    def __str__(self) -> str:
+        # render
+        return self.render()
+
+
+# end of file

--- a/packages/pyre/envi/Reader.py
+++ b/packages/pyre/envi/Reader.py
@@ -1,0 +1,202 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import pyre
+import journal
+
+# the header
+from .Header import Header
+
+# the local exceptions
+from . import exceptions
+
+
+# the ENVI header reader
+class Reader:
+    """
+    A reader of ENVI headers
+
+    The text is a sequence of {keyword = value} entries after a line with the {ENVI} marker;
+    lines that start with a semicolon are comments, and a value in braces may span lines. Known
+    keywords land on the traits of the header, converted to their documented types; a known
+    keyword whose value cannot be converted, and every keyword the standard does not define, land
+    in the header's {extras} as text.
+    """
+
+    # constants
+    # the marker that opens every header
+    marker = "ENVI"
+    # the comment leader
+    comment = ";"
+
+    # interface
+    def read(self, uri, name: str | None = None) -> Header:
+        """
+        Read the header at {uri}
+        """
+        # the location, as a path
+        path = pyre.primitives.path(uri)
+        # open the file; headers are ASCII, so anything else is tolerated rather than fatal
+        with open(path, mode="r", encoding="utf-8", errors="replace") as stream:
+            # and parse it
+            return self.parse(stream=stream, uri=str(path), name=name)
+
+    def parse(self, stream, uri: str = "<stream>", name: str | None = None) -> Header:
+        """
+        Build a header out of the lines of {stream}; {uri} labels the source in complaints
+        """
+        # scan the text into (keyword, value) pairs
+        entries = self.scan(stream=stream, uri=uri)
+        # and assemble the header
+        return self.assemble(entries=entries, uri=uri, name=name)
+
+    # implementation details
+    def scan(self, stream, uri: str):
+        """
+        Scan the lines of {stream} and generate (keyword, value) pairs; a value is a string when
+        bare and a list of strings when braced
+        """
+        # number the lines, the way editors do
+        lines = enumerate(stream, start=1)
+        # the first significant line must be the marker
+        for number, line in lines:
+            # clean up
+            text = line.strip()
+            # skip blank lines and comments
+            if not text or text.startswith(self.comment):
+                # by moving on
+                continue
+            # anything else must be the marker
+            if text != self.marker:
+                # or this is not an ENVI header
+                raise exceptions.MissingMarkerError(uri=uri)
+            # found it
+            break
+        # if the loop ran out of lines
+        else:
+            # the file is empty
+            raise exceptions.MissingMarkerError(uri=uri)
+
+        # go through the rest
+        for number, line in lines:
+            # clean up
+            text = line.strip()
+            # skip blank lines and comments
+            if not text or text.startswith(self.comment):
+                # by moving on
+                continue
+            # an entry is an assignment; split on the first {=} only, since values may contain
+            # more of them
+            keyword, separator, value = text.partition("=")
+            # if there is no separator
+            if not separator:
+                # the line is not an entry
+                raise exceptions.MalformedHeaderError(
+                    uri=uri, line=number, text=text, reason="expected 'keyword = value'"
+                )
+            # normalize the keyword: lower case, with single spaces
+            keyword = " ".join(keyword.split()).lower()
+            # and clean up the value
+            value = value.strip()
+            # a braced value
+            if value.startswith("{"):
+                # collects everything up to the closing brace, however many lines that takes
+                pieces = []
+                # the remainder of this line
+                body = value[1:]
+                # the number of the line that opened the brace, for the complaint
+                opener = number
+                # until the closing brace shows up
+                while "}" not in body:
+                    # keep this piece
+                    pieces.append(body.strip())
+                    # get the next line
+                    try:
+                        # numbered
+                        number, line = next(lines)
+                    # if there isn't one
+                    except StopIteration:
+                        # the brace was never closed
+                        raise exceptions.MalformedHeaderError(
+                            uri=uri, line=opener, text=text, reason="unterminated brace"
+                        )
+                    # this is the new body
+                    body = line
+                # keep the part before the closing brace
+                pieces.append(body[: body.index("}")].strip())
+                # the items are separated by commas; drop empty ones
+                items = [item.strip() for item in " ".join(pieces).split(",")]
+                # and hand off the list
+                yield keyword, [item for item in items if item]
+            # a bare value
+            else:
+                # is handed off as is
+                yield keyword, value
+        # all done
+        return
+
+    def assemble(self, entries, uri: str, name: str | None) -> Header:
+        """
+        Build a header out of (keyword, value) {entries}
+        """
+        # make a header; parsed values are deposited by assignment rather than as constructor
+        # keywords: assignment works for anonymous headers, applies one value at a time so a bad
+        # one can be diverted to the extras, and records facts about the file above any
+        # configuration, which is where they belong
+        header = Header(name=name)
+        # make a channel for complaints about values
+        channel = journal.warning("pyre.envi.header")
+        # go through the entries
+        for keyword, value in entries:
+            # look for the trait that answers to this keyword
+            try:
+                # by alias
+                trait = Header.pyre_trait(alias=keyword)
+            # if there isn't one
+            except Header.TraitNotFoundError:
+                # the keyword goes in the bag as is
+                header.extras[keyword] = value
+                # and we are done with it
+                continue
+            # a braced value bound for a trait travels as text; scalar traits get the items
+            # joined back with commas, which the sequence traits split again
+            text = ", ".join(value) if isinstance(value, list) else value
+            # attempt to
+            try:
+                # deposit the value
+                setattr(header, trait.name, text)
+                # and read it back, which is when the conversion to the documented type happens
+                converted = getattr(header, trait.name)
+                # a sequence trait drops the items it cannot convert rather than failing, so a
+                # braced value that came back as a shorter sequence has lost something; a text
+                # trait gets the whole braced value as one string, so it is not subject to this
+                if (
+                    isinstance(value, list)
+                    and isinstance(converted, (list, tuple))
+                    and len(converted) != len(value)
+                ):
+                    # which is a failure as well
+                    raise exceptions.MalformedValueError(keyword=keyword, value=value)
+            # if the conversion fails
+            except pyre.PyreError as error:
+                # the trait stays unset
+                setattr(header, trait.name, None)
+                # the value goes in the bag as text
+                header.extras[keyword] = value
+                # and the user hears about it
+                channel.line(f"while reading '{uri}'")
+                channel.indent()
+                channel.line(f"could not convert the value of '{keyword}': {error}")
+                channel.line(f"the text is available in the extras of the header")
+                channel.outdent()
+                channel.log()
+        # all done
+        return header
+
+
+# end of file

--- a/packages/pyre/envi/Writer.py
+++ b/packages/pyre/envi/Writer.py
@@ -1,0 +1,95 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import pyre
+
+# the header
+from .Header import Header
+
+
+# the ENVI header writer
+class Writer:
+    """
+    A writer of ENVI headers
+
+    Traits that have been set are rendered under their ENVI spellings, in declaration order,
+    followed by the extras; sequences and text fields go in braces, everything else bare.
+    """
+
+    # constants
+    # the marker that opens every header
+    marker = "ENVI"
+    # the string valued keywords ENVI writes in braces
+    braced = {"description", "map info", "projection info", "coordinate system string"}
+
+    # interface
+    def write(self, header: Header, uri) -> None:
+        """
+        Write {header} to the file at {uri}
+        """
+        # the location, as a path
+        path = pyre.primitives.path(uri)
+        # open the file
+        with open(path, mode="w", encoding="utf-8") as stream:
+            # and render into it
+            stream.write(self.render(header=header))
+        # all done
+        return
+
+    def render(self, header: Header) -> str:
+        """
+        Render {header} as the text of an ENVI header file
+        """
+        # start with the marker
+        lines = [self.marker]
+        # go through the traits
+        for trait in Header.pyre_traits():
+            # get the value
+            value = getattr(header, trait.name)
+            # skip the ones that were never set
+            if value is None:
+                # by moving on
+                continue
+            # the ENVI spelling is the alias that isn't the attribute name, when there is one
+            keyword = self.keyword(trait=trait)
+            # render the entry
+            lines.append(f"{keyword} = {self.value(keyword=keyword, value=value)}")
+        # then the extras, which carry their own keywords
+        for keyword, value in header.extras.items():
+            # render the entry
+            lines.append(f"{keyword} = {self.value(keyword=keyword, value=value)}")
+        # terminate the last line and assemble the text
+        return "\n".join(lines) + "\n"
+
+    # implementation details
+    def keyword(self, trait) -> str:
+        """
+        The ENVI spelling of {trait}
+        """
+        # the aliases other than the attribute name
+        spellings = sorted(trait.aliases - {trait.name})
+        # the ENVI spelling is the one that's there, or the name itself when there isn't one
+        return spellings[0] if spellings else trait.name
+
+    def value(self, keyword: str, value) -> str:
+        """
+        Render {value} the way ENVI expects it for {keyword}
+        """
+        # sequences go in braces, comma separated
+        if isinstance(value, (list, tuple)):
+            # rendered item by item
+            return "{" + ", ".join(str(item) for item in value) + "}"
+        # text fields go in braces as well
+        if keyword in self.braced:
+            # as they are
+            return "{" + str(value) + "}"
+        # everything else is bare
+        return str(value)
+
+
+# end of file

--- a/packages/pyre/envi/__init__.py
+++ b/packages/pyre/envi/__init__.py
@@ -1,0 +1,40 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Support for ENVI headers, the text sidecars that describe flat binary rasters.
+
+An ENVI header is a text file of {keyword = value} entries, with braces around values that have
+several items or contain spaces. The standard keywords are known here by name and type, and
+land on the traits of {header}; anything else lands in its {extras} bag as text, a string for a
+bare value and a list of strings for a braced one, for the consumer to interpret.
+
+The sequence
+
+    import pyre
+    hdr = pyre.envi.reader().read(uri="product.hdr")
+    shape = hdr.shape
+    cell = hdr.datatype
+
+reads a header and recovers the layout of the product it describes; {writer} renders a header
+back to text.
+"""
+
+# the exceptions
+from . import exceptions
+
+# the header
+from .Header import Header as header
+
+# the georeferencing record
+from .MapInfo import MapInfo as mapInfo
+
+# reading and writing
+from .Reader import Reader as reader
+from .Writer import Writer as writer
+
+# end of file

--- a/packages/pyre/envi/__init__.py
+++ b/packages/pyre/envi/__init__.py
@@ -16,12 +16,12 @@ bare value and a list of strings for a braced one, for the consumer to interpret
 The sequence
 
     import pyre
+    import pyre.grid
     hdr = pyre.envi.reader().read(uri="product.hdr")
-    shape = hdr.shape
-    cell = hdr.datatype
+    data = pyre.grid.map(uri="product", shape=hdr.shape, cell=hdr.cell, create=False)
 
-reads a header and recovers the layout of the product it describes; {writer} renders a header
-back to text.
+reads a header and lays a grid over the product it describes, in place, whatever byte order the
+product was written in; {writer} renders a header back to text.
 """
 
 # the exceptions

--- a/packages/pyre/envi/exceptions.py
+++ b/packages/pyre/envi/exceptions.py
@@ -1,0 +1,105 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Definitions for all the exceptions raised by this package
+"""
+
+# superclass
+from ..framework.exceptions import FrameworkError
+
+
+# the local base
+class ENVIError(FrameworkError):
+    """
+    The base class of all exceptions raised by the envi package
+    """
+
+    # public data
+    description = "generic ENVI error"
+
+
+class MissingMarkerError(ENVIError):
+    """
+    Exception raised when a header does not start with the ENVI marker
+    """
+
+    # public data
+    description = "'{0.uri}' does not start with the ENVI marker"
+
+    # metamethods
+    def __init__(self, uri, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save the location
+        self.uri = uri
+        # all done
+        return
+
+
+class MalformedHeaderError(ENVIError):
+    """
+    Exception raised when a header line cannot be understood
+    """
+
+    # public data
+    description = "'{0.uri}', line {0.line}: {0.reason}: '{0.text}'"
+
+    # metamethods
+    def __init__(self, uri, line, text, reason, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save the location
+        self.uri = uri
+        self.line = line
+        # the offending text
+        self.text = text
+        # and what is wrong with it
+        self.reason = reason
+        # all done
+        return
+
+
+class MalformedValueError(ENVIError):
+    """
+    Exception raised when the value of a known keyword cannot be converted to its documented type
+    """
+
+    # public data
+    description = "could not convert the value of '{0.keyword}': {0.value}"
+
+    # metamethods
+    def __init__(self, keyword, value, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save the keyword
+        self.keyword = keyword
+        # and the offending value
+        self.value = value
+        # all done
+        return
+
+
+class UnknownDataTypeError(ENVIError):
+    """
+    Exception raised when a header declares a data type code that ENVI does not define
+    """
+
+    # public data
+    description = "unknown ENVI data type code {0.code}"
+
+    # metamethods
+    def __init__(self, code, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save the code
+        self.code = code
+        # all done
+        return
+
+
+# end of file

--- a/tests/pyre.pkg/envi/cell.py
+++ b/tests/pyre.pkg/envi/cell.py
@@ -1,0 +1,63 @@
+#! /usr/bin/env python3
+# -*- python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Lay a grid over a product written in each byte order, using nothing but its header
+    """
+    # access the package
+    import pyre
+
+    # and the grid factories
+    import pyre.grid
+
+    # for packing the product
+    import struct
+
+    # the layout
+    lines, samples = 2, 3
+    # the values, each with two distinct bytes
+    values = [0x0100 * (i + 1) + (i + 1) for i in range(lines * samples)]
+
+    # for each byte order the header can declare
+    for order, code in [(0, "<"), (1, ">")]:
+        # the product and its sidecar
+        uri = f"envi_cell_test_{order}.dat"
+        hdr = f"envi_cell_test_{order}.hdr"
+        # write the product in that order
+        with open(uri, "wb") as product:
+            product.write(struct.pack(f"{code}{len(values)}H", *values))
+        # describe it
+        header = pyre.envi.header(
+            samples=samples, lines=lines, bands=1, dataType=12, interleave="bsq", byteOrder=order
+        )
+        # write the sidecar
+        pyre.envi.writer().write(header=header, uri=hdr)
+
+        # read the sidecar back
+        header = pyre.envi.reader().read(uri=hdr)
+        # lay a grid over the product using only what the header says
+        grid = pyre.grid.map(
+            uri=uri, shape=header.shape, cell=header.cell, create=False, writable=False
+        )
+        # every cell must read as its value, whatever the order of the bytes on disk
+        assert [grid[i, j] for i in range(lines) for j in range(samples)] == values
+        # let go
+        del grid
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/envi/extras.py
+++ b/tests/pyre.pkg/envi/extras.py
@@ -1,0 +1,55 @@
+#! /usr/bin/env python3
+# -*- python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    A known keyword whose value cannot be converted lands in the extras as text, with a warning,
+    rather than aborting the read
+    """
+    # access the package
+    import pyre
+    import journal
+
+    # for a header in memory
+    import io
+
+    # the warning is expected; quiet it
+    journal.warning("pyre.envi.header").active = False
+
+    # a header with a bad line count and a bad wavelength list
+    text = "\n".join(
+        [
+            "ENVI",
+            "samples = 10",
+            "lines = many",
+            "wavelength = {0.4, blue, 0.6}",
+            "",
+        ]
+    )
+    # parse it
+    hdr = pyre.envi.reader().parse(stream=io.StringIO(text), uri="memory")
+
+    # the good field made it
+    assert hdr.samples == 10
+    # the bad ones did not
+    assert hdr.lines is None
+    assert hdr.wavelength is None
+    # and their text is in the bag, a bare value as a string and a braced one as a list
+    assert hdr.extras == {"lines": "many", "wavelength": ["0.4", "blue", "0.6"]}
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/envi/header.py
+++ b/tests/pyre.pkg/envi/header.py
@@ -61,6 +61,17 @@ def test():
         # through the header
         assert pyre.envi.header(dataType=code).datatype == name
 
+    # the cell name carries the byte order marker the header calls for
+    assert pyre.envi.header(dataType=12, byteOrder=1).cell == "uint16be"
+    assert pyre.envi.header(dataType=12, byteOrder=0).cell == "uint16le"
+    assert pyre.envi.header(dataType=6, byteOrder=1).cell == "complex64be"
+    # without a byte order it is the native cell
+    assert pyre.envi.header(dataType=12).cell == "uint16"
+    # a single byte scalar has no order
+    assert pyre.envi.header(dataType=1, byteOrder=1).cell == "uint8"
+    # and without a data type there is no cell
+    assert pyre.envi.header(byteOrder=1).cell is None
+
     # the header offset survives
     hdr = pyre.envi.header(headerOffset=128)
     assert hdr.offset == 128

--- a/tests/pyre.pkg/envi/header.py
+++ b/tests/pyre.pkg/envi/header.py
@@ -13,14 +13,6 @@ def test():
     # access the package
     import pyre
 
-    # for unique instance names
-    import itertools
-
-    # keyword construction needs a named instance, and each name is one instance
-    counter = itertools.count()
-    # so build every header under a fresh name
-    make = lambda **kwds: pyre.envi.header(name=f"header-{next(counter)}", **kwds)
-
     # a bare header knows nothing
     hdr = pyre.envi.header()
     assert hdr.shape is None
@@ -30,24 +22,24 @@ def test():
     assert hdr.extras == {}
 
     # a single band product is a plane, whatever the interleave says
-    hdr = make(lines=4, samples=5, bands=1, interleave="bip")
+    hdr = pyre.envi.header(lines=4, samples=5, bands=1, interleave="bip")
     assert hdr.shape == (4, 5)
     # and so is one that never mentions bands
-    hdr = make(lines=4, samples=5)
+    hdr = pyre.envi.header(lines=4, samples=5)
     assert hdr.shape == (4, 5)
 
     # a multi-band product puts the band axis where the interleave says
-    hdr = make(lines=4, samples=5, bands=3, interleave="bsq")
+    hdr = pyre.envi.header(lines=4, samples=5, bands=3, interleave="bsq")
     assert hdr.shape == (3, 4, 5)
-    hdr = make(lines=4, samples=5, bands=3, interleave="bil")
+    hdr = pyre.envi.header(lines=4, samples=5, bands=3, interleave="bil")
     assert hdr.shape == (4, 3, 5)
-    hdr = make(lines=4, samples=5, bands=3, interleave="bip")
+    hdr = pyre.envi.header(lines=4, samples=5, bands=3, interleave="bip")
     assert hdr.shape == (4, 5, 3)
     # and defaults to band sequential
-    hdr = make(lines=4, samples=5, bands=3)
+    hdr = pyre.envi.header(lines=4, samples=5, bands=3)
     assert hdr.shape == (3, 4, 5)
     # the interleave is folded to lower case on the way in
-    hdr = make(interleave="BSQ")
+    hdr = pyre.envi.header(interleave="BSQ")
     assert hdr.interleave == "bsq"
 
     # every ENVI data type code names a pyre cell
@@ -67,19 +59,19 @@ def test():
     # check them all
     for code, name in codes.items():
         # through the header
-        assert make(dataType=code).datatype == name
+        assert pyre.envi.header(dataType=code).datatype == name
 
     # the header offset survives
-    hdr = make(headerOffset=128)
+    hdr = pyre.envi.header(headerOffset=128)
     assert hdr.offset == 128
-    # and the ENVI spellings work as keywords too, since the framework matches by alias
-    hdr = make(**{"header offset": 256, "data type": 4, "byte order": 1})
+    # the ENVI spellings work as keywords too, since the framework matches by alias
+    hdr = pyre.envi.header(**{"header offset": 256, "data type": 4, "byte order": 1})
     assert hdr.offset == 256
     assert hdr.datatype == "float32"
     assert hdr.byteOrder == 1
 
     # extras ride along
-    hdr = make(extras={"custom": "value"})
+    hdr = pyre.envi.header(extras={"custom": "value"})
     assert hdr.extras == {"custom": "value"}
 
     # all done

--- a/tests/pyre.pkg/envi/header.py
+++ b/tests/pyre.pkg/envi/header.py
@@ -1,0 +1,95 @@
+#! /usr/bin/env python3
+# -*- python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Build headers directly and check what they derive from their fields
+    """
+    # access the package
+    import pyre
+
+    # for unique instance names
+    import itertools
+
+    # keyword construction needs a named instance, and each name is one instance
+    counter = itertools.count()
+    # so build every header under a fresh name
+    make = lambda **kwds: pyre.envi.header(name=f"header-{next(counter)}", **kwds)
+
+    # a bare header knows nothing
+    hdr = pyre.envi.header()
+    assert hdr.shape is None
+    assert hdr.datatype is None
+    assert hdr.offset == 0
+    assert hdr.map() is None
+    assert hdr.extras == {}
+
+    # a single band product is a plane, whatever the interleave says
+    hdr = make(lines=4, samples=5, bands=1, interleave="bip")
+    assert hdr.shape == (4, 5)
+    # and so is one that never mentions bands
+    hdr = make(lines=4, samples=5)
+    assert hdr.shape == (4, 5)
+
+    # a multi-band product puts the band axis where the interleave says
+    hdr = make(lines=4, samples=5, bands=3, interleave="bsq")
+    assert hdr.shape == (3, 4, 5)
+    hdr = make(lines=4, samples=5, bands=3, interleave="bil")
+    assert hdr.shape == (4, 3, 5)
+    hdr = make(lines=4, samples=5, bands=3, interleave="bip")
+    assert hdr.shape == (4, 5, 3)
+    # and defaults to band sequential
+    hdr = make(lines=4, samples=5, bands=3)
+    assert hdr.shape == (3, 4, 5)
+    # the interleave is folded to lower case on the way in
+    hdr = make(interleave="BSQ")
+    assert hdr.interleave == "bsq"
+
+    # every ENVI data type code names a pyre cell
+    codes = {
+        1: "uint8",
+        2: "int16",
+        3: "int32",
+        4: "float32",
+        5: "float64",
+        6: "complex64",
+        9: "complex128",
+        12: "uint16",
+        13: "uint32",
+        14: "int64",
+        15: "uint64",
+    }
+    # check them all
+    for code, name in codes.items():
+        # through the header
+        assert make(dataType=code).datatype == name
+
+    # the header offset survives
+    hdr = make(headerOffset=128)
+    assert hdr.offset == 128
+    # and the ENVI spellings work as keywords too, since the framework matches by alias
+    hdr = make(**{"header offset": 256, "data type": 4, "byte order": 1})
+    assert hdr.offset == 256
+    assert hdr.datatype == "float32"
+    assert hdr.byteOrder == 1
+
+    # extras ride along
+    hdr = make(extras={"custom": "value"})
+    assert hdr.extras == {"custom": "value"}
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/envi/malformed.py
+++ b/tests/pyre.pkg/envi/malformed.py
@@ -1,0 +1,98 @@
+#! /usr/bin/env python3
+# -*- python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Structural problems with a header are reported as exceptions that say where they are
+    """
+    # access the package
+    import pyre
+
+    # for headers in memory
+    import io
+
+    # the reader
+    reader = pyre.envi.reader()
+    # the exceptions
+    exceptions = pyre.envi.exceptions
+
+    # a file that does not open with the marker is not an ENVI header
+    try:
+        # parse
+        reader.parse(stream=io.StringIO("samples = 10\n"), uri="memory")
+    # the refusal
+    except exceptions.MissingMarkerError as error:
+        # names the source
+        assert error.uri == "memory"
+        assert "memory" in str(error)
+    # anything else
+    else:
+        # is a failure
+        assert False, "a header without the marker was accepted"
+
+    # and neither is an empty file, or one with only comments
+    try:
+        # parse
+        reader.parse(stream=io.StringIO("; nothing here\n\n"), uri="memory")
+    # the refusal
+    except exceptions.MissingMarkerError:
+        # is expected
+        pass
+    # anything else
+    else:
+        # is a failure
+        assert False, "an empty header was accepted"
+
+    # a line that is not an assignment
+    text = "ENVI\nsamples = 10\nthis is not an entry\n"
+    try:
+        # parse
+        reader.parse(stream=io.StringIO(text), uri="memory")
+    # the refusal
+    except exceptions.MalformedHeaderError as error:
+        # points at the line
+        assert error.line == 3
+        assert error.text == "this is not an entry"
+        assert "line 3" in str(error)
+    # anything else
+    else:
+        # is a failure
+        assert False, "a line without an assignment was accepted"
+
+    # a brace that is never closed
+    text = "ENVI\nsamples = 10\nband names = {Band 1,\nBand 2\n"
+    try:
+        # parse
+        reader.parse(stream=io.StringIO(text), uri="memory")
+    # the refusal
+    except exceptions.MalformedHeaderError as error:
+        # points at the line that opened the brace
+        assert error.line == 3
+        assert error.reason == "unterminated brace"
+    # anything else
+    else:
+        # is a failure
+        assert False, "an unterminated brace was accepted"
+
+    # a data type code ENVI does not define is caught by the trait validator on the way in, so
+    # it lands in the extras; the datatype lookup itself refuses an unknown code
+    hdr = pyre.envi.header()
+    hdr.dataType = 12
+    assert hdr.datatype == "uint16"
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/envi/mapinfo.py
+++ b/tests/pyre.pkg/envi/mapinfo.py
@@ -1,0 +1,58 @@
+#! /usr/bin/env python3
+# -*- python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Parse, render, and use the georeferencing record
+    """
+    # access the package
+    import pyre
+
+    # a geographic record
+    text = "Geographic Lat/Lon, 1, 1, -180, 90, 0.5, 0.25, WGS-84, units=Degrees"
+    # parse
+    info = pyre.envi.mapInfo.parse(text=text)
+    # check the fixed items
+    assert info.projection == "Geographic Lat/Lon"
+    assert info.pixel == (1.0, 1.0)
+    assert info.coordinates == (-180.0, 90.0)
+    assert info.size == (0.5, 0.25)
+    # and the projection dependent ones
+    assert info.extras == ["WGS-84", "units=Degrees"]
+    assert info.settings() == {"units": "Degrees"}
+    # the reference pixel maps to the origin of the image
+    assert info.toPixel(x=-180.0, y=90.0) == (0.0, 0.0)
+    # a point one pixel to the east and two to the south
+    assert info.toPixel(x=-179.5, y=89.5) == (2.0, 1.0)
+    # and back
+    assert info.toMap(line=2.0, sample=1.0) == (-179.5, 89.5)
+    # rendering reproduces the text
+    assert info.render() == text
+    assert str(info) == text
+
+    # a UTM record, with a zone and hemisphere
+    text = "UTM, 1.5, 1.5, 500000, 4000000, 30, 30, 11, North, WGS-84, units=Meters"
+    # parse
+    info = pyre.envi.mapInfo.parse(text=text)
+    # the reference pixel is the center of the first pixel
+    assert info.pixel == (1.5, 1.5)
+    assert info.extras == ["11", "North", "WGS-84", "units=Meters"]
+    # and rendering reproduces the text
+    assert info.render() == text
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/envi/read.py
+++ b/tests/pyre.pkg/envi/read.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python3
+# -*- python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Read a sample header and check that every field landed where it should, converted to its
+    type
+    """
+    # access the package
+    import pyre
+
+    # read the sample
+    hdr = pyre.envi.reader().read(uri="sample.hdr")
+
+    # the layout
+    assert hdr.samples == 43200
+    assert hdr.lines == 21600
+    assert hdr.bands == 3
+    assert hdr.headerOffset == 128
+    assert hdr.offset == 128
+    assert hdr.fileType == "ENVI Standard"
+    assert hdr.dataType == 12
+    assert hdr.datatype == "uint16"
+    # the interleave is folded to lower case
+    assert hdr.interleave == "bil"
+    assert hdr.shape == (21600, 3, 43200)
+    assert hdr.byteOrder == 0
+
+    # the braced text keeps its punctuation, including the sign the parser splits on
+    assert hdr.description == "sample ENVI header; with a comma, and an = sign"
+    # the georeferencing
+    assert hdr.mapInfo.startswith("Arbitrary, 1, 1, -180.00138889")
+    info = hdr.map()
+    assert info.projection == "Arbitrary"
+    assert info.pixel == (1.0, 1.0)
+    assert info.coordinates == (-180.00138889, 90.00138889)
+    assert info.size == (0.00833333, 0.00833333)
+    assert info.extras == ["0", "North"]
+    # and renders back to the text in the file
+    assert info.render() == hdr.mapInfo
+
+    # a braced list that spans lines
+    assert hdr.bandNames == ["Band 1", "Band 2", "Band 3"]
+    # per-band values
+    assert hdr.wavelength == [0.45, 0.55, 0.65]
+    assert hdr.fwhm == [0.01, 0.02, 0.03]
+    # scalars
+    assert hdr.xStart == 12.5
+    assert hdr.yStart == 7.0
+    assert hdr.dataIgnore == -9999.0
+    # text
+    assert hdr.acquisitionTime == "2011-09-18T16:32:57Z"
+    assert hdr.sensorType == "Unknown"
+
+    # keywords the standard does not define land in the bag: bare values as strings, braced
+    # ones as lists of strings
+    assert hdr.extras == {"custom scalar": "42", "custom list": ["a", "b", "c"]}
+
+    # fields the sample never mentions are unset
+    assert hdr.classes is None
+    assert hdr.dem is None
+    assert hdr.bbl is None
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/envi/sample.hdr
+++ b/tests/pyre.pkg/envi/sample.hdr
@@ -1,0 +1,26 @@
+ENVI
+description = {
+  sample ENVI header; with a comma, and an = sign }
+samples = 43200
+lines   = 21600
+bands   = 3
+header offset = 128
+file type = ENVI Standard
+data type = 12
+interleave = BIL
+byte order = 0
+
+; a comment line
+map info = {Arbitrary, 1, 1, -180.00138889, 90.00138889, 0.00833333, 0.00833333, 0, North}
+band names = {
+Band 1, Band 2,
+Band 3}
+wavelength = {0.45, 0.55, 0.65}
+fwhm = {0.01, 0.02, 0.03}
+x start = 12.5
+y start = 7
+data ignore value = -9999
+acquisition time = 2011-09-18T16:32:57Z
+sensor type = Unknown
+custom scalar = 42
+custom list = {a, b, c}

--- a/tests/pyre.pkg/envi/sanity.py
+++ b/tests/pyre.pkg/envi/sanity.py
@@ -1,0 +1,26 @@
+#! /usr/bin/env python3
+# -*- python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def test():
+    """
+    Sanity test: make sure the envi package is accessible
+    """
+    # access the package
+    from pyre import envi
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the test
+    test()
+
+
+# end of file

--- a/tests/pyre.pkg/envi/write.py
+++ b/tests/pyre.pkg/envi/write.py
@@ -1,0 +1,103 @@
+#! /usr/bin/env python3
+# -*- python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+def render():
+    """
+    Render a header and read it back; every field must survive the round trip
+    """
+    # access the package
+    import pyre
+
+    # for headers in memory
+    import io
+
+    # build a header with a bit of everything; keyword construction needs a name
+    hdr = pyre.envi.header(
+        name="render",
+        description="a product; with punctuation, and an = sign",
+        samples=5,
+        lines=4,
+        bands=3,
+        headerOffset=0,
+        fileType="ENVI Standard",
+        dataType=4,
+        interleave="bsq",
+        byteOrder=1,
+        mapInfo="UTM, 1, 1, 500000, 4000000, 30, 30, 11, North, WGS-84, units=Meters",
+        bandNames=["red", "green", "blue"],
+        wavelength=[0.65, 0.55, 0.45],
+        fwhm=[0.01, 0.01, 0.01],
+        xStart=1.5,
+        yStart=2.0,
+        dataIgnore=-9999.0,
+        defaultBands=[1, 2, 3],
+        extras={"custom scalar": "42", "custom list": ["a", "b"]},
+    )
+    # render it
+    text = pyre.envi.writer().render(header=hdr)
+    # the text opens with the marker
+    assert text.startswith("ENVI\n")
+    # spells keywords the ENVI way
+    assert "\nheader offset = 0\n" in text
+    assert "\ndata ignore value = -9999.0\n" in text
+    # braces text fields and sequences, and leaves scalars bare
+    assert "\ndescription = {a product; with punctuation, and an = sign}\n" in text
+    assert "\nband names = {red, green, blue}\n" in text
+    assert "\nfile type = ENVI Standard\n" in text
+    assert "\ninterleave = bsq\n" in text
+    # and carries the extras
+    assert "\ncustom scalar = 42\n" in text
+    assert "\ncustom list = {a, b}\n" in text
+
+    # read it back
+    copy = pyre.envi.reader().parse(stream=io.StringIO(text), uri="memory")
+    # every trait must match
+    for trait in pyre.envi.header.pyre_traits():
+        # compare
+        assert getattr(copy, trait.name) == getattr(hdr, trait.name), trait.name
+    # and so must the extras
+    assert copy.extras == hdr.extras
+    # the georeferencing round trips too
+    assert copy.map().settings() == {"units": "Meters"}
+
+    # all done
+    return
+
+
+def write():
+    """
+    Write a header to a file and read it back
+    """
+    # access the package
+    import pyre
+
+    # the scratch product
+    uri = "envi_write_test.hdr"
+    # a header
+    hdr = pyre.envi.header(name="write", samples=5, lines=4, dataType=12, interleave="bip")
+    # write it
+    pyre.envi.writer().write(header=hdr, uri=uri)
+    # read it back
+    copy = pyre.envi.reader().read(uri=uri)
+    # check
+    assert copy.shape == (4, 5)
+    assert copy.datatype == "uint16"
+    assert copy.interleave == "bip"
+
+    # all done
+    return
+
+
+# main
+if __name__ == "__main__":
+    # run the tests
+    render()
+    write()
+
+
+# end of file

--- a/tests/pyre.pkg/envi/write.py
+++ b/tests/pyre.pkg/envi/write.py
@@ -16,9 +16,8 @@ def render():
     # for headers in memory
     import io
 
-    # build a header with a bit of everything; keyword construction needs a name
+    # build a header with a bit of everything
     hdr = pyre.envi.header(
-        name="render",
         description="a product; with punctuation, and an = sign",
         samples=5,
         lines=4,
@@ -79,7 +78,7 @@ def write():
     # the scratch product
     uri = "envi_write_test.hdr"
     # a header
-    hdr = pyre.envi.header(name="write", samples=5, lines=4, dataType=12, interleave="bip")
+    hdr = pyre.envi.header(samples=5, lines=4, dataType=12, interleave="bip")
     # write it
     pyre.envi.writer().write(header=hdr, uri=uri)
     # read it back


### PR DESCRIPTION
Support for ENVI headers, the text sidecars that describe flat binary rasters, as the package `pyre.envi`.

## The format

An ENVI header is a text file that opens with the marker `ENVI` and continues with `keyword = value` entries. Braces surround a value that has several items or contains spaces, and such a value may span lines; lines that start with a semicolon are comments. The format carries no type information: the types of the standard keywords come from the published specification, and a keyword the specification does not define is text.

## The header

`pyre.envi.header` is a component with family `pyre.envi.header` and no protocol. Every standard keyword is a trait aliased to its ENVI spelling, documented from the specification, with a `None` default so a header knows which fields were present; the header offset defaults to zero as the specification says. Relative to earlier keyword lists in circulation, `fwhm` is present, `wavelength` is per band, `x start` and `y start` are scalars, and the keyword is `data ignore value`. Keywords the specification does not define land in `extras`, a string for a bare value and a list of strings for a braced one.

The header derives the shape of the product from lines, samples, bands, and interleave, with the band axis where the interleave puts it and band sequential as the default; names the pyre cell type for its data type code; reports the byte offset of the first cell; and parses `map info` into a `MapInfo` record that converts between map coordinates and image coordinates in both directions and renders back to the field's text.

As with every component, a named header accepts trait values as constructor keywords, under either the attribute names or the ENVI spellings, and configuration under its name overrides them. With the anonymous keyword construction that landed in #241, an anonymous header accepts them as well.

## Reader and writer

`pyre.envi.reader` and `pyre.envi.writer` are plain classes. The reader splits each entry on its first `=`, so values may contain the sign; collects braced values across lines; and refuses a file without the marker, a line that is not an assignment, or an unterminated brace, each through an exception that names the source and the line. Known keywords are deposited on the header one at a time, so a value that does not convert to its documented type lands in `extras` with a warning on the `pyre.envi.header` channel rather than aborting the read; a braced list that comes back shorter than it went in counts as such a failure, since sequence traits drop items they cannot convert. The writer renders the set fields under their ENVI spellings in declaration order, braces the text fields and sequences, leaves scalars bare, and appends the extras.

The reader deposits by assignment rather than through constructor keywords on purpose: assignment works for anonymous headers, applies one value at a time, and records facts about the file above any configuration, which is where they belong. Repairing a header from configuration is a matter for the component that owns the reader.

## Tests

Eight drivers under `tests/pyre.pkg/envi` cover the derived layout for every interleave and data type code, a sample header with every kind of value including a multi-line braced list and a description containing the separator, diversion of unconvertible values into the extras, the three structural refusals, a render and parse round trip of every trait plus a write to disk, the georeferencing record, and the cell name with a grid mapped from the header alone.

## The cell name

`header.cell` names the pyre cell that reads the product in place: the data type's name with the byte order marker the header's `byte order` field calls for, `uint16be` for 1 and `uint16le` for 0, the bare native name when no order is declared, and no marker for single byte scalars. The grid factories accept either marker and collapse the one that names the host's own order to the native cell, so a grid laid over the product with `pyre.grid.map(uri, shape=header.shape, cell=header.cell, create=False)` reads native values whatever machine wrote the product. The `cell` driver exercises this for a product written in each order, going through the writer and the reader on the way.
